### PR TITLE
Add new idf normalisations in tf-idf weighting scheme

### DIFF
--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -442,11 +442,13 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      * @li The second character indicates the normalization for the idf.  The
      *     following normalizations are currently supported:
      *
-     *     @li 'n': None   idfn=1
-     *     @li 't': TfIdf  idfn=log(N/Termfreq) where N is the number of
+     *     @li 'n': None    idfn=1
+     *     @li 't': TfIdf   idfn=log(N/Termfreq) where N is the number of
      *         documents in collection and Termfreq is the number of documents
      *         which are indexed by the term t.
-     *     @li 'p': Prob   idfn=log((N-Termfreq)/Termfreq)
+     *     @li 'p': Prob    idfn=log((N-Termfreq)/Termfreq)
+     *     @li 'f': Freq    idfn=1/Termfreq
+     *     @li 's': Squared idfn=log(N/Termfreq)^2
      *
      * @li The third and the final character indicates the normalization for
      *     the document weight.  The following normalizations are currently

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -596,6 +596,22 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     mset_expect_order(mset2, 2, 4);
     TEST_EQUAL_DOUBLE(15 * mset[0].get_weight(), mset2[0].get_weight());
 
+    // check for "nfn" when termfreq != N
+    enquire.set_query(query);
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("nfn"));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8.0 / 2);
+
+    // check for "nsn" when termfreq != N
+    enquire.set_query(query);
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("nsn"));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8.0 * pow(log(6.0 / 2), 2.0));
+
     // Check for "bnn" and for both branches of 'b'.
     enquire.set_query(Xapian::Query("test"));
     enquire.set_weighting_scheme(Xapian::TfIdfWeight("bnn"));

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -38,7 +38,7 @@ TfIdfWeight::TfIdfWeight(const std::string &normals)
 {
     if (normalizations.length() != 3 ||
 	!strchr("nbsl", normalizations[0]) ||
-	!strchr("ntp", normalizations[1]) ||
+	!strchr("ntpfs", normalizations[1]) ||
 	!strchr("n", normalizations[2]))
 	throw Xapian::InvalidArgumentError("Normalization string is invalid");
     if (normalizations[1] != 'n') {
@@ -141,7 +141,7 @@ double
 TfIdfWeight::get_idfn(Xapian::doccount termfreq, char c) const
 {
     double N = 1.0;
-    if (c != 'n') N = get_collection_size();
+    if (c != 'n' && c != 'f') N = get_collection_size();
     switch (c) {
 	case 'n':
 	    return 1.0;
@@ -149,6 +149,10 @@ TfIdfWeight::get_idfn(Xapian::doccount termfreq, char c) const
 	    // All documents are indexed by the term
 	    if (N == termfreq) return 0;
 	    return log((N - termfreq) / termfreq);
+	case 'f':
+	    return (1.0 / termfreq);
+	case 's':
+	    return pow(log(N / termfreq), 2.0);
 	default:
 	    AssertEq(c, 't');
 	    return (log(N / termfreq));


### PR DESCRIPTION
- Add support for freq & squared normalisations.
- Add additional tests for these schemes.
- Modify weight.h to reflect changes in Documentation.