### PR TITLE
Add standard ExpandDecider subclass to restrict to terms with a particular prefix

### DIFF
--- a/xapian-bindings/csharp/Makefile.am
+++ b/xapian-bindings/csharp/Makefile.am
@@ -25,6 +25,7 @@ XAPIAN_SWIG_CS_SRCS=\
 	generated-csharp/Enquire.cs \
 	generated-csharp/ExpandDecider.cs \
 	generated-csharp/ExpandDeciderAnd.cs \
+	generated-csharp/ExpandDeciderFilterPrefix.cs \
 	generated-csharp/FieldProcessor.cs \
 	generated-csharp/FixedWeightPostingSource.cs \
 	generated-csharp/GreatCircleMetric.cs \

--- a/xapian-bindings/java/Makefile.am
+++ b/xapian-bindings/java/Makefile.am
@@ -34,6 +34,7 @@ XAPIAN_SWIG_JAVA_SRCS=\
 	org/xapian/ESetIterator.java\
 	org/xapian/ExpandDecider.java\
 	org/xapian/ExpandDeciderAnd.java\
+	org/xapian/ExpandDeciderFilterPrefix.java\
 	org/xapian/FieldProcessor.java\
 	org/xapian/FixedWeightPostingSource.java\
 	org/xapian/GreatCircleMetric.java\

--- a/xapian-core/api/expanddecider.cc
+++ b/xapian-core/api/expanddecider.cc
@@ -21,6 +21,7 @@
 #include <config.h>
 
 #include <xapian/expanddecider.h>
+#include "stringutils.h"
 
 using namespace std;
 
@@ -43,6 +44,12 @@ ExpandDeciderFilterTerms::operator()(const string &term) const
      * result of find() to a const_iterator. */
     set<string>::const_iterator i = rejects.find(term);
     return i == rejects.end();
+}
+
+bool    
+ExpandDeciderFilterPrefix::operator()(const string &term) const
+{
+    return startswith(term, prefix);
 }
 
 }

--- a/xapian-core/include/xapian/expanddecider.h
+++ b/xapian-core/include/xapian/expanddecider.h
@@ -96,6 +96,24 @@ class XAPIAN_VISIBILITY_DEFAULT ExpandDeciderFilterTerms : public ExpandDecider 
     virtual bool operator()(const std::string &term) const;
 };
 
+/** ExpandDecider subclass which restrict terms to a particular prefix
+ *
+ *  ExpandDeciderFilterPrefix provides an easy way to choose terms with a  
+ *  particular prefix when generating an ESet.
+ */
+class XAPIAN_VISIBILITY_DEFAULT ExpandDeciderFilterPrefix : public ExpandDecider {
+    std::string prefix;
+
+  public:
+    /** The parameter specify the prefix of terms to be retained
+     *  @param prefix_   restrict terms to the particular prefix_ 
+     */
+    ExpandDeciderFilterPrefix(const std::string &prefix_)
+       : prefix(prefix_) { }   
+
+    virtual bool operator() (const std::string &term) const;
+};
+
 }
 
 #endif // XAPIAN_INCLUDED_EXPANDDECIDER_H

--- a/xapian-core/tests/api_nodb.cc
+++ b/xapian-core/tests/api_nodb.cc
@@ -433,3 +433,17 @@ DEFINE_TESTCASE(emptymset1, !backend) {
 		   emptymset.get_termfreq("foo"));
     return true;
 }
+
+DEFINE_TESTCASE(expanddeciderfilterprefix1, !backend) {
+    string prefix = "tw";
+    Xapian::ExpandDeciderFilterPrefix decider(prefix);
+    TEST(!decider("one"));
+    TEST(!decider("t"));
+    TEST(!decider(""));
+    TEST(!decider("Two"));
+    TEST(decider("two"));
+    TEST(decider("twitter"));
+    TEST(decider(prefix));
+
+    return true;
+}


### PR DESCRIPTION
Hi, I have done this patch for ticket #467, please take a look
1. Add class ExpandDeciderFilterPrefix(expanddecider.h/cc) and related testcase(    api_anydb.cc api_nodb.cc)
2. Add line 'generated-csharp/ExpandDeciderFilterPrefix.cs' and 'org/xapian/ExpandDeciderFilterPrefix.java' in related Makefile.am(Java and C#)
