### PR TITLE
Java Iterator implementation: MSetIterator

### DIFF
--- a/xapian-bindings/java/SmokeTest.java
+++ b/xapian-bindings/java/SmokeTest.java
@@ -121,8 +121,20 @@ public class SmokeTest {
 		System.exit(1);
 	    }
 	    Enquire enq = new Enquire(db);
-	    enq.setQuery(new Query(Query.OP_OR, "there", "is"));
+	    enq.setQuery(new Query("dog"));
 	    MSet mset = enq.getMSet(0, 10);
+	    // MSet size is 0
+	    if (mset.size() == 0) {
+		for (MSetIterator.MatchDescriptor descriptor : mset) {
+		    System.err.println("Empty iterator entered invalid section (from MSet java iterator)");
+		    System.exit(1);
+		}
+	    } else {
+		System.err.println("Unexpected mset.size(), should be 0");
+		System.exit(1);
+	    }
+	    enq.setQuery(new Query(Query.OP_OR, "there", "is"));
+	    mset = enq.getMSet(0, 10);
 	    if (mset.size() != 1) {
 		System.err.println("Unexpected mset.size()");
 		System.exit(1);
@@ -131,7 +143,7 @@ public class SmokeTest {
 	    Document m_doc = null;
 	    long m_id;
 	    while(m_itor.hasNext()) {
-		m_id = m_itor.next();
+		m_id = m_itor.next().getDocId();
 		if(m_itor.hasNext()) {
 		    m_doc = mset.getDocument(m_id);
 		}
@@ -140,7 +152,16 @@ public class SmokeTest {
 	    // Only one doc exists in this mset
 	    if(m_doc != null && m_doc.getDocId() != 0) {
 		System.err.println("Unexpected docid");
-		    System.exit(1);
+		System.exit(1);
+	    }
+	    // New iterator, should start from the beginning
+	    int iterations = 0;
+	    for(MSetIterator.MatchDescriptor descriptor : mset) {
+		iterations++;
+	    }
+	    if(iterations != mset.size()) {
+		System.err.println("Unexpected number of iterations (from MSet java iterator)");
+		System.exit(1);
 	    }
 
 	    String term_str = "";

--- a/xapian-bindings/java/docs/examples/SimpleSearch.java
+++ b/xapian-bindings/java/docs/examples/SimpleSearch.java
@@ -52,16 +52,12 @@ public class SimpleSearch {
         Enquire enquire = new Enquire(db);
         enquire.setQuery(query);
         MSet matches = enquire.getMSet(0, 2500);    // get up to 2500 matching documents
-        MSetIterator itr = matches.begin();
 
         System.err.println("Found " + matches.size() + " matching documents using " + query);
-        while (itr.hasNext()) {
-            int percent = itr.getPercent();
-            long docID = itr.next();
-            // TODO:  Make this more like a Java Iterator by returning some
-            // kind of "MatchDescriptor" object
-            Document doc = db.getDocument(docID);
-            System.err.println(percent + "% [" + docID + "] " + doc.getValue(0));
+        for (MSetIterator.MatchDescriptor match : matches) {
+            System.err.println(match.getPercent() + "% "
+				+ "[" + match.getDocId() + "] "
+				+ match.getDocument().getValue(0));
         }
     }
 

--- a/xapian-bindings/java/java.i
+++ b/xapian-bindings/java/java.i
@@ -174,20 +174,68 @@ namespace Xapian {
     bool hasNext() const { return Xapian::iterator_valid(*self); }
 }
 
+%ignore MSetIterator::next();
+%javamethodmodifiers MSetIterator::next_helper() "private"
+
 %extend MSetIterator {
-    Xapian::docid next () {
-	Xapian::docid tmp;
+    void next_helper () {
 	if (Xapian::iterator_valid(*self)) {
-	    tmp = (**self);
 	    ++(*self);
-	} else {
-	    tmp = -1;
 	}
-	return tmp;
     }
 
     bool hasNext() const { return Xapian::iterator_valid(*self); }
 }
+
+%typemap(javaimports) Xapian::MSetIterator "import java.util.Iterator;"
+%typemap(javaimports) Xapian::MSetIterator %{
+import java.util.NoSuchElementException;
+import java.util.Iterator;
+%}
+%typemap(javainterfaces) Xapian::MSetIterator "Iterator<MSetIterator.MatchDescriptor>"
+%typemap(javacode) MSetIterator%{
+    @Override
+    public MatchDescriptor next() {
+        MatchDescriptor descriptor = new MatchDescriptor();
+        if(hasNext()) {
+            nextHelper();
+        } else {
+            throw new NoSuchElementException();
+        }
+        return descriptor;
+    }
+
+    public class MatchDescriptor {
+        private long docId,rank;
+        private int percent;
+        private double weight;
+        private Document document;
+
+        public MatchDescriptor() {
+            MSetIterator thisIterator = MSetIterator.this;
+            this.docId = thisIterator.getDocId();
+            this.rank = thisIterator.getRank();
+            this.percent = thisIterator.getPercent();
+            this.weight = thisIterator.getWeight();
+            this.document = thisIterator.getDocument();
+        }
+
+        public long getDocId() { return docId; }
+        public long getRank() { return rank; }
+        public int getPercent() { return percent; }
+        public double getWeight() { return weight; }
+        public Document getDocument() { return document; }
+    }
+
+%}
+
+%typemap(javaimports) Xapian::MSet "import java.util.Iterator;"
+%typemap(javainterfaces) Xapian::MSet "Iterable<MSetIterator.MatchDescriptor>";
+%typemap(javacode) MSet%{
+    public Iterator<MSetIterator.MatchDescriptor> iterator() {
+        return begin();
+    }
+%}
 
 }
 


### PR DESCRIPTION
Created a class MatchDescriptor as an inner class of MSetIterator. MSetIterator now implements the Iterable<MatchDescriptor> interface and implements the method iterator() to enable the use of MSetIterator in a foreach loop.
