### PR TITLE
Replace atoi with strtol: Initial Patch

### DIFF
--- a/xapian-applications/omega/date.cc
+++ b/xapian-applications/omega/date.cc
@@ -166,7 +166,7 @@ date_range_filter(const string & date_start, const string & date_end,
 	    }
 	    secs = time_t(str_to_long) * 24 * 60 * 60;
 	} else {
-	    long str_to_longlong;
+	    long long str_to_longlong;
 	    errno = 0;
 	    str_to_longlong = strtoll(date_span.c_str(),NULL,0);
 	    if (errno == ERANGE) {

--- a/xapian-applications/omega/date.cc
+++ b/xapian-applications/omega/date.cc
@@ -31,6 +31,9 @@
 #include <stdio.h>
 #include <cstdlib>
 #include <ctime>
+#include <climits> // for detecting underflow or overflow e.g LONG_MIN
+#include <cstring> // for strerror
+#include <errno.h> // for errno variable
 
 using namespace std;
 
@@ -144,7 +147,40 @@ date_range_filter(const string & date_start, const string & date_end,
 {
     int y1, m1, d1, y2, m2, d2;
     if (!date_span.empty()) {
-	time_t secs = atoi(date_span.c_str()) * (24 * 60 * 60);
+    	time_t secs;
+	// For x32 system use long (32bit)
+	// For x64 system use long long (64bit)
+	if (sizeof(int *) < 8) {
+	    long str_to_long;
+	    errno = 0;
+	    str_to_long = strtol(date_span.c_str(),NULL,0);
+	    if (errno == ERANGE) {
+		switch(str_to_long) {
+		    case LONG_MIN:
+			throw (string("Date span underflow: ") + string(strerror(errno)));
+		    break;
+		    case LONG_MAX:
+			throw (string("Date span overflow: ") + string(strerror(errno)));
+		    break;
+		}
+	    }
+	    secs = time_t(str_to_long) * 24 * 60 * 60;
+	} else {
+	    long str_to_longlong;
+	    errno = 0;
+	    str_to_longlong = strtoll(date_span.c_str(),NULL,0);
+	    if (errno == ERANGE) {
+		switch(str_to_longlong) {
+		    case LLONG_MIN:
+			throw (string("Date span underflow: ") + string(strerror(errno)));
+		    break;
+		    case LLONG_MAX:
+			throw (string("Date span overflow: ") + string(strerror(errno)));
+		    break;
+		}
+	    }
+	    secs = time_t(str_to_longlong) * 24 * 60 * 60;
+	}
 	if (!date_end.empty()) {
 	    parse_date(date_end, &y2, &m2, &d2);
 	    struct tm t;

--- a/xapian-applications/omega/date.cc
+++ b/xapian-applications/omega/date.cc
@@ -147,10 +147,12 @@ date_range_filter(const string & date_start, const string & date_end,
     if (!date_span.empty()) {
 	long long str_to_longlong = strtoll(date_span.c_str(), NULL, 0);
 	time_t secs;
-	if (str_to_longlong > (numeric_limits<time_t>::max() / (24 * 60 * 60))) {
-	    secs = numeric_limits<time_t>::max();
-	} else if (str_to_longlong < (numeric_limits<time_t>::min() / (24 * 60 * 60))) {
-	    secs = numeric_limits<time_t>::min();
+	time_t max_time = numeric_limits<time_t>::max();
+	time_t min_time = numeric_limits<time_t>::min();
+	if (str_to_longlong > (max_time / (24 * 60 * 60))) {
+	    secs = max_time;
+	} else if (str_to_longlong < (min_time / (24 * 60 * 60))) {
+	    secs = min_time;
 	} else {
 	    secs = time_t(str_to_longlong) * (24 * 60 * 60);
 	}
@@ -164,15 +166,17 @@ date_range_filter(const string & date_start, const string & date_end,
 	    t.tm_min = t.tm_sec = 0;
 	    t.tm_isdst = -1;
 	    time_t given_time = mktime(&t);
+	    if (secs == min_time)
+	    	secs += 1;
 	    time_t then = given_time - secs;
 	    bool flag = given_time < 0;
 	    //check for underflow
 	    if (flag == (secs > 0) && flag != (then < 0))
-		then = numeric_limits<time_t>::min();
+		then = min_time;
 	    flag = given_time > 0;
 	    //check for overflow
 	    if (flag == (secs < 0) && flag != (then > 0))
-		then = numeric_limits<time_t>::max();
+		then = max_time;
 	    struct tm *t2 = localtime(&then);
 	    y1 = t2->tm_year + 1900;
 	    m1 = t2->tm_mon + 1;
@@ -191,11 +195,11 @@ date_range_filter(const string & date_start, const string & date_end,
 	    bool flag = given_time < 0;
 	    //check for underflow
 	    if (flag == (secs < 0) && flag != (end < 0))
-		end = numeric_limits<time_t>::min();
+		end = min_time;
 	    flag = given_time > 0;
 	    //check for overflow
 	    if (flag == (secs > 0) && flag != (end > 0))
-		end = numeric_limits<time_t>::max();
+		end = max_time;
 	    struct tm *t2 = localtime(&end);
 	    y2 = t2->tm_year + 1900;
 	    m2 = t2->tm_mon + 1;
@@ -206,15 +210,17 @@ date_range_filter(const string & date_start, const string & date_end,
 	    y2 = t->tm_year + 1900;
 	    m2 = t->tm_mon + 1;
 	    d2 = t->tm_mday;
+	    if (secs == min_time)
+	    	secs += 1;
 	    time_t then = end - secs;
 	    bool flag = end < 0;
 	    //check for underflow
 	    if (flag == (secs > 0) && flag != (then < 0))
-		then = numeric_limits<time_t>::min();
+		then = min_time;
 	    flag = end > 0;
 	    //check for overflow
 	    if (flag == (secs < 0) && flag != (then > 0))
-		then = numeric_limits<time_t>::max();
+		then = max_time;
 	    struct tm *t2 = localtime(&then);
 	    y1 = t2->tm_year + 1900;
 	    m1 = t2->tm_mon + 1;

--- a/xapian-applications/omega/date.cc
+++ b/xapian-applications/omega/date.cc
@@ -159,7 +159,7 @@ date_range_filter(const string & date_start, const string & date_end,
 	}
 	if (time_t(str_to_longlong) > (numeric_limits<time_t>::max() / (24 * 60 * 60)))
 	    throw (string("Date span overflow:"));
-	time_t span = time_t(str_to_longlong) * (24 * 60 * 60);
+	time_t secs = time_t(str_to_longlong) * (24 * 60 * 60);
 	if (!date_end.empty()) {
 	    parse_date(date_end, &y2, &m2, &d2);
 	    struct tm t;

--- a/xapian-applications/omega/date.cc
+++ b/xapian-applications/omega/date.cc
@@ -163,14 +163,16 @@ date_range_filter(const string & date_start, const string & date_end,
 	    t.tm_hour = 12;
 	    t.tm_min = t.tm_sec = 0;
 	    t.tm_isdst = -1;
-	    time_t then;
-	    // if secs is equal to time_t min value,
-	    // then = mktime + time_t min val hence which would do addition
-	    // so checking for that overflow.
-	    if (secs < (mktime(&t) - numeric_limits<time_t>::max()))
+	    time_t given_time = mktime(&t);
+	    time_t then = given_time - secs;
+	    bool flag = given_time < 0;
+	    //check for underflow
+	    if (flag == (secs > 0) && flag != (then < 0))
+		then = numeric_limits<time_t>::min();
+	    flag = given_time > 0;
+	    //check for overflow
+	    if (flag == (secs < 0) && flag != (then > 0))
 		then = numeric_limits<time_t>::max();
-	    else
-		then = mktime(&t) - secs;
 	    struct tm *t2 = localtime(&then);
 	    y1 = t2->tm_year + 1900;
 	    m1 = t2->tm_mon + 1;
@@ -184,12 +186,16 @@ date_range_filter(const string & date_start, const string & date_end,
 	    t.tm_hour = 12;
 	    t.tm_min = t.tm_sec = 0;
 	    t.tm_isdst = -1;
-	    time_t end;
-	    // checking for overflow in case mktime + secs > time_t max value
-	    if (secs > (numeric_limits<time_t>::max() - mktime(&t)))
+	    time_t given_time = mktime(&t);
+	    time_t end = given_time + secs;
+	    bool flag = given_time < 0;
+	    //check for underflow
+	    if (flag == (secs < 0) && flag != (end < 0))
+		end = numeric_limits<time_t>::min();
+	    flag = given_time > 0;
+	    //check for overflow
+	    if (flag == (secs > 0) && flag != (end > 0))
 		end = numeric_limits<time_t>::max();
-	    else
-		end = mktime(&t) + secs;
 	    struct tm *t2 = localtime(&end);
 	    y2 = t2->tm_year + 1900;
 	    m2 = t2->tm_mon + 1;
@@ -200,14 +206,15 @@ date_range_filter(const string & date_start, const string & date_end,
 	    y2 = t->tm_year + 1900;
 	    m2 = t->tm_mon + 1;
 	    d2 = t->tm_mday;
-	    time_t then;
-	    // if secs is equal to time_t min value then
-	    // then = mktime + time_t min val hence which would do addition
-	    // so checking that overflow.
-	    if (secs < (end - numeric_limits<time_t>::max()))
+	    time_t then = end - secs;
+	    bool flag = end < 0;
+	    //check for underflow
+	    if (flag == (secs > 0) && flag != (then < 0))
+		then = numeric_limits<time_t>::min();
+	    flag = end > 0;
+	    //check for overflow
+	    if (flag == (secs < 0) && flag != (then > 0))
 		then = numeric_limits<time_t>::max();
-	    else
-		then = end - secs;
 	    struct tm *t2 = localtime(&then);
 	    y1 = t2->tm_year + 1900;
 	    m1 = t2->tm_mon + 1;

--- a/xapian-applications/omega/date.cc
+++ b/xapian-applications/omega/date.cc
@@ -31,9 +31,7 @@
 #include <stdio.h>
 #include <cstdlib>
 #include <ctime>
-#include <climits> // for detecting underflow or overflow e.g LONG_MIN
 #include <limits>
-#include <errno.h> // for errno variable
 
 using namespace std;
 
@@ -147,8 +145,8 @@ date_range_filter(const string & date_start, const string & date_end,
 {
     int y1, m1, d1, y2, m2, d2;
     if (!date_span.empty()) {
-	errno = 0;
 	long long str_to_longlong = strtoll(date_span.c_str(), NULL, 0);
+	time_t secs;
 	if (str_to_longlong > (numeric_limits<time_t>::max() / (24 * 60 * 60))) {
 	    secs = numeric_limits<time_t>::max();
 	} else if (str_to_longlong < (numeric_limits<time_t>::min() / (24 * 60 * 60))) {

--- a/xapian-applications/omega/datematchdecider.cc
+++ b/xapian-applications/omega/datematchdecider.cc
@@ -21,7 +21,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <climits> // for checking underflow or overflow e.g LONG_MIN
 #include <limits>
 #include <xapian.h>
 

--- a/xapian-applications/omega/datematchdecider.cc
+++ b/xapian-applications/omega/datematchdecider.cc
@@ -103,7 +103,7 @@ DateMatchDecider::DateMatchDecider(Xapian::valueno val_,
 	    }
 	    span = time_t(str_to_long) * 24 * 60 * 60;
 	} else {
-	    long str_to_longlong;
+	    long long str_to_longlong;
 	    errno = 0;
 	    str_to_longlong = strtoll(date_span.c_str(),NULL,0);
 	    if (errno == ERANGE) {

--- a/xapian-applications/omega/datematchdecider.cc
+++ b/xapian-applications/omega/datematchdecider.cc
@@ -97,7 +97,6 @@ DateMatchDecider::DateMatchDecider(Xapian::valueno val_,
 	if (time_t(str_to_longlong) > (numeric_limits<time_t>::max() / (24 * 60 * 60)))
 	    throw (string("Date span overflow:"));
 	time_t span = time_t(str_to_longlong) * (24 * 60 * 60);
-	}
 	if (!date_end.empty()) {
 	    time_t endsec = set_end(date_end);
 	    set_start(endsec - span);

--- a/xapian-applications/omega/datematchdecider.cc
+++ b/xapian-applications/omega/datematchdecider.cc
@@ -83,6 +83,7 @@ DateMatchDecider::DateMatchDecider(Xapian::valueno val_,
 {
     if (!date_span.empty()) {
 	long long str_to_longlong = strtoll(date_span.c_str(), NULL, 0);
+	time_t span;
 	if (str_to_longlong > (numeric_limits<time_t>::max() / (24 * 60 * 60))) {
 	    span = numeric_limits<time_t>::max();
 	} else if (str_to_longlong < (numeric_limits<time_t>::min() / (24 * 60 * 60))) {

--- a/xapian-applications/omega/datematchdecider.cc
+++ b/xapian-applications/omega/datematchdecider.cc
@@ -93,32 +93,40 @@ DateMatchDecider::DateMatchDecider(Xapian::valueno val_,
 	}
 	if (!date_end.empty()) {
 	    time_t endsec = set_end(date_end);
-	    time_t startsec;
-	    // if span is equal to time_t min value i.e -ve value,
-	    // then = endsec + time_t min val hence which would do addition
-	    // so checking for that overflow.
-	    if (span < (endsec - numeric_limits<time_t>::max()))
+	    time_t startsec = endsec - span;
+	    bool flag = endsec < 0;
+	    //check for underflow
+	    if (flag == (span > 0) && flag != (startsec < 0))
+		startsec = numeric_limits<time_t>::min();
+	    flag = endsec > 0;
+	    //check for overflow
+	    if (flag == (span < 0) && flag != (startsec > 0))
 		startsec = numeric_limits<time_t>::max();
-	    else
-		startsec = endsec - span;
 	    set_start(startsec);
 	} else if (!date_start.empty()) {
 	    time_t startsec = set_start(date_start);
-	    time_t endsec;
-	    // checking for overflow in case startsec + secs > time_t max value
-	    if (span > (numeric_limits<time_t>::max() - startsec))
+	    time_t endsec = startsec + span;
+	    bool flag = startsec < 0;
+	    //check for underflow
+	    if (flag == (span < 0) && flag != (endsec < 0))
+		endsec = numeric_limits<time_t>::min();
+	    flag = startsec > 0;
+	    //check for overflow
+	    if (flag == (span > 0) && flag != (endsec > 0))
 		endsec = numeric_limits<time_t>::max();
-	    else
-		endsec = startsec + span;
 	    set_end(endsec);
 	} else {
 	    time_t endsec = time(NULL);
 	    set_end(endsec);
-	    time_t startsec;
-	    if (span < (endsec - numeric_limits<time_t>::max()))
+	    time_t startsec = endsec - span;
+	    bool flag = endsec < 0;
+	    //check for underflow
+	    if (flag == (span > 0) && flag != (startsec < 0))
+		startsec = numeric_limits<time_t>::min();
+	    flag = endsec > 0;
+	    //check for overflow
+	    if (flag == (span < 0) && flag != (startsec > 0))
 		startsec = numeric_limits<time_t>::max();
-	    else
-		startsec = endsec - span;
 	    set_start(startsec);
 	}
     } else {

--- a/xapian-applications/omega/datematchdecider.cc
+++ b/xapian-applications/omega/datematchdecider.cc
@@ -84,24 +84,28 @@ DateMatchDecider::DateMatchDecider(Xapian::valueno val_,
     if (!date_span.empty()) {
 	long long str_to_longlong = strtoll(date_span.c_str(), NULL, 0);
 	time_t span;
-	if (str_to_longlong > (numeric_limits<time_t>::max() / (24 * 60 * 60))) {
-	    span = numeric_limits<time_t>::max();
-	} else if (str_to_longlong < (numeric_limits<time_t>::min() / (24 * 60 * 60))) {
-	    span = numeric_limits<time_t>::min();	
+	time_t min_time = numeric_limits<time_t>::min();
+	time_t max_time = numeric_limits<time_t>::max();
+	if (str_to_longlong > (max_time / (24 * 60 * 60))) {
+	    span = max_time;
+	} else if (str_to_longlong < (min_time / (24 * 60 * 60))) {
+	    span = min_time;	
 	} else {
 	    span = time_t(str_to_longlong) * (24 * 60 * 60);
 	}
 	if (!date_end.empty()) {
 	    time_t endsec = set_end(date_end);
+	    if (span == min_time)
+	    	span += 1;
 	    time_t startsec = endsec - span;
 	    bool flag = endsec < 0;
 	    //check for underflow
 	    if (flag == (span > 0) && flag != (startsec < 0))
-		startsec = numeric_limits<time_t>::min();
+		startsec = min_time;
 	    flag = endsec > 0;
 	    //check for overflow
 	    if (flag == (span < 0) && flag != (startsec > 0))
-		startsec = numeric_limits<time_t>::max();
+		startsec = max_time;
 	    set_start(startsec);
 	} else if (!date_start.empty()) {
 	    time_t startsec = set_start(date_start);
@@ -109,24 +113,26 @@ DateMatchDecider::DateMatchDecider(Xapian::valueno val_,
 	    bool flag = startsec < 0;
 	    //check for underflow
 	    if (flag == (span < 0) && flag != (endsec < 0))
-		endsec = numeric_limits<time_t>::min();
+		endsec = min_time;
 	    flag = startsec > 0;
 	    //check for overflow
 	    if (flag == (span > 0) && flag != (endsec > 0))
-		endsec = numeric_limits<time_t>::max();
+		endsec = max_time;
 	    set_end(endsec);
 	} else {
 	    time_t endsec = time(NULL);
 	    set_end(endsec);
+	    if (span == min_time)
+	    	span += 1;
 	    time_t startsec = endsec - span;
 	    bool flag = endsec < 0;
 	    //check for underflow
 	    if (flag == (span > 0) && flag != (startsec < 0))
-		startsec = numeric_limits<time_t>::min();
+		startsec = min_time;
 	    flag = endsec > 0;
 	    //check for overflow
 	    if (flag == (span < 0) && flag != (startsec > 0))
-		startsec = numeric_limits<time_t>::max();
+		startsec = max_time;
 	    set_start(startsec);
 	}
     } else {

--- a/xapian-applications/omega/datematchdecider.cc
+++ b/xapian-applications/omega/datematchdecider.cc
@@ -21,6 +21,8 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <climits> // for checking underflow or overflow e.g LONG_MIN
+#include <errno.h> // for errno variable
 
 #include <xapian.h>
 
@@ -82,7 +84,40 @@ DateMatchDecider::DateMatchDecider(Xapian::valueno val_,
 	: val(val_)
 {
     if (!date_span.empty()) {
-	time_t span = atoi(date_span.c_str()) * (24 * 60 * 60);
+	time_t span;
+	// For x32 system use long (32bit)
+	// For x64 system use long long (64bit)
+	if (sizeof(int *) < 8) {
+	    long str_to_long;
+	    errno = 0;
+	    str_to_long = strtol(date_span.c_str(),NULL,0);
+	    if (errno == ERANGE) {
+		switch(str_to_long) {
+		    case LONG_MIN:
+			throw (string("Date span underflow: ") + string(strerror(errno)));
+		    break;
+		    case LONG_MAX:
+			throw (string("Date span overflow: ") + string(strerror(errno)));
+		    break;
+		}
+	    }
+	    span = time_t(str_to_long) * 24 * 60 * 60;
+	} else {
+	    long str_to_longlong;
+	    errno = 0;
+	    str_to_longlong = strtoll(date_span.c_str(),NULL,0);
+	    if (errno == ERANGE) {
+		switch(str_to_longlong) {
+		    case LLONG_MIN:
+			throw (string("Date span underflow: ") + string(strerror(errno)));
+		    break;
+		    case LLONG_MAX:
+			throw (string("Date span overflow: ") + string(strerror(errno)));
+		    break;
+		}
+	    }
+	    span = time_t(str_to_longlong) * 24 * 60 * 60;
+	}
 	if (!date_end.empty()) {
 	    time_t endsec = set_end(date_end);
 	    set_start(endsec - span);


### PR DESCRIPTION
1.Modified atoi with strtol and strtoll depending upon the system that is 32bit or 64bit. This will help to represent more year's with 64bit system and atlast ensuring that conversion of second's at last occurs in time_t format by type casting it.
2.Also checked for underflow or overflow condition using errno variable.
