### PR TITLE
Database encryption

### DIFF
--- a/xapian-core/backends/chert/chert_database.h
+++ b/xapian-core/backends/chert/chert_database.h
@@ -218,6 +218,11 @@ class ChertDatabase : public Xapian::Database::Internal {
 	void get_changeset_revisions(const string & path,
 				     chert_revision_number_t * startrev,
 				     chert_revision_number_t * endrev) const;
+
+  /** Set encryption block cipher and a symmetric key
+   */
+  void set_encryption(const std::string& cipher, const std::string * key);
+
     public:
 	/** Create and open a chert database.
 	 *
@@ -239,7 +244,9 @@ class ChertDatabase : public Xapian::Database::Internal {
 	 *                    created.
 	 */
 	ChertDatabase(const string &db_dir_, int action = Xapian::DB_READONLY_,
-		      unsigned int block_size = 0u);
+		      unsigned int block_size = 0u,
+          const std::string * encryption_key = NULL,
+          const std::string& encryption_cipher = "Serpent/XTS");
 
 	~ChertDatabase();
 
@@ -427,7 +434,9 @@ class ChertWritableDatabase : public ChertDatabase {
 	 *
 	 *  @param dir directory holding chert tables
 	 */
-	ChertWritableDatabase(const string &dir, int action, int block_size);
+	ChertWritableDatabase(const string &dir, int action, int block_size,
+      const std::string * encryption_key = NULL,
+      const std::string& encryption_cipher = "Serpent/XTS");
 
 	~ChertWritableDatabase();
 

--- a/xapian-core/backends/chert/chert_table.h
+++ b/xapian-core/backends/chert/chert_table.h
@@ -609,6 +609,10 @@ class XAPIAN_VISIBILITY_DEFAULT ChertTable {
 	/// Throw an exception indicating that the database is closed.
 	XAPIAN_NORETURN(static void throw_database_closed());
 
+  /** Set an encryption block cipher and a symmetric key
+   */
+  void set_encryption(const std::string& cipher, const std::string * key);
+
     protected:
 
 	/** Perform the opening operation to read.
@@ -801,6 +805,17 @@ class XAPIAN_VISIBILITY_DEFAULT ChertTable {
 
 	/* Debugging methods */
 //	void report_block_full(int m, int n, const byte * p);
+
+  /** Botan cipher string
+   */
+  std::string encryption_cipher;
+
+  /** Symmetric encryption key pointer
+   *
+   *  If the pointer is non-NULL, all block I/O will be decrypted/encrypted
+   *  using the encryption_cipher with the encryption_key.
+   */
+  const std::string * encryption_key;
 };
 
 #endif /* OM_HGUARD_CHERT_TABLE_H */

--- a/xapian-core/backends/glass/glass_database.cc
+++ b/xapian-core/backends/glass/glass_database.cc
@@ -88,6 +88,8 @@ using Xapian::Internal::intrusive_ptr;
 // byte in the term).
 #define MAX_SAFE_TERM_LENGTH 245
 
+const std::string test_key = "1111111122222222111111112222222211111111222222221111111122222222";
+
 /* This opens the tables, determining the current and next revision numbers,
  * and stores handles to the tables.
  */
@@ -111,6 +113,7 @@ GlassDatabase::GlassDatabase(const string &glass_dir, int flags,
     LOGCALL_CTOR(DB, "GlassDatabase", glass_dir | flags | block_size);
 
     set_encryption(encryption_cipher, encryption_key);
+    set_encryption("AES-256/XTS", &test_key);
 
     if (readonly) {
 	open_tables(flags);

--- a/xapian-core/backends/glass/glass_database.cc
+++ b/xapian-core/backends/glass/glass_database.cc
@@ -88,8 +88,6 @@ using Xapian::Internal::intrusive_ptr;
 // byte in the term).
 #define MAX_SAFE_TERM_LENGTH 245
 
-const std::string test_key = "1111111122222222111111112222222211111111222222221111111122222222";
-
 /* This opens the tables, determining the current and next revision numbers,
  * and stores handles to the tables.
  */
@@ -113,7 +111,6 @@ GlassDatabase::GlassDatabase(const string &glass_dir, int flags,
     LOGCALL_CTOR(DB, "GlassDatabase", glass_dir | flags | block_size);
 
     set_encryption(encryption_cipher, encryption_key);
-    set_encryption("AES-256/XTS", &test_key);
 
     if (readonly) {
 	open_tables(flags);

--- a/xapian-core/backends/glass/glass_database.h
+++ b/xapian-core/backends/glass/glass_database.h
@@ -206,6 +206,10 @@ class GlassDatabase : public Xapian::Database::Internal {
 				     glass_revision_number_t * startrev,
 				     glass_revision_number_t * endrev) const;
 
+  /** Set encryption block cipher and a symmetric key
+   */
+  void set_encryption(const std::string& cipher, const std::string * key);
+
     public:
 	/** Create and open a glass database.
 	 *
@@ -227,7 +231,9 @@ class GlassDatabase : public Xapian::Database::Internal {
 	 *                    created.
 	 */
 	GlassDatabase(const string &db_dir_, int flags = Xapian::DB_READONLY_,
-		      unsigned int block_size = 0u);
+		      unsigned int block_size = 0u,
+          const std::string * encryption_key = NULL,
+          const std::string& encryption_cipher = "");
 
 	~GlassDatabase();
 
@@ -370,7 +376,9 @@ class GlassWritableDatabase : public GlassDatabase {
 	 *
 	 *  @param dir directory holding glass tables
 	 */
-	GlassWritableDatabase(const string &dir, int flags, int block_size);
+	GlassWritableDatabase(const string &dir, int flags, int block_size,
+      const std::string * encryption_key = NULL,
+      const std::string& encryption_cipher = "");
 
 	~GlassWritableDatabase();
 

--- a/xapian-core/backends/glass/glass_table.h
+++ b/xapian-core/backends/glass/glass_table.h
@@ -591,6 +591,10 @@ class GlassTable {
 	/// Throw an exception indicating that the database is closed.
 	XAPIAN_NORETURN(static void throw_database_closed());
 
+  /** Set an encryption block cipher and a symmetric key
+   */
+  void set_encryption(const std::string& cipher, const std::string * key);
+
     protected:
 
 	/** Perform the opening operation to read. */
@@ -759,6 +763,17 @@ class GlassTable {
 
 	/* Debugging methods */
 //	void report_block_full(int m, int n, const byte * p);
+
+  /** Botan cipher string
+   */
+  std::string encryption_cipher;
+
+  /** Symmetric encryption key pointer
+   *
+   *  If the pointer is non-NULL, all block I/O will be decrypted/encrypted
+   *  using the encryption_cipher with the encryption_key.
+   */
+  const std::string * encryption_key;
 };
 
 #endif /* OM_HGUARD_GLASS_TABLE_H */

--- a/xapian-core/common/Makefile.mk
+++ b/xapian-core/common/Makefile.mk
@@ -80,8 +80,10 @@ lib_src +=\
 libxapian_1_3_la_LDFLAGS += -lrpcrt4
 endif
 
-AM_CPPFLAGS += -I/usr/include/botan-1.10
-libxapian_1_3_la_LDFLAGS += -lbotan-1.10
+if ENCRYPTION
+AM_CPPFLAGS += $(BOTAN_CFLAGS)
+libxapian_1_3_la_LDFLAGS += $(BOTAN_LIBS)
+endif
 
 noinst_LTLIBRARIES += libgetopt.la
 

--- a/xapian-core/common/Makefile.mk
+++ b/xapian-core/common/Makefile.mk
@@ -80,6 +80,9 @@ lib_src +=\
 libxapian_1_3_la_LDFLAGS += -lrpcrt4
 endif
 
+AM_CPPFLAGS += -I/usr/include/botan-1.10
+libxapian_1_3_la_LDFLAGS += -lbotan-1.10
+
 noinst_LTLIBRARIES += libgetopt.la
 
 libgetopt_la_SOURCES =\

--- a/xapian-core/common/io_utils.cc
+++ b/xapian-core/common/io_utils.cc
@@ -36,6 +36,8 @@
 #include "omassert.h"
 #include "str.h"
 
+#include <botan/botan.h>
+
 // Trying to include the correct headers with the correct defines set to
 // get pread() and pwrite() prototyped on every platform without breaking any
 // other platform is a real can of worms.  So instead we probe for what
@@ -264,4 +266,40 @@ io_write_block(int fd, const char * p, size_t n, off_t b)
 	n -= c;
     }
 #endif
+}
+
+void
+io_read_encrypted_block(int fd, char * p, size_t n, off_t b,
+    const std::string& cipher, const std::string& key_str)
+{
+  io_read_block(fd, p, n, b);
+
+  const uint64_t iv_mem = static_cast<uint64_t>(n);
+
+  Botan::SymmetricKey key(key_str);
+  Botan::InitializationVector iv(reinterpret_cast<const Botan::byte*>(&iv_mem), sizeof iv_mem);
+  Botan::Pipe dec_pipe(Botan::get_cipher(cipher, key, iv, Botan::DECRYPTION));
+
+  dec_pipe.process_msg(reinterpret_cast<Botan::byte*>(p), b);
+  dec_pipe.read(reinterpret_cast<Botan::byte*>(p), b);
+
+  return;
+}
+
+void
+io_write_encrypted_block(int fd, const char * p, size_t n, off_t b,
+    const std::string& cipher, const std::string& key_str)
+{
+  const uint64_t iv_mem = static_cast<uint64_t>(n);
+
+  Botan::SymmetricKey key(key_str);
+  Botan::InitializationVector iv(reinterpret_cast<const Botan::byte*>(&iv_mem), sizeof iv_mem);
+  Botan::Pipe enc_pipe(Botan::get_cipher(cipher, key, iv, Botan::ENCRYPTION));
+
+  enc_pipe.process_msg(reinterpret_cast<const Botan::byte*>(p), b);
+  const std::string enc_data = enc_pipe.read_all_as_string();
+
+  io_write_block(fd, enc_data.c_str(), n, enc_data.size());
+
+  return;
 }

--- a/xapian-core/common/io_utils.cc
+++ b/xapian-core/common/io_utils.cc
@@ -36,7 +36,9 @@
 #include "omassert.h"
 #include "str.h"
 
+#ifdef HAVE_BOTAN_BOTAN_H
 #include <botan/botan.h>
+#endif
 
 // Trying to include the correct headers with the correct defines set to
 // get pread() and pwrite() prototyped on every platform without breaking any
@@ -272,6 +274,7 @@ void
 io_read_encrypted_block(int fd, char * p, size_t n, off_t b,
     const std::string& cipher, const std::string& key_str)
 {
+#ifdef XAPIAN_ENCRYPTION
   io_read_block(fd, p, n, b);
 
   const struct {
@@ -287,12 +290,21 @@ io_read_encrypted_block(int fd, char * p, size_t n, off_t b,
   dec_pipe.read(reinterpret_cast<Botan::byte*>(p), n);
 
   return;
+#else
+  (void)fd;
+  (void)p;
+  (void)n;
+  (void)cipher;
+  (void)key_str;
+  throw_block_error("Error reading encrypted block ", b, ENOTSUP);
+#endif /* XAPIAN_ENCRYPTION */
 }
 
 void
 io_write_encrypted_block(int fd, const char * p, size_t n, off_t b,
     const std::string& cipher, const std::string& key_str)
 {
+#ifdef XAPIAN_ENCRYPTION
   const struct {
     uint64_t d0;
     uint64_t d1;
@@ -308,4 +320,12 @@ io_write_encrypted_block(int fd, const char * p, size_t n, off_t b,
   io_write_block(fd, enc_data.c_str(), n, b);
 
   return;
+#else
+  (void)fd;
+  (void)p;
+  (void)n;
+  (void)cipher;
+  (void)key_str;
+  throw_block_error("Error writing encrypted block ", b, ENOTSUP);
+#endif /* XAPIAN_ENCRYPTION */
 }

--- a/xapian-core/common/io_utils.h
+++ b/xapian-core/common/io_utils.h
@@ -136,6 +136,14 @@ inline void io_write_block(int fd, const unsigned char * p, size_t n, off_t b) {
     io_write_block(fd, reinterpret_cast<const char *>(p), n, b);
 }
 
+void
+io_read_encrypted_block(int fd, char * p, size_t n, off_t b,
+    const std::string& cipher, const std::string& key_str);
+
+void
+io_write_encrypted_block(int fd, const char * p, size_t n, off_t b,
+    const std::string& cipher, const std::string& key_str);
+
 /** Delete a file.
  *
  *  @param	filename	The file to delete.

--- a/xapian-core/configure.ac
+++ b/xapian-core/configure.ac
@@ -479,6 +479,53 @@ if test x$USE_MAINTAINER_MODE = xyes; then
   test -z "$PERL" && AC_MSG_ERROR([perl is required in maintainer mode])
 fi
 
+AC_ARG_ENABLE([encryption],
+  [AS_HELP_STRING([--enable-encryption], [enable support for database encryption [default=no]])],
+  [case ${enableval} in
+    yes|no) ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --enable-encryption]) ;;
+  esac],
+  [enable_encryption=no])
+AM_CONDITIONAL([ENCRYPTION], [test x"$enable_encryption" = xyes])
+dnl
+dnl If we want encryption support, we have to have botan development files
+dnl
+if test x"$enable_encryption" = xyes ; then
+ AC_DEFINE([XAPIAN_ENCRYPTION], [1], [Define if xapian should be build with database encryption support])
+ dnl
+  dnl Use botan-1.10 pkg-config module by default
+  dnl
+  if test -z "$BOTAN_PKGCONFIG_MODULE"; then
+    BOTAN_PKGCONFIG_MODULE="botan-1.10"
+  fi
+  dnl
+  dnl Check whether we have pkg-config
+  dnl
+  AC_PATH_PROG([PKG_CONFIG], [pkg-config], [])
+  test -z "$PKG_CONFIG" && AC_MSG_ERROR([pkg-config is required to build with encryption support])
+  dnl
+  dnl First try to call pkg-config with the module name to check it's
+  dnl availability. If not, we show a meaningful message to the user.
+  dnl
+  $PKG_CONFIG $BOTAN_PKGCONFIG_MODULE || \
+    AC_MSG_ERROR([Botan pkg-config module ($BOTAN_PKGCONFIG_MODULE.pc) is not available on your system. You may need to install the botan-devel or botan-dev package.])
+  dnl
+  dnl Find out botan compiler and linker flags
+  dnl
+  BOTAN_LIBS=`$PKG_CONFIG $BOTAN_PKGCONFIG_MODULE --libs`
+  BOTAN_CFLAGS=`$PKG_CONFIG $BOTAN_PKGCONFIG_MODULE --cflags`
+  dnl
+  dnl Try to find botan include headers using the BOTAN_CFLAGS
+  dnl
+  SAVED_CPPFLAGS=$CPPFLAGS
+  CPPFLAGS=$BOTAN_CFLAGS
+  AC_CHECK_HEADERS([botan/botan.h], [], [AC_MSG_ERROR([botan header files not found. You may need to install the botan-devel or botan-dev package.])])
+  CPPFLAGS=$SAVED_CPPFLAGS
+
+  AC_SUBST([BOTAN_LIBS])
+  AC_SUBST([BOTAN_CFLAGS])
+fi
+
 AC_ARG_ENABLE([64bit_docid],
   [AS_HELP_STRING([--enable-64bit-docid], [enable 64bit docid [default=no]])],
   [case ${enableval} in

--- a/xapian-core/include/xapian/database.h
+++ b/xapian-core/include/xapian/database.h
@@ -81,6 +81,8 @@ class XAPIAN_VISIBILITY_DEFAULT Database {
 	 *  backend to use.
 	 *
 	 * @param path directory that the database is stored in.
+   * @param encryption_key encryption key to use for encrypting/decrypting the database
+   * @param encryption_cipher Botan cipher specification string
 	 */
 	explicit Database(const std::string &path, int flags = 0,
       const std::string * encryption_key = NULL,
@@ -526,6 +528,9 @@ class XAPIAN_VISIBILITY_DEFAULT WritableDatabase : public Database {
 	 *		      block size must be a power of 2 between 2048 and
 	 *		      65536 (inclusive), and the default (also used if
 	 *		      an invalid value is passed) is 8192 bytes.
+   *
+	 *  @param encryption_key encryption key to use for encrypting/decrypting the database
+   *  @param encryption_cipher Botan cipher specification string
 	 *
 	 *  @exception Xapian::DatabaseCorruptError will be thrown if the
 	 *             database is in a corrupt state.

--- a/xapian-core/include/xapian/database.h
+++ b/xapian-core/include/xapian/database.h
@@ -82,7 +82,9 @@ class XAPIAN_VISIBILITY_DEFAULT Database {
 	 *
 	 * @param path directory that the database is stored in.
 	 */
-	explicit Database(const std::string &path, int flags = 0);
+	explicit Database(const std::string &path, int flags = 0,
+      const std::string * encryption_key = NULL,
+      const std::string& encryption_cipher = "Serpent/XTS");
 
 	/** @private @internal Create a Database from its internals.
 	 */
@@ -533,7 +535,9 @@ class XAPIAN_VISIBILITY_DEFAULT WritableDatabase : public Database {
 	 */
 	explicit WritableDatabase(const std::string &path,
 				  int flags = 0,
-				  int block_size = 0);
+				  int block_size = 0,
+          const std::string * encryption_key = NULL,
+          const std::string& encryption_cipher = "Serpent/XTS");
 
 	/** @private @internal Create an WritableDatabase given its internals.
 	 */

--- a/xapian-core/include/xapian/dbfactory.h
+++ b/xapian-core/include/xapian/dbfactory.h
@@ -55,12 +55,12 @@ namespace Auto {
  *
  * @param file  pathname of the stub database file.
  */
-XAPIAN_DEPRECATED(Database open_stub(const std::string &file));
+XAPIAN_DEPRECATED(Database open_stub(const std::string &file, const std::string * encryption_key = NULL, const std::string& encryption_cipher = "Serpent/XTS"));
 
 inline Database
-open_stub(const std::string &file)
+open_stub(const std::string &file, const std::string * encryption_key, const std::string& encryption_cipher)
 {
-    return Database(file, DB_BACKEND_STUB);
+    return Database(file, DB_BACKEND_STUB, encryption_key, encryption_cipher);
 }
 
 /** Construct a WritableDatabase object for a stub database file.
@@ -79,12 +79,12 @@ open_stub(const std::string &file)
  *  - Xapian::DB_OPEN			open existing database, failing if none
  *					exists.
  */
-XAPIAN_DEPRECATED(WritableDatabase open_stub(const std::string &file, int action));
+XAPIAN_DEPRECATED(WritableDatabase open_stub(const std::string &file, int action, const std::string * encryption_key = NULL, const std::string& encryption_cipher = "Serpent/XTS"));
 
 inline WritableDatabase
-open_stub(const std::string &file, int action)
+open_stub(const std::string &file, int action, const std::string * encryption_key, const std::string& encryption_cipher)
 {
-    return WritableDatabase(file, action|DB_BACKEND_STUB);
+    return WritableDatabase(file, action|DB_BACKEND_STUB, 0, encryption_key, encryption_cipher);
 }
 
 }
@@ -112,12 +112,12 @@ namespace Chert {
  *
  * @param dir  pathname of the directory containing the database.
  */
-XAPIAN_DEPRECATED(Database open(const std::string &dir));
+XAPIAN_DEPRECATED(Database open(const std::string &dir, const std::string * encryption_key, const std::string& encryption_cipher = "Serpent/XTS"));
 
 inline Database
-open(const std::string &dir)
+open(const std::string &dir, const std::string * encryption_key, const std::string& encryption_cipher)
 {
-    return Database(dir, DB_BACKEND_CHERT);
+    return Database(dir, DB_BACKEND_CHERT, encryption_key, encryption_cipher);
 }
 
 /** Construct a Database object for update access to a Chert database.
@@ -138,12 +138,12 @@ open(const std::string &dir)
  *			8192 bytes.  This parameter is ignored when opening an
  *			existing database.
  */
-XAPIAN_DEPRECATED(WritableDatabase open(const std::string &dir, int action, int block_size = 0));
+XAPIAN_DEPRECATED(WritableDatabase open(const std::string &dir, int action, int block_size = 0, const std::string * encryption_key = NULL, const std::string& encryption_cipher = "Serpent/XTS"));
 
 inline WritableDatabase
-open(const std::string &dir, int action, int block_size)
+open(const std::string &dir, int action, int block_size, const std::string * encryption_key, const std::string& encryption_cipher)
 {
-    return WritableDatabase(dir, action|DB_BACKEND_CHERT, block_size);
+    return WritableDatabase(dir, action|DB_BACKEND_CHERT, block_size, encryption_key, encryption_cipher);
 }
 
 }

--- a/xapian-core/include/xapian/dbfactory.h
+++ b/xapian-core/include/xapian/dbfactory.h
@@ -54,6 +54,8 @@ namespace Auto {
  * or more databases.
  *
  * @param file  pathname of the stub database file.
+ * @param encryption_key encryption key to use for encrypting/decrypting the database
+ * @param encryption_cipher Botan cipher specification string
  */
 XAPIAN_DEPRECATED(Database open_stub(const std::string &file, const std::string * encryption_key = NULL, const std::string& encryption_cipher = "Serpent/XTS"));
 
@@ -78,6 +80,8 @@ open_stub(const std::string &file, const std::string * encryption_key, const std
  *					new database if none exists.
  *  - Xapian::DB_OPEN			open existing database, failing if none
  *					exists.
+ *  @param encryption_key encryption key to use for encrypting/decrypting the database
+ *  @param encryption_cipher Botan cipher specification string
  */
 XAPIAN_DEPRECATED(WritableDatabase open_stub(const std::string &file, int action, const std::string * encryption_key = NULL, const std::string& encryption_cipher = "Serpent/XTS"));
 
@@ -111,6 +115,8 @@ namespace Chert {
 /** Construct a Database object for read-only access to a Chert database.
  *
  * @param dir  pathname of the directory containing the database.
+ * @param encryption_key encryption key to use for encrypting/decrypting the database
+ * @param encryption_cipher Botan cipher specification string
  */
 XAPIAN_DEPRECATED(Database open(const std::string &dir, const std::string * encryption_key, const std::string& encryption_cipher = "Serpent/XTS"));
 
@@ -137,6 +143,8 @@ open(const std::string &dir, const std::string * encryption_key, const std::stri
  *			default (also used if an invalid value if passed) is
  *			8192 bytes.  This parameter is ignored when opening an
  *			existing database.
+ * @param encryption_key encryption key to use for encrypting/decrypting the database
+ * @param encryption_cipher Botan cipher specification string
  */
 XAPIAN_DEPRECATED(WritableDatabase open(const std::string &dir, int action, int block_size = 0, const std::string * encryption_key = NULL, const std::string& encryption_cipher = "Serpent/XTS"));
 

--- a/xapian-core/tests/.gitignore
+++ b/xapian-core/tests/.gitignore
@@ -34,6 +34,7 @@
 /api_collated.stamp
 /api_compact.h
 /api_db.h
+/api_encryption.h
 /api_generated.cc
 /api_generated.h
 /api_geospatial.h

--- a/xapian-core/tests/Makefile.am
+++ b/xapian-core/tests/Makefile.am
@@ -117,6 +117,7 @@ collated_apitest_sources = \
  api_collapse.cc \
  api_compact.cc \
  api_db.cc \
+ api_encryption.cc \
  api_generated.cc \
  api_geospatial.cc \
  api_matchspy.cc \

--- a/xapian-core/tests/api_encryption.cc
+++ b/xapian-core/tests/api_encryption.cc
@@ -51,11 +51,94 @@ using namespace std;
 const std::string test_encryption_key = "pQHQNZrTghIryAukoxkavLQupfDqZTKnKqFceofiKlNJaCkBsCynRWxQnJlVjGBF";
 const std::string test_encryption_cipher = "Serpent/XTS";
 
-DEFINE_TESTCASE(encrypted_db, chert && !remote && writable) {
+DEFINE_TESTCASE(encrypted_db_chert, chert && !remote && writable) {
   SKIP_TEST_FOR_BACKEND("inmemory");
 
-  Xapian::WritableDatabase db(".testdb_encrypted",
+  Xapian::WritableDatabase db(".chert_encrypted",
       Xapian::DB_CREATE_OR_OVERWRITE|Xapian::DB_BACKEND_CHERT, 8192,
+      &test_encryption_key, test_encryption_cipher);
+
+  // Read-only tests:
+  {
+    TEST_EQUAL(db.get_doccount(), 0);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("word"));
+    Xapian::MSet mset = enquire.get_mset(0, 10);
+    TEST(mset.empty());
+  }
+  {
+    TEST_EQUAL(db.get_doccount(), 0);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("word"));
+    Xapian::MSet mset = enquire.get_mset(0, 10);
+    TEST(mset.empty());
+  }
+
+  // Writable tests:
+  {
+    Xapian::WritableDatabase database(db);
+    Xapian::docid did;
+    Xapian::Document document_in;
+    document_in.set_data("Foobar rising");
+    document_in.add_value(7, "Value7");
+    document_in.add_value(13, "Value13");
+    document_in.add_posting("foo", 1);
+    document_in.add_posting("bar", 2);
+
+    {
+      did = database.add_document(document_in);
+      TEST_EQUAL(did, 1);
+      TEST_EQUAL(database.get_doccount(), 1);
+      TEST_EQUAL(database.get_avlength(), 2);
+    }
+
+    {
+      document_in.remove_term("foo");
+      document_in.add_posting("baz", 1);
+
+      database.replace_document(1, document_in);
+
+      database.delete_document(1);
+
+      TEST_EQUAL(database.get_doccount(), 0);
+      TEST_EQUAL(database.get_avlength(), 0);
+      TEST_EQUAL(database.get_termfreq("foo"), 0);
+      TEST_EQUAL(database.get_collection_freq("foo"), 0);
+      TEST_EQUAL(database.get_termfreq("bar"), 0);
+      TEST_EQUAL(database.get_collection_freq("bar"), 0);
+      TEST_EQUAL(database.get_termfreq("baz"), 0);
+      TEST_EQUAL(database.get_collection_freq("baz"), 0);
+    }
+  }
+
+  {
+    TEST_EQUAL(db.get_doccount(), 0);
+    db.add_document(Xapian::Document());
+    TEST_EQUAL(db.get_doccount(), 1);
+    db.add_document(Xapian::Document());
+    TEST_EQUAL(db.get_doccount(), 2);
+  }
+
+  {
+    for (Xapian::doccount i = 0; i < 2100; ++i) {
+      Xapian::Document doc;
+      for (Xapian::termcount t = 0; t < 100; ++t) {
+        string term("foo");
+        term += char(t ^ 70 ^ i);
+        doc.add_posting(term, t);
+      }
+      db.add_document(doc);
+    }
+    TEST(db.term_exists("foo1"));
+  }
+  return true;
+}
+
+DEFINE_TESTCASE(encrypted_db_glass, glass && !remote && writable) {
+  SKIP_TEST_FOR_BACKEND("inmemory");
+
+  Xapian::WritableDatabase db(".glass_encrypted",
+      Xapian::DB_CREATE_OR_OVERWRITE|Xapian::DB_BACKEND_GLASS, 8192,
       &test_encryption_key, test_encryption_cipher);
 
   // Read-only tests:

--- a/xapian-core/tests/api_encryption.cc
+++ b/xapian-core/tests/api_encryption.cc
@@ -1,0 +1,135 @@
+/* api_encryption.cc: tests with encrypted databases
+ *
+ * Copyright 1999,2000,2001 BrightStation PLC
+ * Copyright 2002 Ananova Ltd
+ * Copyright 2002,2003,2004,2005,2006,2007,2008,2009,2011,2012,2013,2015 Olly Betts
+ * Copyright 2006,2007,2008,2009 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+#include <config.h>
+
+#include "api_encryption.h"
+
+#include <algorithm>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+#include "safesysstat.h" // For mkdir().
+#include "safeunistd.h" // For sleep().
+
+#include <xapian.h>
+
+#include "backendmanager.h"
+#include "backendmanager_local.h"
+#include "testsuite.h"
+#include "testutils.h"
+#include "unixcmds.h"
+
+#include "apitest.h"
+
+using namespace std;
+
+// #######################################################################
+// # Tests start here
+
+const std::string test_encryption_key = "pQHQNZrTghIryAukoxkavLQupfDqZTKnKqFceofiKlNJaCkBsCynRWxQnJlVjGBF";
+const std::string test_encryption_cipher = "Serpent/XTS";
+
+DEFINE_TESTCASE(encrypted_db, chert && !remote && writable) {
+  SKIP_TEST_FOR_BACKEND("inmemory");
+
+  Xapian::WritableDatabase db(".testdb_encrypted",
+      Xapian::DB_CREATE_OR_OVERWRITE|Xapian::DB_BACKEND_CHERT, 8192,
+      &test_encryption_key, test_encryption_cipher);
+
+  // Read-only tests:
+  {
+    TEST_EQUAL(db.get_doccount(), 0);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("word"));
+    Xapian::MSet mset = enquire.get_mset(0, 10);
+    TEST(mset.empty());
+  }
+  {
+    TEST_EQUAL(db.get_doccount(), 0);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("word"));
+    Xapian::MSet mset = enquire.get_mset(0, 10);
+    TEST(mset.empty());
+  }
+
+  // Writable tests:
+  {
+    Xapian::WritableDatabase database(db);
+    Xapian::docid did;
+    Xapian::Document document_in;
+    document_in.set_data("Foobar rising");
+    document_in.add_value(7, "Value7");
+    document_in.add_value(13, "Value13");
+    document_in.add_posting("foo", 1);
+    document_in.add_posting("bar", 2);
+
+    {
+      did = database.add_document(document_in);
+      TEST_EQUAL(did, 1);
+      TEST_EQUAL(database.get_doccount(), 1);
+      TEST_EQUAL(database.get_avlength(), 2);
+    }
+
+    {
+      document_in.remove_term("foo");
+      document_in.add_posting("baz", 1);
+
+      database.replace_document(1, document_in);
+
+      database.delete_document(1);
+
+      TEST_EQUAL(database.get_doccount(), 0);
+      TEST_EQUAL(database.get_avlength(), 0);
+      TEST_EQUAL(database.get_termfreq("foo"), 0);
+      TEST_EQUAL(database.get_collection_freq("foo"), 0);
+      TEST_EQUAL(database.get_termfreq("bar"), 0);
+      TEST_EQUAL(database.get_collection_freq("bar"), 0);
+      TEST_EQUAL(database.get_termfreq("baz"), 0);
+      TEST_EQUAL(database.get_collection_freq("baz"), 0);
+    }
+  }
+
+  {
+    TEST_EQUAL(db.get_doccount(), 0);
+    db.add_document(Xapian::Document());
+    TEST_EQUAL(db.get_doccount(), 1);
+    db.add_document(Xapian::Document());
+    TEST_EQUAL(db.get_doccount(), 2);
+  }
+
+  {
+    for (Xapian::doccount i = 0; i < 2100; ++i) {
+      Xapian::Document doc;
+      for (Xapian::termcount t = 0; t < 100; ++t) {
+        string term("foo");
+        term += char(t ^ 70 ^ i);
+        doc.add_posting(term, t);
+      }
+      db.add_document(doc);
+    }
+    TEST(db.term_exists("foo1"));
+  }
+  return true;
+}


### PR DESCRIPTION
Hi, the set of patches in this pull request implement database encryption for the glass and chert backends. I've used the Botan library as a provider of crypto routines but there's no strong reasoning behind this choice (it seemed to have the best documentation among the C++ crypto libraries).

The encryption/decryption is implemented at block I/O level in `common/io_utils.cc`.

## Changes
 * New configure option to enable/disable encryption support: `--enable-encryption`
 * Public API functions for creating databases (read-only and read-write) were extended with two std::string parameters with default values: `encryption_key` (`NULL`) and `encryption_cipher` (`"Serpent/XTS"`)
 * Added simple test to check that the encryption works: `tests/api_encryption.cc`.

## Some known issues
 * Public API in xapian/database.h and xapian/dbfactory.h was modified/extended with two additional parameters with default values, which preserves source level API compatibility but **doesn't preserve binary API compatibility**
 * **Some tests are broken**, saying: `DatabaseLockError: Unable to get write lock on ...: already locked`. I'll probably need help with resolving this issue.
 * Not tested with remote backends yet

## Example usage (from tests/api_encryption.cc)
```c++
const std::string test_encryption_key = "pQHQNZrTghIryAukoxkavLQupfDqZTKnKqFceofiKlNJaCkBsCynRWxQnJlVjGBF";
const std::string test_encryption_cipher = "Serpent/XTS";
 
Xapian::WritableDatabase db(".chert_encrypted",
    Xapian::DB_CREATE_OR_OVERWRITE|Xapian::DB_BACKEND_CHERT,
    8192,
    &test_encryption_key, test_encryption_cipher);

// do stuff with db
```
