### PR TITLE
SimpleSearch.java example: Fix build and update example.

### DIFF
--- a/xapian-bindings/java/docs/examples/SimpleSearch.java
+++ b/xapian-bindings/java/docs/examples/SimpleSearch.java
@@ -52,14 +52,16 @@ public class SimpleSearch {
         Enquire enquire = new Enquire(db);
         enquire.setQuery(query);
         MSet matches = enquire.getMSet(0, 2500);    // get up to 2500 matching documents
-        MSetIterator itr = matches.iterator();
+        MSetIterator itr = matches.begin();
 
         System.err.println("Found " + matches.size() + " matching documents using " + query);
         while (itr.hasNext()) {
-            itr = (MSetIterator) itr.next(); // TODO:  Make this more like a Java Iterator
-            // by returning some kind of "MatchDescriptor" object
-            Document doc = itr.getDocument();
-            System.err.println(itr.getPercent() + "% [" + itr.getDocumentId() + "] " + doc.getValue(0));
+            float percent = itr.getPercent();
+            long docID = itr.next();
+            // TODO:  Make this more like a Java Iterator by returning some
+            // kind of "MatchDescriptor" object
+            Document doc = db.getDocument(docID);
+            System.err.println(percent + "% [" + docID + "] " + doc.getValue(0));
         }
     }
 


### PR DESCRIPTION
SimpleSearch.java would not build against the current SWIG-generated Java bindings, updated and tried to make the iterator feel a bit more natural.

Thanks for a cool library :-)