### PR TITLE
enum flags is made as anonymous enum and typedef int flags added

### DIFF
--- a/xapian-core/include/xapian/termgenerator.h
+++ b/xapian-core/include/xapian/termgenerator.h
@@ -87,7 +87,8 @@ class XAPIAN_VISIBILITY_DEFAULT TermGenerator {
     void set_database(const Xapian::WritableDatabase &db);
 
     /// Flags to OR together and pass to TermGenerator::set_flags().
-    enum flags {
+	typedef int flags;
+    enum {
 	/// Index data required for spelling correction.
 	FLAG_SPELLING = 128 // Value matches QueryParser flag.
     };


### PR DESCRIPTION
This change was made to solve the following bug:
http://trac.xapian.org/ticket/616
The enum named flags is converted to an anonymous enum and a typedef int flags has been added instead.

With these changes the bug has been solved.
