### PR TITLE
Added skip action to log while ignoring the mimetype.

### DIFF
--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -106,8 +106,7 @@ index_file(const string &file, const string &url, DirectoryIterator & d,
 	string m = "skipping extension '";
 	m += ext;
 	m += "'";
-	skip(urlterm, file.substr(root.size()), m, d.get_size(), d.get_mtime(),
-	    SKIP_VERBOSE_ONLY);
+	skip(urlterm, file.substr(root.size()), m, d.get_size(), d.get_mtime());
 	return;
     }
 

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -101,6 +101,14 @@ index_file(const string &file, const string &url, DirectoryIterator & d,
 	}
     } else if (mimetype == "ignore") {
 	return;
+    } else if (mimetype == "skip") {
+	//Ignore mimetype, skipped mimetype should not be quitely ignored.
+	string m = "skipping extension '";
+	m += ext;
+	m += "'";
+	skip(urlterm, file.substr(root.size()), m, d.get_size(), d.get_mtime(),
+	    SKIP_VERBOSE_ONLY);
+	return;
     }
 
     if (verbose)


### PR DESCRIPTION
I have not added SKIP_VERBOSE_FLAG to the skip command in this action. Since that would make it similar to ignore psuedo-mimetype in most cases.

Not sure if there is any doc which need to be updated with skip feature.

I was thinking to explain it in help, But that might clutter the help section, i guess that might have been the reason to not add ignore psuedo-mimetype as-well. Shall we add it to help ?
