### PR TITLE
Add max-wdf normalization scheme to TfIdfWeight

### DIFF
--- a/xapian-core/api/emptypostlist.cc
+++ b/xapian-core/api/emptypostlist.cc
@@ -77,6 +77,12 @@ EmptyPostList::get_unique_terms() const
     return Xapian::termcount(EmptyPostList::get_docid());
 }
 
+Xapian::termcount
+EmptyPostList::get_wdfdocmax() const
+{
+    return Xapian::termcount(EmptyPostList::get_docid());
+}
+
 double
 EmptyPostList::get_weight() const
 {

--- a/xapian-core/api/emptypostlist.h
+++ b/xapian-core/api/emptypostlist.h
@@ -45,6 +45,7 @@ class EmptyPostList : public PostList {
     Xapian::docid get_docid() const;
     Xapian::termcount get_doclength() const;
     Xapian::termcount get_unique_terms() const;
+    Xapian::termcount get_wdfdocmax() const;
     double get_weight() const;
     bool at_end() const;
     double recalc_maxweight();

--- a/xapian-core/api/leafpostlist.cc
+++ b/xapian-core/api/leafpostlist.cc
@@ -60,6 +60,7 @@ LeafPostList::set_termweight(const Xapian::Weight * weight_)
     weight = weight_;
     need_doclength = weight->get_sumpart_needs_doclength_();
     need_unique_terms = weight->get_sumpart_needs_uniqueterms_();
+    need_wdfdocmax = weight->get_sumpart_needs_wdfdocmax_();
 }
 
 double
@@ -72,14 +73,16 @@ double
 LeafPostList::get_weight() const
 {
     if (!weight) return 0;
-    Xapian::termcount doclen = 0, unique_terms = 0;
+    Xapian::termcount doclen = 0, unique_terms = 0, wdfdocmax = 0;
     // Fetching the document length and number of unique terms is work we can
     // avoid if the weighting scheme doesn't use them.
     if (need_doclength)
 	doclen = get_doclength();
     if (need_unique_terms)
 	unique_terms = get_unique_terms();
-    double sumpart = weight->get_sumpart(get_wdf(), doclen, unique_terms);
+    if (need_wdfdocmax)
+	wdfdocmax = get_wdfdocmax();
+    double sumpart = weight->get_sumpart(get_wdf(), doclen, unique_terms, wdfdocmax);
     AssertRel(sumpart, <=, weight->get_maxpart());
     return sumpart;
 }

--- a/xapian-core/api/leafpostlist.h
+++ b/xapian-core/api/leafpostlist.h
@@ -45,7 +45,7 @@ class LeafPostList : public PostList {
   protected:
     const Xapian::Weight * weight;
 
-    bool need_doclength, need_unique_terms;
+    bool need_doclength, need_unique_terms, need_wdfdocmax;
 
     /// The term name for this postlist (empty for an alldocs postlist).
     std::string term;

--- a/xapian-core/api/postlist.h
+++ b/xapian-core/api/postlist.h
@@ -77,6 +77,9 @@ class Xapian::PostingIterator::Internal : public Xapian::Internal::intrusive_bas
     /// Return the current docid.
     virtual Xapian::docid get_docid() const = 0;
 
+    /// Return the max wdf in the current document.
+    virtual Xapian::termcount get_wdfdocmax() const = 0;
+
     /// Return the length of current document.
     virtual Xapian::termcount get_doclength() const = 0;
     /* FIXME: Once flint has been retired, we should probably strip out

--- a/xapian-core/backends/chert/chert_database.cc
+++ b/xapian-core/backends/chert/chert_database.cc
@@ -810,6 +810,23 @@ ChertDatabase::get_unique_terms(Xapian::docid did) const
     RETURN(termlist.get_approx_size());
 }
 
+Xapian::termcount
+ChertDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    LOGCALL(DB, Xapian::termcount, "ChertDatabase::get_wdfdocmax", did);
+    Assert(did != 0);
+    intrusive_ptr<const ChertDatabase> ptrtothis(this);
+    ChertTermList termlist(ptrtothis, did);
+    Xapian::termcount max_wdf = 0;
+    termlist.next();
+    while (!termlist.at_end()) {
+	Xapian::termcount current_wdf = termlist.get_wdf();
+	if (current_wdf > max_wdf) max_wdf = current_wdf;
+	termlist.next();
+    }
+    RETURN(max_wdf);
+}
+
 void
 ChertDatabase::get_freqs(const string & term,
 			 Xapian::doccount * termfreq_ptr,

--- a/xapian-core/backends/chert/chert_database.h
+++ b/xapian-core/backends/chert/chert_database.h
@@ -267,6 +267,7 @@ class ChertDatabase : public Xapian::Database::Internal {
 	Xapian::doclength get_avlength() const;
 	Xapian::termcount get_doclength(Xapian::docid did) const;
 	Xapian::termcount get_unique_terms(Xapian::docid did) const;
+	Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
 	void get_freqs(const string & term,
 		       Xapian::doccount * termfreq_ptr,
 		       Xapian::termcount * collfreq_ptr) const;

--- a/xapian-core/backends/chert/chert_postlist.cc
+++ b/xapian-core/backends/chert/chert_postlist.cc
@@ -725,6 +725,16 @@ ChertPostList::get_unique_terms() const
     RETURN(this_db->get_unique_terms(did));
 }
 
+Xapian::termcount
+ChertPostList::get_wdfdocmax() const
+{
+    LOGCALL(DB, Xapian::termcount, "ChertPostList::get_wdfdocmax", NO_ARGS);
+    Assert(have_started);
+    Assert(!is_at_end);
+    Assert(this_db.get());
+    RETURN(this_db->get_wdfdocmax(did));
+}
+
 bool
 ChertPostList::next_in_chunk()
 {

--- a/xapian-core/backends/chert/chert_postlist.h
+++ b/xapian-core/backends/chert/chert_postlist.h
@@ -254,6 +254,9 @@ class ChertPostList : public LeafPostList {
 
 	Xapian::termcount get_unique_terms() const;
 
+	/// Returns the max wdf of terms in current document.
+	Xapian::termcount get_wdfdocmax() const;
+
 	/** Returns the Within Document Frequency of the term in the current
 	 *  document.
 	 */

--- a/xapian-core/backends/contiguousalldocspostlist.cc
+++ b/xapian-core/backends/contiguousalldocspostlist.cc
@@ -60,6 +60,14 @@ ContiguousAllDocsPostList::get_unique_terms() const
 }
 
 Xapian::termcount
+ContiguousAllDocsPostList::get_wdfdocmax() const
+{
+   Assert(did != 0);
+   Assert(!at_end());
+   return db->get_wdfdocmax(did);
+}
+
+Xapian::termcount
 ContiguousAllDocsPostList::get_wdf() const
 {
     Assert(did != 0);

--- a/xapian-core/backends/contiguousalldocspostlist.h
+++ b/xapian-core/backends/contiguousalldocspostlist.h
@@ -67,6 +67,9 @@ class ContiguousAllDocsPostList : public LeafPostList {
     /// Return the number of unique terms.
     Xapian::termcount get_unique_terms() const;
 
+    /// Return the max wdf of terms in current document
+    Xapian::termcount get_wdfdocmax() const;
+
     /// Always return 1 (wdf isn't totally meaningful for us).
     Xapian::termcount get_wdf() const;
 

--- a/xapian-core/backends/database.h
+++ b/xapian-core/backends/database.h
@@ -149,6 +149,13 @@ class Database::Internal : public Xapian::Internal::intrusive_base {
 	 */
 	virtual	Xapian::termcount get_unique_terms(Xapian::docid did) const = 0;
 
+	/** Get the max wdf of terms in document.
+	 *
+	 *  @param did  The document id of the document whose max-wdf is
+	 *		being requested.
+	 */
+	virtual	Xapian::termcount get_wdfdocmax(Xapian::docid did) const = 0;
+
 	/** Returns frequencies for a term.
 	 *
 	 *  @param term		The term to get frequencies for

--- a/xapian-core/backends/glass/glass_database.cc
+++ b/xapian-core/backends/glass/glass_database.cc
@@ -744,6 +744,23 @@ GlassDatabase::get_unique_terms(Xapian::docid did) const
     RETURN(termlist.get_approx_size());
 }
 
+Xapian::termcount
+GlassDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    LOGCALL(DB, Xapian::termcount, "GlassDatabase::get_wdfdocmax", did);
+    Assert(did != 0);
+    intrusive_ptr<const GlassDatabase> ptrtothis(this);
+    GlassTermList termlist(ptrtothis, did);
+    Xapian::termcount max_wdf = 0;
+    termlist.next();
+    while (!termlist.at_end()) {
+	Xapian::termcount current_wdf = termlist.get_wdf();
+	if (current_wdf > max_wdf) max_wdf = current_wdf;
+	termlist.next();
+    }
+    RETURN(max_wdf);
+}
+
 void
 GlassDatabase::get_freqs(const string & term,
 			 Xapian::doccount * termfreq_ptr,

--- a/xapian-core/backends/glass/glass_database.h
+++ b/xapian-core/backends/glass/glass_database.h
@@ -251,6 +251,7 @@ class GlassDatabase : public Xapian::Database::Internal {
 	Xapian::doclength get_avlength() const;
 	Xapian::termcount get_doclength(Xapian::docid did) const;
 	Xapian::termcount get_unique_terms(Xapian::docid did) const;
+	Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
 	void get_freqs(const string & term,
 		       Xapian::doccount * termfreq_ptr,
 		       Xapian::termcount * collfreq_ptr) const;

--- a/xapian-core/backends/glass/glass_postlist.cc
+++ b/xapian-core/backends/glass/glass_postlist.cc
@@ -754,6 +754,15 @@ GlassPostList::get_unique_terms() const
     RETURN(this_db->get_unique_terms(did));
 }
 
+Xapian::termcount
+GlassPostList::get_wdfdocmax() const
+{
+    LOGCALL(DB, Xapian::termcount, "GlassPostList::get_wdfdocmax", NO_ARGS);
+    Assert(have_started);
+    Assert(this_db.get());
+    RETURN(this_db->get_wdfdocmax(did));
+}
+
 bool
 GlassPostList::next_in_chunk()
 {

--- a/xapian-core/backends/glass/glass_postlist.h
+++ b/xapian-core/backends/glass/glass_postlist.h
@@ -268,6 +268,9 @@ class GlassPostList : public LeafPostList {
 	/// Returns the number of unique terms in the current document.
 	Xapian::termcount get_unique_terms() const;
 
+	/// Returns the max wdf of all terms in current document.
+	Xapian::termcount get_wdfdocmax() const;
+
 	/** Returns the Within Document Frequency of the term in the current
 	 *  document.
 	 */

--- a/xapian-core/backends/inmemory/inmemory_database.cc
+++ b/xapian-core/backends/inmemory/inmemory_database.cc
@@ -163,6 +163,12 @@ InMemoryPostList::get_unique_terms() const
     return db->get_unique_terms(get_docid());
 }
 
+Xapian::termcount
+InMemoryPostList::get_wdfdocmax() const
+{
+   return db->get_wdfdocmax(get_docid());
+}
+
 PositionList *
 InMemoryPostList::read_position_list()
 {
@@ -334,6 +340,12 @@ Xapian::termcount
 InMemoryAllDocsPostList::get_unique_terms() const
 {
     return db->get_unique_terms(did);
+}
+
+Xapian::termcount
+InMemoryAllDocsPostList::get_wdfdocmax() const
+{
+   return db->get_wdfdocmax(did);
 }
 
 Xapian::termcount
@@ -552,6 +564,21 @@ InMemoryDatabase::get_unique_terms(Xapian::docid did) const
 	throw Xapian::DocNotFoundError(string("Docid ") + str(did) +
 				 string(" not found"));
     return termlists[did - 1].terms.size();
+}
+
+Xapian::termcount
+InMemoryDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    if (closed) InMemoryDatabase::throw_database_closed();
+    if (did == 0 || did > termlists.size() || !termlists[did - 1].is_valid)
+    throw Xapian::DocNotFoundError(string("Docid ") + str(did) +
+                string(" not found"));
+    vector<InMemoryTermEntry> all_terms = termlists[did-1].terms;
+    Xapian::termcount max_wdf = 0;
+    for (vector<InMemoryTermEntry>::iterator i = all_terms.begin(); i != all_terms.end(); ++i) {
+	if ( i->wdf > max_wdf ) max_wdf = i->wdf;
+    }
+    return max_wdf;
 }
 
 TermList *

--- a/xapian-core/backends/inmemory/inmemory_database.h
+++ b/xapian-core/backends/inmemory/inmemory_database.h
@@ -156,6 +156,7 @@ class InMemoryPostList : public LeafPostList {
 	Xapian::docid       get_docid() const;     // Gets current docid
 	Xapian::termcount   get_doclength() const; // Length of current document
 	Xapian::termcount   get_unique_terms() const; // number of terms in current document
+	Xapian::termcount 	get_wdfdocmax() const; 	// Max wdf of terms in current document
 	Xapian::termcount   get_wdf() const;	   // Within Document Frequency
 	PositionList * read_position_list();
 	PositionList * open_position_list() const;
@@ -186,6 +187,7 @@ class InMemoryAllDocsPostList : public LeafPostList {
 	Xapian::docid       get_docid() const;     // Gets current docid
 	Xapian::termcount   get_doclength() const; // Length of current document
 	Xapian::termcount   get_unique_terms() const; // number of terms in current document
+	Xapian::termcount 	get_wdfdocmax() const; 	// Max wdf of terms in current document
 	Xapian::termcount   get_wdf() const;       // Within Document Frequency
 	PositionList * read_position_list();
 	PositionList * open_position_list() const;
@@ -323,6 +325,7 @@ class InMemoryDatabase : public Xapian::Database::Internal {
     Xapian::doclength get_avlength() const;
     Xapian::termcount get_doclength(Xapian::docid did) const;
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
 
     void get_freqs(const string & term,
 		   Xapian::doccount * termfreq_ptr,

--- a/xapian-core/backends/multi/multi_postlist.cc
+++ b/xapian-core/backends/multi/multi_postlist.cc
@@ -122,6 +122,17 @@ MultiPostList::get_unique_terms() const
 }
 
 Xapian::termcount
+MultiPostList::get_wdfdocmax() const
+{
+    LOGCALL(DB, Xapian::termcount, "MultiPostList::get_wdfdocmax", NO_ARGS);
+    Assert(!at_end());
+    Assert(currdoc != 0);
+    Xapian::termcount result = postlists[(currdoc - 1) % multiplier]->get_wdfdocmax();
+    AssertEqParanoid(result, this_db.get_wdfdocmax(get_docid()));
+    RETURN(result);
+}
+
+Xapian::termcount
 MultiPostList::get_wdf() const
 {
     return postlists[(currdoc - 1) % multiplier]->get_wdf();

--- a/xapian-core/backends/multi/multi_postlist.h
+++ b/xapian-core/backends/multi/multi_postlist.h
@@ -54,6 +54,7 @@ class MultiPostList : public PostList {
 	Xapian::docid  get_docid() const;     // Gets current docid
 	Xapian::termcount get_doclength() const; // Get length of current document
 	Xapian::termcount get_unique_terms() const; // Get number of unique term in current document
+	Xapian::termcount get_wdfdocmax() const;	// Get max wdf of terms in current document
         Xapian::termcount get_wdf() const;	    // Within Document Frequency
 	PositionList * open_position_list() const;
 	PostList *next(double w_min);          // Moves to next docid

--- a/xapian-core/backends/remote/net_postlist.cc
+++ b/xapian-core/backends/remote/net_postlist.cc
@@ -53,6 +53,12 @@ NetworkPostList::get_unique_terms() const
 }
 
 Xapian::termcount
+NetworkPostList::get_wdfdocmax() const
+{
+    return db->get_wdfdocmax(lastdocid);
+}
+
+Xapian::termcount
 NetworkPostList::get_wdf() const
 {
     return lastwdf;

--- a/xapian-core/backends/remote/net_postlist.h
+++ b/xapian-core/backends/remote/net_postlist.h
@@ -79,6 +79,9 @@ class NetworkPostList : public LeafPostList {
     /// Get the number of unique terms in the current document.
     Xapian::termcount get_unique_terms() const;
 
+    /// Get max wdf of terms in current document
+    Xapian::termcount get_wdfdocmax() const;
+
     /// Get the Within Document Frequency of the term in the current document.
     Xapian::termcount get_wdf() const;
 

--- a/xapian-core/backends/remote/remote-database.cc
+++ b/xapian-core/backends/remote/remote-database.cc
@@ -562,6 +562,14 @@ RemoteDatabase::get_unique_terms(Xapian::docid did) const
     return doclen;
 }
 
+Xapian::termcount
+RemoteDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    (void)did;
+    // FIXME : Needs to be implemented for this
+    throw Xapian::UnimplementedError("get_wdfdocmax is currently unsupported for RemoteDatabase");
+}
+
 reply_type
 RemoteDatabase::get_message(string &result, reply_type required_type) const
 {

--- a/xapian-core/backends/remote/remote-database.h
+++ b/xapian-core/backends/remote/remote-database.h
@@ -214,6 +214,7 @@ class RemoteDatabase : public Xapian::Database::Internal {
 
     Xapian::termcount get_doclength(Xapian::docid did) const;
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
 
     /// Check if term exists.
     bool term_exists(const string & tname) const;

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -62,7 +62,9 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
 	/// Sum of wdf over the whole collection for the current term.
 	COLLECTION_FREQ = 4096,
 	/// Number of unique terms in the current document.
-	UNIQUE_TERMS = 8192
+	UNIQUE_TERMS = 8192,
+	/// Maximum wdf in the current document.
+	WDF_DOC_MAX = 16384
     } stat_flags;
 
     /** Tell Xapian that your subclass will want a particular statistic.
@@ -221,7 +223,8 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
      */
     virtual double get_sumpart(Xapian::termcount wdf,
 			       Xapian::termcount doclen,
-			       Xapian::termcount uniqterms) const = 0;
+			       Xapian::termcount uniqterms,
+ 			       Xapian::termcount wdfdocmax) const = 0;
 
     /** Return an upper bound on what get_sumpart() can return for any document.
      *
@@ -313,6 +316,16 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
 	return stats_needed & UNIQUE_TERMS;
     }
 
+    /** @private @internal Return true if the maximum WDF for a document is needed.
+     *
+     *  If this method returns true, then the max WDF will be
+     *  fetched and passed to @a get_sumpart().  Otherwise 0 may be passed for
+     *  the max wdf.
+     */
+    bool get_sumpart_needs_wdfdocmax_() const {
+	return stats_needed & WDF_DOC_MAX;
+    }
+
   protected:
     /** Don't allow copying.
      *
@@ -392,7 +405,8 @@ class XAPIAN_VISIBILITY_DEFAULT BoolWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+ 		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -415,7 +429,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /* When additional normalizations are implemented in the future, the additional statistics for them
        should be accessed by these functions. */
-    double get_wdfn(Xapian::termcount wdf, char c) const;
+    double get_wdfn(Xapian::termcount wdf, char c, Xapian::termcount wdfdocmax = 0) const;
     double get_idfn(Xapian::doccount termfreq, char c) const;
     double get_wtn(double wt, char c) const;
 
@@ -435,8 +449,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      *     @li 'b': Boolean    wdfn=1 if term in document else wdfn=0
      *     @li 's': Square     wdfn=wdf*wdf
      *     @li 'l': Logarithmic wdfn=1+log<sub>e</sub>(wdf)
+     *     @li 'm': Max_wdf     wdfn=wdf/max_wdf
      *
-     *     The Max-wdf and Augmented Max wdf normalizations haven't yet been
+     *     The Augmented Max_wdf normalization hasn't yet been
      *     implemented.
      *
      * @li The second character indicates the normalization for the idf.  The
@@ -475,7 +490,8 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+ 		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -580,7 +596,8 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -641,7 +658,8 @@ class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqueterms) const;
+		       Xapian::termcount uniqueterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -714,7 +732,8 @@ class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -787,7 +806,8 @@ class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -858,7 +878,8 @@ class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -934,7 +955,8 @@ class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -994,7 +1016,8 @@ class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1072,7 +1095,8 @@ class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1135,7 +1159,8 @@ class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1227,7 +1252,8 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const;

--- a/xapian-core/matcher/andmaybepostlist.cc
+++ b/xapian-core/matcher/andmaybepostlist.cc
@@ -214,6 +214,15 @@ AndMaybePostList::get_unique_terms() const
 }
 
 Xapian::termcount
+AndMaybePostList::get_wdfdocmax() const
+{
+    LOGCALL(MATCH, Xapian::termcount, "AndMaybePostList::get_wdfdocmax", NO_ARGS);
+    Assert(lhead != 0); // check we've started
+    if (lhead == rhead) AssertEq(l->get_wdfdocmax(), r->get_wdfdocmax());
+    RETURN(l->get_wdfdocmax());
+}
+
+Xapian::termcount
 AndMaybePostList::get_wdf() const
 {
     LOGCALL(MATCH, Xapian::termcount, "AndMaybePostList::get_wdf", NO_ARGS);

--- a/xapian-core/matcher/andmaybepostlist.h
+++ b/xapian-core/matcher/andmaybepostlist.h
@@ -85,6 +85,8 @@ class AndMaybePostList : public BranchPostList {
 
 	virtual Xapian::termcount get_unique_terms() const;
 
+	virtual Xapian::termcount get_wdfdocmax() const;
+
         AndMaybePostList(PostList *left_,
 			 PostList *right_,
 			 MultiMatch *matcher_,

--- a/xapian-core/matcher/andnotpostlist.cc
+++ b/xapian-core/matcher/andnotpostlist.cc
@@ -222,6 +222,13 @@ AndNotPostList::get_unique_terms() const
 }
 
 Xapian::termcount
+AndNotPostList::get_wdfdocmax() const
+{
+    LOGCALL(MATCH, Xapian::termcount, "AndNotPostList::get_wdfdocmax", NO_ARGS);
+    RETURN(l->get_wdfdocmax());
+}
+
+Xapian::termcount
 AndNotPostList::get_wdf() const
 {
     LOGCALL(MATCH, Xapian::termcount, "AndNotPostList::get_wdf", NO_ARGS);

--- a/xapian-core/matcher/andnotpostlist.h
+++ b/xapian-core/matcher/andnotpostlist.h
@@ -66,6 +66,8 @@ class AndNotPostList : public BranchPostList {
 
 	virtual Xapian::termcount get_unique_terms() const;
 
+	virtual Xapian::termcount get_wdfdocmax() const;
+
         AndNotPostList(PostList *left,
 		       PostList *right,
 		       MultiMatch *matcher_,

--- a/xapian-core/matcher/const_database_wrapper.cc
+++ b/xapian-core/matcher/const_database_wrapper.cc
@@ -77,6 +77,12 @@ ConstDatabaseWrapper::get_unique_terms(Xapian::docid did) const
     return realdb->get_unique_terms(did);
 }
 
+Xapian::termcount
+ConstDatabaseWrapper::get_wdfdocmax(Xapian::docid did) const
+{
+   return realdb->get_wdfdocmax(did);
+}
+
 void
 ConstDatabaseWrapper::get_freqs(const string & term,
 				Xapian::doccount * termfreq_ptr,

--- a/xapian-core/matcher/const_database_wrapper.h
+++ b/xapian-core/matcher/const_database_wrapper.h
@@ -54,6 +54,7 @@ class ConstDatabaseWrapper : public Xapian::Database::Internal {
     Xapian::doclength get_avlength() const;
     Xapian::termcount get_doclength(Xapian::docid did) const;
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
     void get_freqs(const string & term,
 		   Xapian::doccount * termfreq_ptr,
 		   Xapian::termcount * collfreq_ptr) const;

--- a/xapian-core/matcher/externalpostlist.cc
+++ b/xapian-core/matcher/externalpostlist.cc
@@ -115,6 +115,13 @@ ExternalPostList::get_unique_terms() const
     return 0;
 }
 
+Xapian::termcount
+ExternalPostList::get_wdfdocmax() const
+{
+   Assert(false);
+   return 0;
+}
+
 double
 ExternalPostList::recalc_maxweight()
 {

--- a/xapian-core/matcher/externalpostlist.h
+++ b/xapian-core/matcher/externalpostlist.h
@@ -74,6 +74,8 @@ class ExternalPostList : public PostList {
 
     Xapian::termcount get_unique_terms() const;
 
+    Xapian::termcount get_wdfdocmax() const;
+
     double recalc_maxweight();
 
     PositionList * read_position_list();

--- a/xapian-core/matcher/extraweightpostlist.h
+++ b/xapian-core/matcher/extraweightpostlist.h
@@ -107,6 +107,10 @@ class ExtraWeightPostList : public PostList {
 	    return pl->get_unique_terms();
 	}
 
+	virtual Xapian::termcount get_wdfdocmax() const {
+		return pl->get_wdfdocmax();
+	}
+
 	ExtraWeightPostList(PostList * pl_, Xapian::Weight *wt_,
 			    MultiMatch *matcher_)
 	    : pl(pl_), wt(wt_), matcher(matcher_),

--- a/xapian-core/matcher/localsubmatch.cc
+++ b/xapian-core/matcher/localsubmatch.cc
@@ -85,7 +85,8 @@ class LazyWeight : public Xapian::Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -130,11 +131,13 @@ LazyWeight::unserialise(const string &) const
 double
 LazyWeight::get_sumpart(Xapian::termcount wdf,
 			Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const
 {
     (void)wdf;
     (void)doclen;
     (void)uniqterms;
+    (void)wdfdocmax;
     throw Xapian::InvalidOperationError("LazyWeight::get_sumpart()");
 }
 

--- a/xapian-core/matcher/maxpostlist.cc
+++ b/xapian-core/matcher/maxpostlist.cc
@@ -165,6 +165,26 @@ MaxPostList::get_unique_terms() const
     return unique_terms;
 }
 
+Xapian::termcount
+MaxPostList::get_wdfdocmax() const
+{
+    Assert(did);
+    Xapian::termcount wdfdocmax = 0;
+    bool wdfdocmax_set = false;
+    for (size_t i = 0; i < n_kids; ++i) {
+	if (plist[i]->get_docid() == did) {
+	    if (wdfdocmax_set) {
+		AssertEq(wdfdocmax, plist[i]->get_wdfdocmax());
+	    } else {
+		wdfdocmax = plist[i]->get_wdfdocmax();
+		wdfdocmax_set = true;
+	    }
+	}
+    }
+    Assert(wdfdocmax_set);
+    return wdfdocmax;
+}
+
 double
 MaxPostList::get_weight() const
 {

--- a/xapian-core/matcher/maxpostlist.h
+++ b/xapian-core/matcher/maxpostlist.h
@@ -97,6 +97,8 @@ class MaxPostList : public PostList {
 
     Xapian::termcount get_unique_terms() const;
 
+    Xapian::termcount get_wdfdocmax() const;
+
     double get_weight() const;
 
     bool at_end() const;

--- a/xapian-core/matcher/mergepostlist.cc
+++ b/xapian-core/matcher/mergepostlist.cc
@@ -238,6 +238,15 @@ MergePostList::get_unique_terms() const
     RETURN(plists[current]->get_unique_terms());
 }
 
+
+Xapian::termcount
+MergePostList::get_wdfdocmax() const
+{
+    LOGCALL(MATCH, Xapian::termcount, "MergePostList::get_wdfdocmax", NO_ARGS);
+    Assert(current != -1);
+    RETURN(plists[current]->get_wdfdocmax());
+}
+
 Xapian::termcount
 MergePostList::count_matching_subqs() const
 {

--- a/xapian-core/matcher/mergepostlist.h
+++ b/xapian-core/matcher/mergepostlist.h
@@ -89,6 +89,9 @@ class MergePostList : public PostList {
 	/** Return the number of unique terms in the document. */
 	virtual Xapian::termcount get_unique_terms() const;
 
+	/** Return the max WDF in the current document. */
+	virtual Xapian::termcount get_wdfdocmax() const;
+
 	Xapian::termcount count_matching_subqs() const;
 
 	MergePostList(const std::vector<PostList *> & plists_,

--- a/xapian-core/matcher/msetpostlist.cc
+++ b/xapian-core/matcher/msetpostlist.cc
@@ -110,6 +110,12 @@ MSetPostList::get_unique_terms() const
     throw Xapian::UnimplementedError("MSetPostList::get_unique_terms() unimplemented");
 }
 
+Xapian::termcount
+MSetPostList::get_wdfdocmax() const
+{
+   throw Xapian::UnimplementedError("MSetPostList::get_wdfdocmax() unimplemented");
+}
+
 double
 MSetPostList::recalc_maxweight()
 {

--- a/xapian-core/matcher/msetpostlist.h
+++ b/xapian-core/matcher/msetpostlist.h
@@ -77,6 +77,8 @@ class MSetPostList : public PostList {
 
     Xapian::termcount get_unique_terms() const;
 
+    Xapian::termcount get_wdfdocmax() const;
+
     double recalc_maxweight();
 
     PostList *next(double w_min);

--- a/xapian-core/matcher/multiandpostlist.cc
+++ b/xapian-core/matcher/multiandpostlist.cc
@@ -172,6 +172,17 @@ MultiAndPostList::get_unique_terms() const
     return unique_terms;
 }
 
+Xapian::termcount
+MultiAndPostList::get_wdfdocmax() const
+{
+    Assert(did);
+    Xapian::termcount wdfdocmax = plist[0]->get_wdfdocmax();
+    for (size_t i = 1; i < n_kids; ++i) {
+	AssertEq(wdfdocmax, plist[i]->get_wdfdocmax());
+    }
+    return wdfdocmax;
+}
+
 double
 MultiAndPostList::get_weight() const
 {

--- a/xapian-core/matcher/multiandpostlist.h
+++ b/xapian-core/matcher/multiandpostlist.h
@@ -169,6 +169,8 @@ class MultiAndPostList : public PostList {
 
     Xapian::termcount get_unique_terms() const;
 
+    Xapian::termcount get_wdfdocmax() const;
+
     double get_weight() const;
 
     bool at_end() const;

--- a/xapian-core/matcher/multixorpostlist.cc
+++ b/xapian-core/matcher/multixorpostlist.cc
@@ -184,6 +184,26 @@ MultiXorPostList::get_unique_terms() const
     return unique_terms;
 }
 
+Xapian::termcount
+MultiXorPostList::get_wdfdocmax() const
+{
+    Assert(did);
+    Xapian::termcount wdfdocmax = 0;
+    bool wdfdocmax_set = false;
+    for (size_t i = 0; i < n_kids; ++i) {
+	if (plist[i]->get_docid() == did) {
+	    if (wdfdocmax_set) {
+		AssertEq(wdfdocmax, plist[i]->get_wdfdocmax());
+	    } else {
+		wdfdocmax = plist[i]->get_wdfdocmax();
+		wdfdocmax_set = true;
+	    }
+	}
+    }
+    Assert(wdfdocmax_set);
+    return wdfdocmax;
+}
+
 double
 MultiXorPostList::get_weight() const
 {

--- a/xapian-core/matcher/multixorpostlist.h
+++ b/xapian-core/matcher/multixorpostlist.h
@@ -97,6 +97,8 @@ class MultiXorPostList : public PostList {
 
     Xapian::termcount get_unique_terms() const;
 
+    Xapian::termcount get_wdfdocmax() const;
+
     double get_weight() const;
 
     bool at_end() const;

--- a/xapian-core/matcher/orpostlist.cc
+++ b/xapian-core/matcher/orpostlist.cc
@@ -426,6 +426,26 @@ OrPostList::get_unique_terms() const
 }
 
 Xapian::termcount
+OrPostList::get_wdfdocmax() const
+{
+    LOGCALL(MATCH, Xapian::termcount, "OrPostList::get_wdfdocmax", NO_ARGS);
+    Xapian::termcount wdfdocmax;
+
+    Assert(lhead != 0 && rhead != 0); // check we've started
+    if (lhead > rhead) {
+	wdfdocmax = r->get_wdfdocmax();
+	LOGLINE(MATCH, "OrPostList::get_wdfdocmax() [right docid=" << rhead <<
+		       "] = " << wdfdocmax);
+    } else {
+	wdfdocmax = l->get_wdfdocmax();
+	LOGLINE(MATCH, "OrPostList::get_wdfdocmax() [left docid=" << lhead <<
+		       "] = " << wdfdocmax);
+    }
+
+    RETURN(wdfdocmax);
+}
+
+Xapian::termcount
 OrPostList::get_wdf() const
 {
     LOGCALL(MATCH, Xapian::termcount, "OrPostList::get_wdf", NO_ARGS);

--- a/xapian-core/matcher/orpostlist.h
+++ b/xapian-core/matcher/orpostlist.h
@@ -73,6 +73,9 @@ class OrPostList : public BranchPostList {
 	/// Return the number of unique terms in the document.
 	virtual Xapian::termcount get_unique_terms() const;
 
+	/// Return the max WDF in the document.
+	virtual Xapian::termcount get_wdfdocmax() const;
+
         OrPostList(PostList * left_,
 		   PostList * right_,
 		   MultiMatch * matcher_,

--- a/xapian-core/matcher/selectpostlist.h
+++ b/xapian-core/matcher/selectpostlist.h
@@ -63,6 +63,7 @@ class SelectPostList : public PostList {
 	}
 	Xapian::termcount get_doclength() const { return source->get_doclength(); }
 	Xapian::termcount get_unique_terms() const { return source->get_unique_terms(); }
+	Xapian::termcount get_wdfdocmax() const { return source->get_wdfdocmax(); }
 	double recalc_maxweight() { return source->recalc_maxweight(); }
 	PositionList * read_position_list() { return source->read_position_list(); }
 	PositionList * open_position_list() const { return source->open_position_list(); }

--- a/xapian-core/matcher/synonympostlist.cc
+++ b/xapian-core/matcher/synonympostlist.cc
@@ -41,6 +41,7 @@ SynonymPostList::set_weight(const Xapian::Weight * wt_)
     wt = wt_;
     want_doclength = wt->get_sumpart_needs_doclength_();
     want_wdf = wt->get_sumpart_needs_wdf_();
+    want_wdfdocmax = wt->get_sumpart_needs_wdfdocmax_();
 }
 
 PostList *
@@ -80,6 +81,10 @@ SynonymPostList::get_weight() const
     Xapian::termcount unique_terms = 0;
     if (want_unique_terms)
 	unique_terms = get_unique_terms();
+    Xapian::termcount wdfdocmax = 0;
+    if (want_wdfdocmax) {
+	wdfdocmax = get_wdfdocmax();
+    }
     if (want_wdf) {
 	Xapian::termcount wdf = get_wdf();
 	Xapian::termcount doclen = 0;
@@ -87,12 +92,12 @@ SynonymPostList::get_weight() const
 	    doclen = get_doclength();
 	    if (wdf > doclen) wdf = doclen;
 	}
-	double sumpart = wt->get_sumpart(wdf, doclen, unique_terms);
+	double sumpart = wt->get_sumpart(wdf, doclen, unique_terms, wdfdocmax);
 	AssertRel(sumpart, <=, wt->get_maxpart());
 	RETURN(sumpart);
     }
     Xapian::termcount doclen = want_doclength ? get_doclength() : 0;
-    RETURN(wt->get_sumpart(0, doclen, unique_terms));
+    RETURN(wt->get_sumpart(0, doclen, unique_terms, wdfdocmax));
 }
 
 double
@@ -162,6 +167,12 @@ bool
 SynonymPostList::at_end() const {
     LOGCALL(MATCH, bool, "SynonymPostList::at_end", NO_ARGS);
     RETURN(subtree->at_end());
+}
+
+Xapian::termcount
+SynonymPostList::get_wdfdocmax() const {
+    LOGCALL(MATCH, Xapian::termcount, "SynonymPostList::get_wdfdocmax", NO_ARGS);
+    RETURN(subtree->get_wdfdocmax());
 }
 
 Xapian::termcount

--- a/xapian-core/matcher/synonympostlist.h
+++ b/xapian-core/matcher/synonympostlist.h
@@ -58,6 +58,12 @@ class SynonymPostList : public PostList {
      */
     bool want_unique_terms;
 
+    /** Flag indicating whether the weighting object needs the max wdf of
+     *  terms.
+     *  FIXME : Not implemented
+     */
+    bool want_wdfdocmax;
+
     /// Flag indicating if we've called recalc_maxweight on the subtree yet.
     bool have_calculated_subtree_maxweights;
 
@@ -69,7 +75,7 @@ class SynonymPostList : public PostList {
 		    Xapian::termcount doclen_lower_bound_)
 	: subtree(subtree_), matcher(matcher_), wt(NULL),
 	  want_doclength(false), want_wdf(false), want_unique_terms(false),
-	  have_calculated_subtree_maxweights(false),
+	  want_wdfdocmax(false), have_calculated_subtree_maxweights(false),
 	  doclen_lower_bound(doclen_lower_bound_) { }
 
     ~SynonymPostList();
@@ -99,6 +105,7 @@ class SynonymPostList : public PostList {
     Xapian::docid get_docid() const;
     Xapian::termcount get_doclength() const;
     Xapian::termcount get_unique_terms() const;
+    Xapian::termcount get_wdfdocmax() const;
     bool at_end() const;
 
     Xapian::termcount count_matching_subqs() const;

--- a/xapian-core/matcher/valuerangepostlist.cc
+++ b/xapian-core/matcher/valuerangepostlist.cc
@@ -105,6 +105,13 @@ ValueRangePostList::get_unique_terms() const
     return 0;
 }
 
+Xapian::termcount
+ValueRangePostList::get_wdfdocmax() const
+{
+    Assert(db);
+    return 0;
+}
+
 double
 ValueRangePostList::recalc_maxweight()
 {

--- a/xapian-core/matcher/valuerangepostlist.h
+++ b/xapian-core/matcher/valuerangepostlist.h
@@ -73,6 +73,8 @@ class ValueRangePostList : public PostList {
 
     Xapian::termcount get_unique_terms() const;
 
+    Xapian::termcount get_wdfdocmax() const;
+
     double recalc_maxweight();
 
     PositionList * read_position_list();

--- a/xapian-core/tests/api_db.cc
+++ b/xapian-core/tests/api_db.cc
@@ -1793,7 +1793,7 @@ class MyWeight : public Xapian::Weight {
     double get_sumpart(Xapian::termcount, Xapian::termcount) const {
 	return scale_factor;
     }
-    double get_sumpart(Xapian::termcount, Xapian::termcount, Xapian::termcount) const {
+    double get_sumpart(Xapian::termcount, Xapian::termcount, Xapian::termcount, Xapian::termcount) const {
 	return scale_factor;
     }
     double get_maxpart() const { return scale_factor; }

--- a/xapian-core/tests/api_percentages.cc
+++ b/xapian-core/tests/api_percentages.cc
@@ -322,6 +322,7 @@ class ZWeight : public Xapian::Weight {
 
     double get_sumpart(Xapian::termcount,
 		       Xapian::termcount,
+		       Xapian::termcount,
 		       Xapian::termcount) const {
 	return 0.0;
     }

--- a/xapian-core/tests/api_serialise.cc
+++ b/xapian-core/tests/api_serialise.cc
@@ -416,7 +416,7 @@ class ExceptionalWeight : public Xapian::Weight {
     double get_sumpart(Xapian::termcount, Xapian::termcount) const {
 	return 0;
     }
-    double get_sumpart(Xapian::termcount, Xapian::termcount, Xapian::termcount) const {
+    double get_sumpart(Xapian::termcount, Xapian::termcount, Xapian::termcount, Xapian::termcount) const {
 	return 0;
     }
     double get_maxpart() const { return 0; }

--- a/xapian-core/weight/bb2weight.cc
+++ b/xapian-core/weight/bb2weight.cc
@@ -135,7 +135,7 @@ BB2Weight::unserialise(const string & s) const
 
 double
 BB2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		       Xapian::termcount) const
+		       Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
 

--- a/xapian-core/weight/bm25weight.cc
+++ b/xapian-core/weight/bm25weight.cc
@@ -162,7 +162,7 @@ BM25Weight::unserialise(const string & s) const
 
 double
 BM25Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     LOGCALL(WTCALC, double, "BM25Weight::get_sumpart", wdf | len);
     Xapian::doclength normlen = max(len * len_factor, param_min_normlen);

--- a/xapian-core/weight/boolweight.cc
+++ b/xapian-core/weight/boolweight.cc
@@ -59,7 +59,7 @@ BoolWeight::unserialise(const string &) const
 
 double
 BoolWeight::get_sumpart(Xapian::termcount, Xapian::termcount,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/dlhweight.cc
+++ b/xapian-core/weight/dlhweight.cc
@@ -106,7 +106,7 @@ DLHWeight::unserialise(const string &) const
 
 double
 DLHWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		       Xapian::termcount) const
+		       Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
 

--- a/xapian-core/weight/dphweight.cc
+++ b/xapian-core/weight/dphweight.cc
@@ -129,7 +129,7 @@ DPHWeight::unserialise(const string &) const
 
 double
 DPHWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		       Xapian::termcount) const
+		       Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
 

--- a/xapian-core/weight/ifb2weight.cc
+++ b/xapian-core/weight/ifb2weight.cc
@@ -109,7 +109,7 @@ IfB2Weight::unserialise(const string & s) const
 
 double
 IfB2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
     double wdfn = wdf;

--- a/xapian-core/weight/ineb2weight.cc
+++ b/xapian-core/weight/ineb2weight.cc
@@ -108,7 +108,7 @@ IneB2Weight::unserialise(const string & s) const
 
 double
 IneB2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			 Xapian::termcount) const
+			 Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
     double wdfn = wdf;

--- a/xapian-core/weight/inl2weight.cc
+++ b/xapian-core/weight/inl2weight.cc
@@ -106,7 +106,7 @@ InL2Weight::unserialise(const string & s) const
 
 double
 InL2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
     double wdfn = wdf;

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -141,7 +141,7 @@ LMWeight::unserialise(const string & s) const
 
 double
 LMWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		      Xapian::termcount uniqterm) const
+		      Xapian::termcount uniqterm, Xapian::termcount) const
 {
     // Within Document Frequency of the term in document being considered.
     double wdf_double = wdf;

--- a/xapian-core/weight/pl2weight.cc
+++ b/xapian-core/weight/pl2weight.cc
@@ -114,7 +114,7 @@ PL2Weight::unserialise(const string & s) const
 
 double
 PL2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		       Xapian::termcount) const
+		       Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
 

--- a/xapian-core/weight/tradweight.cc
+++ b/xapian-core/weight/tradweight.cc
@@ -142,7 +142,7 @@ TradWeight::unserialise(const string & s) const
 
 double
 TradWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     double wdf_double = wdf;
     return termweight * (wdf_double / (len * len_factor + wdf_double));


### PR DESCRIPTION
- Added code to track the max-wdf for each document. This was achieved by adding functionality to the PostList and Database API to compute max wdf for a document.
- Added an additional test in api_weights to verify results.
- The code builds successfully.
- Code passes all tests.
