### PR TITLE
Code formatted. Comments and test added.

### DIFF
--- a/xapian-bindings/java/SmokeTest.java
+++ b/xapian-bindings/java/SmokeTest.java
@@ -44,6 +44,8 @@ class MyExpandDecider extends ExpandDecider {
 
 public class SmokeTest {
     public static void main(String[] args) throws Exception {
+	TermGenerator termGenerator = new TermGenerator();
+	termGenerator.setFlags(TermGenerator.FLAG_SPELLING);
 	try {
 	    Stem stem = new Stem("english");
 	    if (!stem.toString().equals("Xapian::Stem(english)")) {

--- a/xapian-core/include/xapian/termgenerator.h
+++ b/xapian-core/include/xapian/termgenerator.h
@@ -86,8 +86,10 @@ class XAPIAN_VISIBILITY_DEFAULT TermGenerator {
     /// Set the database to index spelling data to.
     void set_database(const Xapian::WritableDatabase &db);
 
+    /// For backward comptibility with Xapian 1.2
+    typedef int flags;
+
     /// Flags to OR together and pass to TermGenerator::set_flags().
-	typedef int flags;
     enum {
 	/// Index data required for spelling correction.
 	FLAG_SPELLING = 128 // Value matches QueryParser flag.


### PR DESCRIPTION
The extra spaces before 'typedef int flags' in termgenerator.h are removed. And an appropriate documentation comment is added.
Also a test has been added on SmokeTest.java to show that the #616 bug is solved.
