### PR TITLE
Makesnippetqueryrelevant: display snippet showing the area surrounding the searched word / phrase text

### DIFF
--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1886,6 +1886,7 @@ eval(const string &fmt, const vector<string> &param)
 	    }
 	    case CMD_snippet: {
 		Xapian::Snipper snipper;
+		snipper.set_query(queryterms);
 		snipper.set_mset(mset);
 		snipper.set_stemmer(Xapian::Stem(option["stemmer"]));
 		size_t len = (args.size() == 1) ? 200 : string_to_int(args[1]);

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1030,7 +1030,7 @@ T(set,		   2, 2, N, 0), // set option value
 T(setmap,	   1, N, N, 0), // set map of option values
 T(setrelevant,     0, 1, N, Q), // set rset
 T(slice,	   2, 2, N, 0), // slice a list using a second list
-T(snippet,	   1, 2, N, 0), // generate snippet from text
+T(snippet,	   1, 3, N, 0), // generate snippet from text
 T(split,	   1, 2, N, 0), // split a string to give a list
 T(stoplist,	   0, 0, N, Q), // return list of stopped terms
 T(sub,		   2, 2, N, 0), // subtract
@@ -1890,8 +1890,9 @@ eval(const string &fmt, const vector<string> &param)
 		snipper.set_mset(mset);
 		snipper.set_stemmer(Xapian::Stem(option["stemmer"]));
 		size_t len = (args.size() == 1) ? 200 : string_to_int(args[1]);
-		double qweight = (args.size() == 2) ? 0.5 : string_to_double(args[2]); 
-		value = snipper.generate_snippet(args[0], len,qweight);
+		//double qweight = (args.size() == 2) ? 0.5 : atof(args[2].c_str()); 
+		double qweight = (args.size() == 3) ? 1 : 0.9; 
+		value = snipper.generate_snippet(args[0], len,len,0.5,qweight);
 		break;
 	    }
 	    case CMD_split: {

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1886,11 +1886,11 @@ eval(const string &fmt, const vector<string> &param)
 	    }
 	    case CMD_snippet: {
 		Xapian::Snipper snipper;
-		snipper.set_query(queryterms);
+		snipper.set_query(query);
 		snipper.set_mset(mset);
 		snipper.set_stemmer(Xapian::Stem(option["stemmer"]));
 		size_t len = (args.size() == 1) ? 200 : string_to_int(args[1]);
-		double qweight = (args.size() < 3) ? 0.9 : string_to_double(args[2]); 
+		double qweight = (args.size() < 3) ? 0.5 : string_to_double(args[2]); 
 		value = snipper.generate_snippet(args[0], len, 5, 0.5, qweight);
 		break;
 	    }

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1890,8 +1890,7 @@ eval(const string &fmt, const vector<string> &param)
 		snipper.set_mset(mset);
 		snipper.set_stemmer(Xapian::Stem(option["stemmer"]));
 		size_t len = (args.size() == 1) ? 200 : string_to_int(args[1]);
-		//double qweight = (args.size() == 2) ? 0.5 : atof(args[2].c_str()); 
-		double qweight = (args.size() == 3) ? 1 : 0.9; 
+		double qweight = (args.size() < 3) ? 0.9 : atof(args[2].c_str()); 
 		value = snipper.generate_snippet(args[0], len,len,0.5,qweight);
 		break;
 	    }

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1890,7 +1890,8 @@ eval(const string &fmt, const vector<string> &param)
 		snipper.set_mset(mset);
 		snipper.set_stemmer(Xapian::Stem(option["stemmer"]));
 		size_t len = (args.size() == 1) ? 200 : string_to_int(args[1]);
-		value = snipper.generate_snippet(args[0], len);
+		double qweight = (args.size() == 2) ? 0.5 : string_to_double(args[2]); 
+		value = snipper.generate_snippet(args[0], len,qweight);
 		break;
 	    }
 	    case CMD_split: {

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1890,8 +1890,8 @@ eval(const string &fmt, const vector<string> &param)
 		snipper.set_mset(mset);
 		snipper.set_stemmer(Xapian::Stem(option["stemmer"]));
 		size_t len = (args.size() == 1) ? 200 : string_to_int(args[1]);
-		double qweight = (args.size() < 3) ? 0.9 : atof(args[2].c_str()); 
-		value = snipper.generate_snippet(args[0], len,len,0.5,qweight);
+		double qweight = (args.size() < 3) ? 0.9 : string_to_double(args[2]); 
+		value = snipper.generate_snippet(args[0], len, 5, 0.5, qweight);
 		break;
 	    }
 	    case CMD_split: {

--- a/xapian-applications/omega/utils.cc
+++ b/xapian-applications/omega/utils.cc
@@ -28,6 +28,7 @@
 #include <cstdlib>
 
 #include <string>
+#include <sstream>
 
 using namespace std;
 
@@ -54,6 +55,16 @@ string_to_int(const string &s)
 {
     return atoi(s.c_str());
 }
+
+double 
+string_to_double(const string &s)
+{
+    std::istringstream i(s);
+    double x;
+    if (!(i >> x))
+        return 0;
+    return x;
+} 
 
 string
 double_to_string(double val)

--- a/xapian-applications/omega/utils.cc
+++ b/xapian-applications/omega/utils.cc
@@ -28,7 +28,6 @@
 #include <cstdlib>
 
 #include <string>
-#include <sstream>
 
 using namespace std;
 
@@ -59,11 +58,7 @@ string_to_int(const string &s)
 double 
 string_to_double(const string &s)
 {
-    std::istringstream i(s);
-    double x;
-    if (!(i >> x))
-        return 0;
-    return x;
+    return strtod(s.c_str(), NULL);
 } 
 
 string

--- a/xapian-applications/omega/utils.h
+++ b/xapian-applications/omega/utils.h
@@ -28,6 +28,9 @@ std::string date_to_string(int year, int month, int day);
 /** Converts a double to a string. */
 std::string double_to_string(double value);
 
+/** Converts a string to a double. */
+double string_to_double(const std::string & s);
+
 /** Converts a string to an int. */
 int string_to_int(const std::string & s);
 

--- a/xapian-core/api/snipper.cc
+++ b/xapian-core/api/snipper.cc
@@ -21,7 +21,6 @@
  */
 
 #include <config.h>
-#include <iostream>
 
 #include "xapian/snipper.h"
 #include "snipperinternal.h"
@@ -35,7 +34,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <math.h> 
+#include <cmath> 
 
 #include "str.h"
 
@@ -63,7 +62,7 @@ Snipper::~Snipper()
 }
 
 void
-Snipper::set_query(std::string queryterm)
+Snipper::set_query(const string & queryterm)
 {
     internal->set_query(queryterm);
 }
@@ -97,32 +96,25 @@ Snipper::Internal::is_stemmed(const string & term)
 }
 
 void
-Snipper::Internal::set_query(std::string query)
+Snipper::Internal::set_query(const string & query)
 {
-	/*Indexing the query terms using same logic as done with document string.*/
-	Document text_doc;
+	/* Indexing the query terms using same logic as done with document string. */
+	Document snippet_doc;
 	TermGenerator term_gen;
 	
-	term_gen.set_document(text_doc);
+	term_gen.set_document(snippet_doc);
 	term_gen.set_stemmer(stemmer);
 	term_gen.index_text(query);
 
-	const Document & snippet_doc = term_gen.get_document();
-
 	// Document terms.
 	for (TermIterator it = snippet_doc.termlist_begin(); it != snippet_doc.termlist_end(); ++it) {
-	if (is_stemmed(*it))
-		continue;
-	//Positional information
-	for (PositionIterator pit = it.positionlist_begin(); pit != it.positionlist_end(); ++pit) {
-		if (queryterms.find(*it) != queryterms.end()) {
-			queryterms[*it]++;
-		} else {
-			queryterms[*it] = 1;
-		}
+		if (is_stemmed(*it))
+			continue;
+		//Positional information
+		queryterms[*it] = it.positionlist_count();
+	
 	}
-	}
-	for (std::map<std::string,unsigned int>::iterator queryit = queryterms.begin(); queryit!= queryterms.end(); ++queryit) {
+	for (map<string, unsigned int>::iterator queryit = queryterms.begin(); queryit!= queryterms.end(); ++queryit) {
 		query_square_sum += (queryit->second)*(queryit->second);
 	}
 	querystring = query;
@@ -135,8 +127,8 @@ Snipper::Internal::calculate_rm(const MSet & mset, Xapian::doccount rm_docno)
     rm_docid current_id = 0;
 
     // Initialize global relevance model info.
-    rm_total_weight = 0.1;
-    rm_coll_size = 1;
+    rm_total_weight = 0;
+    rm_coll_size = 0;
     rm_documents.clear();
     rm_term_data.clear();
 
@@ -167,6 +159,15 @@ Snipper::Internal::calculate_rm(const MSet & mset, Xapian::doccount rm_docno)
 
 	rm_documents.push_back(RMDocumentInfo(current_id++, doc_size, ms_it.get_weight()));
     }
+
+	// In case the collection has some issues which makes score to go to NAN.
+	if (rm_coll_size == 0) {
+		rm_coll_size =  0.01;		
+	}
+
+	if (rm_total_weight == 0) {
+		rm_total_weight = 0.01;
+	}
 }
 
 string
@@ -262,48 +263,37 @@ Snipper::Internal::generate_snippet(const string & text,
 	    docterms_relevance[i] = (prev_score + next_score) / 2;
 	}
     }
-	std::map<std::string,unsigned int> sentence_frequency;
+	map<string, unsigned int> sentence_frequency;
     for (unsigned int i = snippet_begin; i < snippet_end; ++i) {
 	double score = docterms_relevance[i];
-	if(sentence_frequency.find(docterms[i].term) != sentence_frequency.end()) {
-		sentence_frequency[docterms[i].term]++;
-	} else {
-		sentence_frequency[docterms[i].term] = 1;
-	}
+	string current_stemmed_term = 'z' + stemmer(docterms[i].term);
+	 ++sentence_frequency[current_stemmed_term];
 	sum += score;
     }
     max_sum = sum;
     max_qcontrib  =  calculate_cosine_similarity(sentence_frequency);
-	//cout<<"primary sum "<<sum<<endl;
 
     for (size_t i = snippet_end; i < docterms.size(); ++i) {
 	double score = docterms_relevance[i];
-	if(sentence_frequency.find(docterms[i].term) != sentence_frequency.end()) {
-		sentence_frequency[docterms[i].term]++;
-	} else {
-		sentence_frequency[docterms[i].term] = 1;
-	}
+	string current_stemmed_term = 'z'+stemmer(docterms[i].term);
+	++sentence_frequency[current_stemmed_term];
 	sum += score;
-	//cout<<"initial sum "<<sum<<" score "<<score<<endl;
 	double head_score = docterms_relevance[i - window_size];
-	if(sentence_frequency.find(docterms[i-window_size].term) != sentence_frequency.end()) {
-		sentence_frequency[docterms[i-window_size].term]--;
-		if(sentence_frequency[docterms[i-window_size].term] == 0) {
-			sentence_frequency.erase(sentence_frequency.find(docterms[i-window_size].term));
+	string removed_stemmed_word = 'z'+stemmer(docterms[i - window_size].term);
+	if(sentence_frequency.find(removed_stemmed_word) != sentence_frequency.end()) {
+		sentence_frequency[removed_stemmed_word]--;
+		if(sentence_frequency[removed_stemmed_word] == 0) {
+			sentence_frequency.erase(sentence_frequency.find(removed_stemmed_word));
 		}
 	}
 	sum -= head_score;
-	//cout<<"nowsum "<<sum<<" now headscore"<<head_score<<endl;
 
 	double qcontrib_score = calculate_cosine_similarity(sentence_frequency);
 	if ((((1-query_contribution)*sum) + (query_contribution*qcontrib_score)) > (((1-query_contribution)*max_sum) + (query_contribution*max_qcontrib))) {
 	    max_sum = sum;
-	    max_qcontrib  = 1;
+	    max_qcontrib  = qcontrib_score;
 	    snippet_begin = i - window_size + 1;
 	    snippet_end = i + 1;
-	} else {
-		//cout<<"first term"<<(((1-query_contribution)*sum) + (query_contribution*qcontrib_score))<<" second term "<<(((1-query_contribution)*max_sum) + (query_contribution*max_qcontrib))<<endl;
-		//cout<<" sum "<<sum<<" max_sum "<<max_sum<<" max_qcont "<<max_qcontrib<<endl;
 	}
     }
 
@@ -353,19 +343,18 @@ Snipper::Internal::generate_snippet(const string & text,
 }
 
 double
-Snipper::Internal::calculate_cosine_similarity(std::map<std::string,unsigned int> sentence_frequency)
+Snipper::Internal::calculate_cosine_similarity(const map<string, unsigned int> & sentence_frequency)
 {
 	double numerator = 0.0;
 	double denominator1 = 0.0;
 	
-	for (std::map<std::string,unsigned int>::iterator it = sentence_frequency.begin(); it!=sentence_frequency.end(); ++it) {
-		if(queryterms.find(it->first) != queryterms.end()) {
+	for (map<string, unsigned int>::const_iterator it = sentence_frequency.begin(); it != sentence_frequency.end(); ++it) {
+		if (queryterms.find(it->first) != queryterms.end()) {
 			numerator += (queryterms[it->first])*(it->second);
 		}
 		denominator1 += (it->second)*(it->second);
 	}
 	double denominator = sqrt(denominator1 + query_square_sum);
-	//Dummy or fake implementation currently.
 	return numerator/denominator;	
 }
 
@@ -378,10 +367,9 @@ Snipper::get_description() const
     desc += str(internal->rm_term_data.size());
     desc += ", rm_collection_size=";
     desc += str(internal->rm_coll_size);
-    const std::string empty = "";
-    if(empty.compare(internal->querystring) != 0){
+    if (!internal->querystring.empty()) {
         desc += ", query=";
-        desc += str(internal->querystring);
+        desc += internal->querystring;
     }
     desc += ")";
     return desc;

--- a/xapian-core/api/snipper.cc
+++ b/xapian-core/api/snipper.cc
@@ -61,6 +61,12 @@ Snipper::~Snipper()
 }
 
 void
+Snipper::set_query(std::string queryterm)
+{
+    internal->set_query(queryterm);
+}
+
+void
 Snipper::set_mset(const MSet & mset, unsigned int rm_docno)
 {
     internal->calculate_rm(mset, rm_docno);
@@ -86,6 +92,13 @@ Snipper::Internal::is_stemmed(const string & term)
 {
     return (term.length() > 0 && term[0] == 'Z');
 }
+
+void
+Snipper::Internal::set_query(std::string query)
+{
+    queryterms = query;
+}
+
 
 void
 Snipper::Internal::calculate_rm(const MSet & mset, Xapian::doccount rm_docno)
@@ -293,6 +306,12 @@ Snipper::get_description() const
     desc += str(internal->rm_term_data.size());
     desc += ", rm_collection_size=";
     desc += str(internal->rm_coll_size);
+    const std::string empty = "";
+    if(empty.compare(internal->queryterms) != 0){
+        desc += ", query=";
+        desc += str(internal->queryterms);
+    }
+    desc += ")";
     return desc;
 }
 

--- a/xapian-core/api/snipper.cc
+++ b/xapian-core/api/snipper.cc
@@ -108,17 +108,18 @@ Snipper::Internal::set_query(std::string query)
 	const Document & snippet_doc = term_gen.get_document();
 
 	// Document terms.
-	vector<TermPositionInfo> qterms;
 	for (TermIterator it = snippet_doc.termlist_begin(); it != snippet_doc.termlist_end(); ++it) {
 	if (is_stemmed(*it))
 		continue;
 	//Positional information
 	for (PositionIterator pit = it.positionlist_begin(); pit != it.positionlist_end(); ++pit) {
-		queryterms.push_back(TermPositionInfo(*it, *pit));
+		if (queryterms.find(*it) != queryterms.end()) {
+			queryterms[*it]++;
+		} else {
+			queryterms[*it] = 1;
+		}
 	}
 	}
-	sort(qterms.begin(), qterms.end());
-	queryterms = qterms;
 	querystring = query;
 }
 

--- a/xapian-core/api/snipperinternal.h
+++ b/xapian-core/api/snipperinternal.h
@@ -124,7 +124,7 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 		     query_square_sum(0) { }
 
     /** Set the query terms for the generation of the Snippet
-     *  @param querytem The query terms for the current query.
+     *  @param queryterm The query terms for the current query.
      */
     void set_query(const std::string & queryterm);
 

--- a/xapian-core/api/snipperinternal.h
+++ b/xapian-core/api/snipperinternal.h
@@ -116,11 +116,12 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 	double rm_total_weight;
 
     /** To store query terms to be  used for cosine measure of query component in snippet. **/
-    std::string  queryterms;
+    std::vector<TermPositionInfo>  queryterms;
+    std::string  querystring;
 
 	Internal() : rm_coll_size(0),
 		     rm_total_weight(0),
-             queryterms("") { }
+		     querystring(""){ }
 
     /** Set the query terms for the generation of the Snippet
      *  @param querytem The query terms for the current query.
@@ -140,6 +141,18 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 	 *  @param rm_docno	How many documents to use from @a mset
 	 */
 	void calculate_rm(const MSet & mset, Xapian::doccount rm_docno);
+
+	/** Calculate and return cosine similarity for two strings.
+	 *
+	 *  @param docterms		Terms of the doc in vector, to extract sentence.
+	 *  @param sentence_start Index to start current sentence from.
+	 *  @param sentence_end Index to end current sentence at.
+	 * 
+	 *  Second sentence will be taken from queryterms, which is available to the snipper internal class
+	 */
+
+	double calculate_cosine_similarity(std::vector<TermPositionInfo> docterms,unsigned int sentence_start,unsigned int sentence_end);
+
 };
 
 }

--- a/xapian-core/api/snipperinternal.h
+++ b/xapian-core/api/snipperinternal.h
@@ -47,6 +47,7 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
     public:
 	typedef int rm_docid;
 
+
 	/** Holds information about a document in the relevance model.*/
 	struct RMDocumentInfo {
 	    /** ID in the relevance model */
@@ -114,8 +115,17 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 	/** Relevance model total document weight */
 	double rm_total_weight;
 
+    /** To store query terms to be  used for cosine measure of query component in snippet. **/
+    std::string  queryterms;
+
 	Internal() : rm_coll_size(0),
-		     rm_total_weight(0) { }
+		     rm_total_weight(0),
+             queryterms("") { }
+
+    /** Set the query terms for the generation of the Snippet
+     *  @param querytem The query terms for the current query.
+     */
+    void set_query(std::string queryterm);
 
 	/** Return snippet generated from text using the precalculated relevance model */
 	std::string generate_snippet(const std::string & text,

--- a/xapian-core/api/snipperinternal.h
+++ b/xapian-core/api/snipperinternal.h
@@ -25,6 +25,7 @@
 
 #include <xapian/enquire.h>
 #include <xapian/snipper.h>
+#include <xapian/query.h>
 #include <xapian/stem.h>
 
 #include <map>
@@ -126,7 +127,7 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
     /** Set the query terms for the generation of the Snippet
      *  @param queryterm The query terms for the current query.
      */
-    void set_query(const std::string & queryterm);
+    void set_query(const Xapian::Query & queryterm);
 
 	/** Return snippet generated from text using the precalculated relevance model */
 	std::string generate_snippet(const std::string & text,

--- a/xapian-core/api/snipperinternal.h
+++ b/xapian-core/api/snipperinternal.h
@@ -47,7 +47,6 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
     public:
 	typedef int rm_docid;
 
-
 	/** Holds information about a document in the relevance model.*/
 	struct RMDocumentInfo {
 	    /** ID in the relevance model */
@@ -115,20 +114,19 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 	/** Relevance model total document weight */
 	double rm_total_weight;
 
-    /** To store query terms to be  used for cosine measure of query component in snippet. **/
-    std::map<std::string,unsigned int>  queryterms;
-    std::string  querystring;
+    /** To store query terms to be  used for cosine measure of query component in snippet. */
+	std::map<std::string, unsigned int> queryterms;
+	std::string querystring;
 	double query_square_sum;
 
 	Internal() : rm_coll_size(0),
 		     rm_total_weight(0),
-		     querystring(""),
 		     query_square_sum(0) { }
 
     /** Set the query terms for the generation of the Snippet
      *  @param querytem The query terms for the current query.
      */
-    void set_query(std::string queryterm);
+    void set_query(const std::string & queryterm);
 
 	/** Return snippet generated from text using the precalculated relevance model */
 	std::string generate_snippet(const std::string & text,
@@ -151,7 +149,7 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 	 *  Second sentence will be taken from queryterms, which is available to the snipper internal class
 	 */
 
-	double calculate_cosine_similarity(std::map<std::string,unsigned int> sentence_frequency);
+	double calculate_cosine_similarity(const std::map<std::string, unsigned int> & sentence_frequency);
 
 };
 

--- a/xapian-core/api/snipperinternal.h
+++ b/xapian-core/api/snipperinternal.h
@@ -131,7 +131,8 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 	std::string generate_snippet(const std::string & text,
 				     size_t length,
 				     unsigned int window_size,
-				     double smoothing);
+				     double smoothing,
+				     double query_contribution);
 
 	/** Calculate relevance model based on a MSet.
 	 *

--- a/xapian-core/api/snipperinternal.h
+++ b/xapian-core/api/snipperinternal.h
@@ -116,12 +116,14 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 	double rm_total_weight;
 
     /** To store query terms to be  used for cosine measure of query component in snippet. **/
-    std::vector<TermPositionInfo>  queryterms;
+    std::map<std::string,unsigned int>  queryterms;
     std::string  querystring;
+	double query_square_sum;
 
 	Internal() : rm_coll_size(0),
 		     rm_total_weight(0),
-		     querystring(""){ }
+		     querystring(""),
+		     query_square_sum(0) { }
 
     /** Set the query terms for the generation of the Snippet
      *  @param querytem The query terms for the current query.
@@ -144,14 +146,12 @@ class Snipper::Internal : public Xapian::Internal::intrusive_base {
 
 	/** Calculate and return cosine similarity for two strings.
 	 *
-	 *  @param docterms		Terms of the doc in vector, to extract sentence.
-	 *  @param sentence_start Index to start current sentence from.
-	 *  @param sentence_end Index to end current sentence at.
+	 *  @param sentence_frequenct		Terms of the doc with frequency in map.
 	 * 
 	 *  Second sentence will be taken from queryterms, which is available to the snipper internal class
 	 */
 
-	double calculate_cosine_similarity(std::vector<TermPositionInfo> docterms,unsigned int sentence_start,unsigned int sentence_end);
+	double calculate_cosine_similarity(std::map<std::string,unsigned int> sentence_frequency);
 
 };
 

--- a/xapian-core/include/xapian/snipper.h
+++ b/xapian-core/include/xapian/snipper.h
@@ -68,7 +68,7 @@ class XAPIAN_VISIBILITY_DEFAULT Snipper {
     /** Set the query terms for the generation of the Snippet
      *  @param querytem The query terms for the current query.
      */
-    void set_query(std::string queryterm);
+    void set_query(const std::string & queryterm);
 
     /**
      * Set the MSet and calculate the relevance model according to it.
@@ -87,7 +87,7 @@ class XAPIAN_VISIBILITY_DEFAULT Snipper {
      *			    (default: 200)
      * @param window_size   Size of the window (default: 25)
      * @param smoothing	    Smoothing coefficient (default: 0.5)
-     * @param query_contribution    Query contribution coefficient (default: 0.5)
+     * @param query_contribution    Query contribution coefficient (default: 0.9)
      *
      * @return	    Text of the snippet relevant to the model from input.
      */
@@ -95,7 +95,7 @@ class XAPIAN_VISIBILITY_DEFAULT Snipper {
 				 size_t length = 200,
 				 Xapian::termcount window_size = 25,
 				 double smoothing = 0.5,
-				 double query_contribution = 0.5);
+				 double query_contribution = 0.9);
     
     /// Return a string describing this object.
     std::string get_description() const XAPIAN_PURE_FUNCTION;

--- a/xapian-core/include/xapian/snipper.h
+++ b/xapian-core/include/xapian/snipper.h
@@ -31,6 +31,7 @@
 #include <xapian/attributes.h>
 #include <xapian/intrusive_ptr.h>
 #include <xapian/types.h>
+#include <xapian/query.h>
 #include <xapian/visibility.h>
 
 namespace Xapian {
@@ -68,7 +69,7 @@ class XAPIAN_VISIBILITY_DEFAULT Snipper {
     /** Set the query terms for the generation of the Snippet
      *  @param querytem The query terms for the current query.
      */
-    void set_query(const std::string & queryterm);
+    void set_query(const Xapian::Query & queryterm);
 
     /**
      * Set the MSet and calculate the relevance model according to it.
@@ -87,7 +88,7 @@ class XAPIAN_VISIBILITY_DEFAULT Snipper {
      *			    (default: 200)
      * @param window_size   Size of the window (default: 25)
      * @param smoothing	    Smoothing coefficient (default: 0.5)
-     * @param query_contribution    Query contribution coefficient (default: 0.9)
+     * @param query_contribution    Query contribution coefficient (default: 0.5)
      *
      * @return	    Text of the snippet relevant to the model from input.
      */
@@ -95,7 +96,7 @@ class XAPIAN_VISIBILITY_DEFAULT Snipper {
 				 size_t length = 200,
 				 Xapian::termcount window_size = 25,
 				 double smoothing = 0.5,
-				 double query_contribution = 0.9);
+				 double query_contribution = 0.5);
     
     /// Return a string describing this object.
     std::string get_description() const XAPIAN_PURE_FUNCTION;

--- a/xapian-core/include/xapian/snipper.h
+++ b/xapian-core/include/xapian/snipper.h
@@ -87,14 +87,16 @@ class XAPIAN_VISIBILITY_DEFAULT Snipper {
      *			    (default: 200)
      * @param window_size   Size of the window (default: 25)
      * @param smoothing	    Smoothing coefficient (default: 0.5)
+     * @param query_contribution    Query contribution coefficient (default: 0.5)
      *
      * @return	    Text of the snippet relevant to the model from input.
      */
     std::string generate_snippet(const std::string & text,
 				 size_t length = 200,
 				 Xapian::termcount window_size = 25,
-				 double smoothing = 0.5);
-
+				 double smoothing = 0.5,
+				 double query_contribution = 0.5);
+    
     /// Return a string describing this object.
     std::string get_description() const XAPIAN_PURE_FUNCTION;
 };

--- a/xapian-core/include/xapian/snipper.h
+++ b/xapian-core/include/xapian/snipper.h
@@ -65,6 +65,11 @@ class XAPIAN_VISIBILITY_DEFAULT Snipper {
     /** Set the stemmer for the Snipper object. */
     void set_stemmer(const Xapian::Stem & stemmer);
 
+    /** Set the query terms for the generation of the Snippet
+     *  @param querytem The query terms for the current query.
+     */
+    void set_query(std::string queryterm);
+
     /**
      * Set the MSet and calculate the relevance model according to it.
      *

--- a/xapian-core/tests/api_snipper.cc
+++ b/xapian-core/tests/api_snipper.cc
@@ -38,14 +38,15 @@ using namespace std;
 // tests that the number of indexed documents is the size of the one set
 DEFINE_TESTCASE(snipper1, backend) {
     Xapian::Enquire enquire(get_database("apitest_simpledata"));
-    enquire.set_query(Xapian::Query("this"));
+	Xapian::Query query = Xapian::Query("this");
+    enquire.set_query(query);
     Xapian::MSet mymset = enquire.get_mset(0, 10);
 
     // MSet size should be 6.
     TEST_MSET_SIZE(mymset, 6);
 
     Xapian::Snipper snipper;
-    snipper.set_query("this");
+    snipper.set_query(query);
     snipper.set_mset(mymset, 4);
     TEST(snipper.get_description().find("rm_doccount=4,") != string::npos);
     TEST(snipper.get_description().find("query=this)") != string::npos);

--- a/xapian-core/tests/api_snipper.cc
+++ b/xapian-core/tests/api_snipper.cc
@@ -45,8 +45,10 @@ DEFINE_TESTCASE(snipper1, backend) {
     TEST_MSET_SIZE(mymset, 6);
 
     Xapian::Snipper snipper;
+    snipper.set_query("this");
     snipper.set_mset(mymset, 4);
     TEST(snipper.get_description().find("rm_doccount=4,") != string::npos);
+    TEST(snipper.get_description().find("query=this)") != string::npos);
     return true;
 }
 
@@ -73,3 +75,22 @@ DEFINE_TESTCASE(snipper2, backend) {
     TEST(snipper.get_description().find("rm_doccount=2,") != string::npos);
     return true;
 }
+
+
+/* tests that the number of indexed documents is the size of the one set and check if query was not set in snipper,
+ *  it doesn't come in description */
+DEFINE_TESTCASE(snipper3, backend) {
+    Xapian::Enquire enquire(get_database("apitest_simpledata"));
+    enquire.set_query(Xapian::Query("this"));
+    Xapian::MSet mymset = enquire.get_mset(0, 10);
+
+    // MSet size should be 6.
+    TEST_MSET_SIZE(mymset, 6);
+
+    Xapian::Snipper snipper;
+    snipper.set_mset(mymset, 4);
+    TEST(snipper.get_description().find("rm_doccount=4,") != string::npos);
+    TEST(snipper.get_description().find("query=)") == string::npos);
+    return true;
+}
+


### PR DESCRIPTION
Added the cosine similarity as an addition factor with weight.

To get the query term in the snippet. Attached is the image from local testing.

Most of the document seems to get the query word but few of them are still not able to get the query words, but snippet is picked from a location very close to the query word. needs a little more tunning of parameters for that i guess.

![2014-08-28-16 37 44-screenshot](https://cloud.githubusercontent.com/assets/1573133/4074644/e778e1a6-2ea3-11e4-94e6-9ed9f91c7fcc.png)
