### PR TITLE
making ValueIterator::decref() function Inline

### DIFF
--- a/xapian-core/api/valueiterator.cc
+++ b/xapian-core/api/valueiterator.cc
@@ -30,7 +30,7 @@ using namespace std;
 
 namespace Xapian {
 
-void
+inline void
 ValueIterator::decref()
 {
     Assert(internal);


### PR DESCRIPTION
making ValueIterator::decref() inline will probably speed it up a little.