### PR TITLE
Change response feeds to support opensearch 1.1

### DIFF
--- a/xapian-applications/omega/templates/opensearch
+++ b/xapian-applications/omega/templates/opensearch
@@ -1,5 +1,5 @@
-$httpheader{Content-Type,application/xml}<?xml version="1.0"?>
-  <rss version="2.0" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+$httpheader{Content-Type,application/xml}<?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0" xmlns:openSearch="http://a9.com/-/spec/opensearch/1.1/">
     <channel>
       <title>Xapian search results</title>
       <link>$html{$env{SCRIPT_NAME}?DB=$url{$dbname}&P=$url{$query}}</link>


### PR DESCRIPTION
1)Change response feeds to support opensearch 1.1
http://www.opensearch.org/Specifications/OpenSearch/1.1#Examples_of_OpenSearch_responses

RSS-based search results in Omega previously used OpenSearch 1.0.
This patch adds the support for newer OpenSearch 1.1 standard.

The changes 1.0 -> 1.1 mostly include 
1)change of XML Namespaces URI
There are no changes in the tags and attributes used, as those are compatible with OpenSearch 1.1 standard.

Issue:
Currently Omega is using query.html for its search interface.
One possibility can be to add OpenSearch Description document replacing the same(query.html).(Devs have to check if this is feasible or not)
That could be done in separate project since there is some more work involved. 