### PR TITLE
Added missing msg_freqs remote command

### DIFF
--- a/xapian-core/net/remoteserver.cc
+++ b/xapian-core/net/remoteserver.cc
@@ -184,6 +184,7 @@ RemoteServer::run()
 		0, // MSG_GETMSET - used during a conversation.
 		0, // MSG_SHUTDOWN - handled by get_message().
 		&RemoteServer::msg_openmetadatakeylist,
+		&RemoteServer::msg_freqs,
 		&RemoteServer::msg_uniqueterms,
 	    };
 


### PR DESCRIPTION
`MSG_FREQS` command was missing from the remote server, it's listed as a `message_type` in common/remoteprotocol.h but it's skipped in list of commands in the remote server's `run()` thus making both `MSG_FREQS` and `MSG_UNIQUETERMS` fail (o return unexpected mixed results).