### PR TITLE
Add support for BM25+ weighting function

### DIFF
--- a/xapian-bindings/csharp/Makefile.am
+++ b/xapian-bindings/csharp/Makefile.am
@@ -11,8 +11,8 @@ ASSEMBLY=XapianSharp
 XAPIAN_SWIG_CS_SRCS=\
 	generated-csharp/Auto.cs \
 	generated-csharp/BB2Weight.cs \
-	generated-csharp/BM25Weight.cs \
 	generated-csharp/BM25PlusWeight.cs\
+	generated-csharp/BM25Weight.cs \
 	generated-csharp/BoolWeight.cs \
 	generated-csharp/Chert.cs \
 	generated-csharp/Compactor.cs \

--- a/xapian-bindings/csharp/Makefile.am
+++ b/xapian-bindings/csharp/Makefile.am
@@ -12,6 +12,7 @@ XAPIAN_SWIG_CS_SRCS=\
 	generated-csharp/Auto.cs \
 	generated-csharp/BB2Weight.cs \
 	generated-csharp/BM25Weight.cs \
+	generated-csharp/BM25PlusWeight.cs\
 	generated-csharp/BoolWeight.cs \
 	generated-csharp/Chert.cs \
 	generated-csharp/Compactor.cs \

--- a/xapian-bindings/java/Makefile.am
+++ b/xapian-bindings/java/Makefile.am
@@ -26,8 +26,8 @@ SmokeTest: SmokeTest.class
 XAPIAN_SWIG_JAVA_SRCS=\
 	org/xapian/Auto.java\
 	org/xapian/BB2Weight.java\
-	org/xapian/BM25Weight.java\
 	org/xapian/BM25PlusWeight.java\
+	org/xapian/BM25Weight.java\
 	org/xapian/BoolWeight.java\
 	org/xapian/Chert.java\
 	org/xapian/Compactor.java\

--- a/xapian-bindings/java/Makefile.am
+++ b/xapian-bindings/java/Makefile.am
@@ -27,6 +27,7 @@ XAPIAN_SWIG_JAVA_SRCS=\
 	org/xapian/Auto.java\
 	org/xapian/BB2Weight.java\
 	org/xapian/BM25Weight.java\
+	org/xapian/BM25PlusWeight.java\
 	org/xapian/BoolWeight.java\
 	org/xapian/Chert.java\
 	org/xapian/Compactor.java\

--- a/xapian-bindings/python/doxy2swig.py
+++ b/xapian-bindings/python/doxy2swig.py
@@ -28,6 +28,7 @@ import sys
 import textwrap
 import types
 import os.path
+import io
 
 def my_open_read(source):
     if hasattr(source, "read"):
@@ -39,7 +40,7 @@ def my_open_write(dest):
     if hasattr(dest, "write"):
         return dest
     else:
-        return open(dest, 'w')
+        return io.open(dest, 'w', encoding = 'utf8')
 
 
 class Doxy2SWIG:

--- a/xapian-core/api/registry.cc
+++ b/xapian-core/api/registry.cc
@@ -39,271 +39,273 @@
 using namespace std;
 
 class Xapian::Registry::Internal : public Xapian::Internal::intrusive_base {
-    friend class Xapian::Registry;
+	friend class Xapian::Registry;
 
-    /// Registered weighting schemes.
-    std::map<std::string, Xapian::Weight *> wtschemes;
+	/// Registered weighting schemes.
+	std::map<std::string, Xapian::Weight *> wtschemes;
 
-    /// Registered external posting sources.
-    std::map<std::string, Xapian::PostingSource *> postingsources;
+	/// Registered external posting sources.
+	std::map<std::string, Xapian::PostingSource *> postingsources;
 
-    /// Registered match spies.
-    std::map<std::string, Xapian::MatchSpy *> matchspies;
+	/// Registered match spies.
+	std::map<std::string, Xapian::MatchSpy *> matchspies;
 
-    /// Registered lat-long metrics.
-    std::map<std::string, Xapian::LatLongMetric *> lat_long_metrics;
+	/// Registered lat-long metrics.
+	std::map<std::string, Xapian::LatLongMetric *> lat_long_metrics;
 
-    /// Add the standard subclasses provided in the API.
-    void add_defaults();
+	/// Add the standard subclasses provided in the API.
+	void add_defaults();
 
-    /// Clear all registered weighting schemes.
-    void clear_weighting_schemes();
+	/// Clear all registered weighting schemes.
+	void clear_weighting_schemes();
 
-    /// Clear all registered posting sources.
-    void clear_posting_sources();
+	/// Clear all registered posting sources.
+	void clear_posting_sources();
 
-    /// Clear all registered match spies.
-    void clear_match_spies();
+	/// Clear all registered match spies.
+	void clear_match_spies();
 
-    /// Clear all registered lat-long metrics.
-    void clear_lat_long_metrics();
+	/// Clear all registered lat-long metrics.
+	void clear_lat_long_metrics();
 
   public:
-    Internal();
-    ~Internal();
+	Internal();
+	~Internal();
 };
 
 template<class T>
 static inline void
 register_object(map<string, T*> & registry, const T & obj)
 {
-    string name = obj.name();
-    if (rare(name.empty())) {
-	throw Xapian::InvalidOperationError("Unable to register object - name() method returned empty string");
-    }
+	string name = obj.name();
+	if (rare(name.empty())) {
+		throw Xapian::InvalidOperationError("Unable to register object - name() method returned empty string");
+	}
 
-    pair<typename map<string, T *>::iterator, bool> r;
-    r = registry.insert(make_pair(name, static_cast<T*>(NULL)));
-    if (!r.second) {
-	// Existing element with this key, so replace the pointer with NULL
-	// and delete the existing pointer.
-	//
-	// If the delete throws, this will leave a NULL entry in the map, but
-	// that won't affect behaviour as we return NULL for "not found"
-	// anyway.  The memory used will be leaked if the dtor throws, but
-	// throwing exceptions from the dtor is bad form, so that's not a big
-	// problem.
-	T * p = NULL;
-	swap(p, r.first->second);
-	delete p;
-    }
+	pair<typename map<string, T *>::iterator, bool> r;
+	r = registry.insert(make_pair(name, static_cast<T*>(NULL)));
+	if (!r.second) {
+		// Existing element with this key, so replace the pointer with NULL
+		// and delete the existing pointer.
+		//
+		// If the delete throws, this will leave a NULL entry in the map, but
+		// that won't affect behaviour as we return NULL for "not found"
+		// anyway.  The memory used will be leaked if the dtor throws, but
+		// throwing exceptions from the dtor is bad form, so that's not a big
+		// problem.
+		T * p = NULL;
+		swap(p, r.first->second);
+		delete p;
+	}
 
-    T * clone = obj.clone();
-    if (rare(!clone)) {
-	throw Xapian::InvalidOperationError("Unable to register object - clone() method returned NULL");
-    }
+	T * clone = obj.clone();
+	if (rare(!clone)) {
+		throw Xapian::InvalidOperationError("Unable to register object - clone() method returned NULL");
+	}
 
-    r.first->second = clone;
+	r.first->second = clone;
 }
- 
+
 template<class T>
 static inline const T *
 lookup_object(map<string, T*> registry, const string & name)
 {
-    typename map<string, T*>::const_iterator i = registry.find(name);
-    if (i == registry.end()) {
-	return NULL;
-    }
-    return i->second;
+	typename map<string, T*>::const_iterator i = registry.find(name);
+	if (i == registry.end()) {
+		return NULL;
+	}
+	return i->second;
 }
 
 namespace Xapian {
 
 Registry::Internal::Internal()
 {
-    add_defaults();
+	add_defaults();
 }
 
 Registry::Internal::~Internal()
 {
-    clear_weighting_schemes();
-    clear_posting_sources();
-    clear_match_spies();
-    clear_lat_long_metrics();
+	clear_weighting_schemes();
+	clear_posting_sources();
+	clear_match_spies();
+	clear_lat_long_metrics();
 }
 
 void
 Registry::Internal::add_defaults()
 {
-    Xapian::Weight * weighting_scheme;
-    weighting_scheme = new Xapian::BB2Weight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::BM25Weight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::BoolWeight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::TradWeight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::TfIdfWeight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::InL2Weight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::IfB2Weight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::IneB2Weight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::DLHWeight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::PL2Weight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::DPHWeight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
-    weighting_scheme = new Xapian::LMWeight;
-    wtschemes[weighting_scheme->name()] = weighting_scheme;
+	Xapian::Weight * weighting_scheme;
+	weighting_scheme = new Xapian::BB2Weight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::BM25Weight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::BM25PlusWeight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::BoolWeight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::TradWeight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::TfIdfWeight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::InL2Weight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::IfB2Weight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::IneB2Weight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::DLHWeight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::PL2Weight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::DPHWeight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
+	weighting_scheme = new Xapian::LMWeight;
+	wtschemes[weighting_scheme->name()] = weighting_scheme;
 
-    Xapian::PostingSource * source;
-    source = new Xapian::ValueWeightPostingSource(0);
-    postingsources[source->name()] = source;
-    source = new Xapian::DecreasingValueWeightPostingSource(0);
-    postingsources[source->name()] = source;
-    source = new Xapian::ValueMapPostingSource(0);
-    postingsources[source->name()] = source;
-    source = new Xapian::FixedWeightPostingSource(0.0);
-    postingsources[source->name()] = source;
-    source = new Xapian::LatLongDistancePostingSource(0,
-	Xapian::LatLongCoords(),
-	Xapian::GreatCircleMetric());
-    postingsources[source->name()] = source;
+	Xapian::PostingSource * source;
+	source = new Xapian::ValueWeightPostingSource(0);
+	postingsources[source->name()] = source;
+	source = new Xapian::DecreasingValueWeightPostingSource(0);
+	postingsources[source->name()] = source;
+	source = new Xapian::ValueMapPostingSource(0);
+	postingsources[source->name()] = source;
+	source = new Xapian::FixedWeightPostingSource(0.0);
+	postingsources[source->name()] = source;
+	source = new Xapian::LatLongDistancePostingSource(0,
+		Xapian::LatLongCoords(),
+		Xapian::GreatCircleMetric());
+	postingsources[source->name()] = source;
 
-    Xapian::MatchSpy * spy;
-    spy = new Xapian::ValueCountMatchSpy();
-    matchspies[spy->name()] = spy;
+	Xapian::MatchSpy * spy;
+	spy = new Xapian::ValueCountMatchSpy();
+	matchspies[spy->name()] = spy;
 
-    Xapian::LatLongMetric * metric;
-    metric = new Xapian::GreatCircleMetric();
-    lat_long_metrics[metric->name()] = metric;
+	Xapian::LatLongMetric * metric;
+	metric = new Xapian::GreatCircleMetric();
+	lat_long_metrics[metric->name()] = metric;
 }
 
 void
 Registry::Internal::clear_weighting_schemes()
 {
-    map<string, Xapian::Weight*>::const_iterator i;
-    for (i = wtschemes.begin(); i != wtschemes.end(); ++i) {
-	delete i->second;
-    }
+	map<string, Xapian::Weight*>::const_iterator i;
+	for (i = wtschemes.begin(); i != wtschemes.end(); ++i) {
+		delete i->second;
+	}
 }
 
 void
 Registry::Internal::clear_posting_sources()
 {
-    map<string, Xapian::PostingSource *>::const_iterator i;
-    for (i = postingsources.begin(); i != postingsources.end(); ++i) {
-	delete i->second;
-    }
+	map<string, Xapian::PostingSource *>::const_iterator i;
+	for (i = postingsources.begin(); i != postingsources.end(); ++i) {
+		delete i->second;
+	}
 }
 
 void
 Registry::Internal::clear_match_spies()
 {
-    map<string, Xapian::MatchSpy *>::const_iterator i;
-    for (i = matchspies.begin(); i != matchspies.end(); ++i) {
-	delete i->second;
-    }
+	map<string, Xapian::MatchSpy *>::const_iterator i;
+	for (i = matchspies.begin(); i != matchspies.end(); ++i) {
+		delete i->second;
+	}
 }
 
 void
 Registry::Internal::clear_lat_long_metrics()
 {
-    map<string, Xapian::LatLongMetric *>::const_iterator i;
-    for (i = lat_long_metrics.begin(); i != lat_long_metrics.end(); ++i) {
-	delete i->second;
-    }
+	map<string, Xapian::LatLongMetric *>::const_iterator i;
+	for (i = lat_long_metrics.begin(); i != lat_long_metrics.end(); ++i) {
+		delete i->second;
+	}
 }
 
 Registry::Registry(const Registry & other)
-	: internal(other.internal)
+		: internal(other.internal)
 {
-    LOGCALL_CTOR(API, "Registry", other);
+	LOGCALL_CTOR(API, "Registry", other);
 }
 
 Registry &
 Registry::operator=(const Registry & other)
 {
-    LOGCALL(API, Xapian::Registry &, "Xapian::Registry::operator=", other);
-    internal = other.internal;
-    RETURN(*this);
+	LOGCALL(API, Xapian::Registry &, "Xapian::Registry::operator=", other);
+	internal = other.internal;
+	RETURN(*this);
 }
 
 Registry::Registry()
-	: internal(new Registry::Internal())
+		: internal(new Registry::Internal())
 {
-    LOGCALL_CTOR(API, "Registry", NO_ARGS);
+	LOGCALL_CTOR(API, "Registry", NO_ARGS);
 }
 
 Registry::~Registry()
 {
-    LOGCALL_DTOR(API, "Registry");
+	LOGCALL_DTOR(API, "Registry");
 
-    // Note - we don't need to do anything special in this destructor, but it
-    // does need to be explicitly defined because the definition of the
-    // internals is not visible externally, which results in an error if the
-    // compiler tries to generate a default destructor.
+	// Note - we don't need to do anything special in this destructor, but it
+	// does need to be explicitly defined because the definition of the
+	// internals is not visible externally, which results in an error if the
+	// compiler tries to generate a default destructor.
 }
 
 void
 Registry::register_weighting_scheme(const Xapian::Weight &wt)
 {
-    LOGCALL_VOID(API, "Xapian::Registry::register_weighting_scheme", wt.name());
-    register_object(internal->wtschemes, wt);
+	LOGCALL_VOID(API, "Xapian::Registry::register_weighting_scheme", wt.name());
+	register_object(internal->wtschemes, wt);
 }
 
 const Xapian::Weight *
 Registry::get_weighting_scheme(const string & name) const
 {
-    LOGCALL(API, const Xapian::Weight *, "Xapian::Registry::get_weighting_scheme", name);
-    RETURN(lookup_object(internal->wtschemes, name));
+	LOGCALL(API, const Xapian::Weight *, "Xapian::Registry::get_weighting_scheme", name);
+	RETURN(lookup_object(internal->wtschemes, name));
 }
 
 void
 Registry::register_posting_source(const Xapian::PostingSource &source)
 {
-    LOGCALL_VOID(API, "Xapian::Registry::register_posting_source", source.name());
-    register_object(internal->postingsources, source);
+	LOGCALL_VOID(API, "Xapian::Registry::register_posting_source", source.name());
+	register_object(internal->postingsources, source);
 }
 
 const Xapian::PostingSource *
 Registry::get_posting_source(const string & name) const
 {
-    LOGCALL(API, const Xapian::PostingSource *, "Xapian::Registry::get_posting_source", name);
-    RETURN(lookup_object(internal->postingsources, name));
+	LOGCALL(API, const Xapian::PostingSource *, "Xapian::Registry::get_posting_source", name);
+	RETURN(lookup_object(internal->postingsources, name));
 }
 
 void
 Registry::register_match_spy(const Xapian::MatchSpy &spy)
 {
-    LOGCALL_VOID(API, "Xapian::Registry::register_match_spy", spy.name());
-    register_object(internal->matchspies, spy);
+	LOGCALL_VOID(API, "Xapian::Registry::register_match_spy", spy.name());
+	register_object(internal->matchspies, spy);
 }
 
 const Xapian::MatchSpy *
 Registry::get_match_spy(const string & name) const
 {
-    LOGCALL(API, const Xapian::MatchSpy *, "Xapian::Registry::get_match_spy", name);
-    RETURN(lookup_object(internal->matchspies, name));
+	LOGCALL(API, const Xapian::MatchSpy *, "Xapian::Registry::get_match_spy", name);
+	RETURN(lookup_object(internal->matchspies, name));
 }
 
 void
 Registry::register_lat_long_metric(const Xapian::LatLongMetric &metric)
 {
-    LOGCALL_VOID(API, "Xapian::Registry::register_lat_long_metric", metric.name());
-    register_object(internal->lat_long_metrics, metric);
+	LOGCALL_VOID(API, "Xapian::Registry::register_lat_long_metric", metric.name());
+	register_object(internal->lat_long_metrics, metric);
 }
 
 const Xapian::LatLongMetric *
 Registry::get_lat_long_metric(const string & name) const
 {
-    LOGCALL(API, const Xapian::LatLongMetric *, "Xapian::Registry::get_lat_long_metric", name);
-    RETURN(lookup_object(internal->lat_long_metrics, name));
+	LOGCALL(API, const Xapian::LatLongMetric *, "Xapian::Registry::get_lat_long_metric", name);
+	RETURN(lookup_object(internal->lat_long_metrics, name));
 }
 
 }

--- a/xapian-core/api/registry.cc
+++ b/xapian-core/api/registry.cc
@@ -309,4 +309,3 @@ Registry::get_lat_long_metric(const string & name) const
 }
 
 }
-

--- a/xapian-core/api/registry.cc
+++ b/xapian-core/api/registry.cc
@@ -39,273 +39,274 @@
 using namespace std;
 
 class Xapian::Registry::Internal : public Xapian::Internal::intrusive_base {
-	friend class Xapian::Registry;
+    friend class Xapian::Registry;
 
-	/// Registered weighting schemes.
-	std::map<std::string, Xapian::Weight *> wtschemes;
+    /// Registered weighting schemes.
+    std::map<std::string, Xapian::Weight *> wtschemes;
 
-	/// Registered external posting sources.
-	std::map<std::string, Xapian::PostingSource *> postingsources;
+    /// Registered external posting sources.
+    std::map<std::string, Xapian::PostingSource *> postingsources;
 
-	/// Registered match spies.
-	std::map<std::string, Xapian::MatchSpy *> matchspies;
+    /// Registered match spies.
+    std::map<std::string, Xapian::MatchSpy *> matchspies;
 
-	/// Registered lat-long metrics.
-	std::map<std::string, Xapian::LatLongMetric *> lat_long_metrics;
+    /// Registered lat-long metrics.
+    std::map<std::string, Xapian::LatLongMetric *> lat_long_metrics;
 
-	/// Add the standard subclasses provided in the API.
-	void add_defaults();
+    /// Add the standard subclasses provided in the API.
+    void add_defaults();
 
-	/// Clear all registered weighting schemes.
-	void clear_weighting_schemes();
+    /// Clear all registered weighting schemes.
+    void clear_weighting_schemes();
 
-	/// Clear all registered posting sources.
-	void clear_posting_sources();
+    /// Clear all registered posting sources.
+    void clear_posting_sources();
 
-	/// Clear all registered match spies.
-	void clear_match_spies();
+    /// Clear all registered match spies.
+    void clear_match_spies();
 
-	/// Clear all registered lat-long metrics.
-	void clear_lat_long_metrics();
+    /// Clear all registered lat-long metrics.
+    void clear_lat_long_metrics();
 
   public:
-	Internal();
-	~Internal();
+    Internal();
+    ~Internal();
 };
 
 template<class T>
 static inline void
 register_object(map<string, T*> & registry, const T & obj)
 {
-	string name = obj.name();
-	if (rare(name.empty())) {
-		throw Xapian::InvalidOperationError("Unable to register object - name() method returned empty string");
-	}
+    string name = obj.name();
+    if (rare(name.empty())) {
+	throw Xapian::InvalidOperationError("Unable to register object - name() method returned empty string");
+    }
 
-	pair<typename map<string, T *>::iterator, bool> r;
-	r = registry.insert(make_pair(name, static_cast<T*>(NULL)));
-	if (!r.second) {
-		// Existing element with this key, so replace the pointer with NULL
-		// and delete the existing pointer.
-		//
-		// If the delete throws, this will leave a NULL entry in the map, but
-		// that won't affect behaviour as we return NULL for "not found"
-		// anyway.  The memory used will be leaked if the dtor throws, but
-		// throwing exceptions from the dtor is bad form, so that's not a big
-		// problem.
-		T * p = NULL;
-		swap(p, r.first->second);
-		delete p;
-	}
+    pair<typename map<string, T *>::iterator, bool> r;
+    r = registry.insert(make_pair(name, static_cast<T*>(NULL)));
+    if (!r.second) {
+	// Existing element with this key, so replace the pointer with NULL
+	// and delete the existing pointer.
+	//
+	// If the delete throws, this will leave a NULL entry in the map, but
+	// that won't affect behaviour as we return NULL for "not found"
+	// anyway.  The memory used will be leaked if the dtor throws, but
+	// throwing exceptions from the dtor is bad form, so that's not a big
+	// problem.
+	T * p = NULL;
+	swap(p, r.first->second);
+	delete p;
+    }
 
-	T * clone = obj.clone();
-	if (rare(!clone)) {
-		throw Xapian::InvalidOperationError("Unable to register object - clone() method returned NULL");
-	}
+    T * clone = obj.clone();
+    if (rare(!clone)) {
+	throw Xapian::InvalidOperationError("Unable to register object - clone() method returned NULL");
+    }
 
-	r.first->second = clone;
+    r.first->second = clone;
 }
 
 template<class T>
 static inline const T *
 lookup_object(map<string, T*> registry, const string & name)
 {
-	typename map<string, T*>::const_iterator i = registry.find(name);
-	if (i == registry.end()) {
-		return NULL;
-	}
-	return i->second;
+    typename map<string, T*>::const_iterator i = registry.find(name);
+    if (i == registry.end()) {
+	return NULL;
+    }
+    return i->second;
 }
 
 namespace Xapian {
 
 Registry::Internal::Internal()
 {
-	add_defaults();
+    add_defaults();
 }
 
 Registry::Internal::~Internal()
 {
-	clear_weighting_schemes();
-	clear_posting_sources();
-	clear_match_spies();
-	clear_lat_long_metrics();
+    clear_weighting_schemes();
+    clear_posting_sources();
+    clear_match_spies();
+    clear_lat_long_metrics();
 }
 
 void
 Registry::Internal::add_defaults()
 {
-	Xapian::Weight * weighting_scheme;
-	weighting_scheme = new Xapian::BB2Weight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::BM25Weight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::BM25PlusWeight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::BoolWeight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::TradWeight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::TfIdfWeight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::InL2Weight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::IfB2Weight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::IneB2Weight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::DLHWeight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::PL2Weight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::DPHWeight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
-	weighting_scheme = new Xapian::LMWeight;
-	wtschemes[weighting_scheme->name()] = weighting_scheme;
+    Xapian::Weight * weighting_scheme;
+    weighting_scheme = new Xapian::BB2Weight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::BM25Weight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::BM25PlusWeight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::BoolWeight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::TradWeight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::TfIdfWeight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::InL2Weight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::IfB2Weight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::IneB2Weight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::DLHWeight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::PL2Weight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::DPHWeight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
+    weighting_scheme = new Xapian::LMWeight;
+    wtschemes[weighting_scheme->name()] = weighting_scheme;
 
-	Xapian::PostingSource * source;
-	source = new Xapian::ValueWeightPostingSource(0);
-	postingsources[source->name()] = source;
-	source = new Xapian::DecreasingValueWeightPostingSource(0);
-	postingsources[source->name()] = source;
-	source = new Xapian::ValueMapPostingSource(0);
-	postingsources[source->name()] = source;
-	source = new Xapian::FixedWeightPostingSource(0.0);
-	postingsources[source->name()] = source;
-	source = new Xapian::LatLongDistancePostingSource(0,
-		Xapian::LatLongCoords(),
-		Xapian::GreatCircleMetric());
-	postingsources[source->name()] = source;
+    Xapian::PostingSource * source;
+    source = new Xapian::ValueWeightPostingSource(0);
+    postingsources[source->name()] = source;
+    source = new Xapian::DecreasingValueWeightPostingSource(0);
+    postingsources[source->name()] = source;
+    source = new Xapian::ValueMapPostingSource(0);
+    postingsources[source->name()] = source;
+    source = new Xapian::FixedWeightPostingSource(0.0);
+    postingsources[source->name()] = source;
+    source = new Xapian::LatLongDistancePostingSource(0,
+	Xapian::LatLongCoords(),
+	Xapian::GreatCircleMetric());
+    postingsources[source->name()] = source;
 
-	Xapian::MatchSpy * spy;
-	spy = new Xapian::ValueCountMatchSpy();
-	matchspies[spy->name()] = spy;
+    Xapian::MatchSpy * spy;
+    spy = new Xapian::ValueCountMatchSpy();
+    matchspies[spy->name()] = spy;
 
-	Xapian::LatLongMetric * metric;
-	metric = new Xapian::GreatCircleMetric();
-	lat_long_metrics[metric->name()] = metric;
+    Xapian::LatLongMetric * metric;
+    metric = new Xapian::GreatCircleMetric();
+    lat_long_metrics[metric->name()] = metric;
 }
 
 void
 Registry::Internal::clear_weighting_schemes()
 {
-	map<string, Xapian::Weight*>::const_iterator i;
-	for (i = wtschemes.begin(); i != wtschemes.end(); ++i) {
-		delete i->second;
-	}
+    map<string, Xapian::Weight*>::const_iterator i;
+    for (i = wtschemes.begin(); i != wtschemes.end(); ++i) {
+	delete i->second;
+    }
 }
 
 void
 Registry::Internal::clear_posting_sources()
 {
-	map<string, Xapian::PostingSource *>::const_iterator i;
-	for (i = postingsources.begin(); i != postingsources.end(); ++i) {
-		delete i->second;
-	}
+    map<string, Xapian::PostingSource *>::const_iterator i;
+    for (i = postingsources.begin(); i != postingsources.end(); ++i) {
+	delete i->second;
+    }
 }
 
 void
 Registry::Internal::clear_match_spies()
 {
-	map<string, Xapian::MatchSpy *>::const_iterator i;
-	for (i = matchspies.begin(); i != matchspies.end(); ++i) {
-		delete i->second;
-	}
+    map<string, Xapian::MatchSpy *>::const_iterator i;
+    for (i = matchspies.begin(); i != matchspies.end(); ++i) {
+	delete i->second;
+    }
 }
 
 void
 Registry::Internal::clear_lat_long_metrics()
 {
-	map<string, Xapian::LatLongMetric *>::const_iterator i;
-	for (i = lat_long_metrics.begin(); i != lat_long_metrics.end(); ++i) {
-		delete i->second;
-	}
+    map<string, Xapian::LatLongMetric *>::const_iterator i;
+    for (i = lat_long_metrics.begin(); i != lat_long_metrics.end(); ++i) {
+	delete i->second;
+    }
 }
 
 Registry::Registry(const Registry & other)
-		: internal(other.internal)
+	: internal(other.internal)
 {
-	LOGCALL_CTOR(API, "Registry", other);
+    LOGCALL_CTOR(API, "Registry", other);
 }
 
 Registry &
 Registry::operator=(const Registry & other)
 {
-	LOGCALL(API, Xapian::Registry &, "Xapian::Registry::operator=", other);
-	internal = other.internal;
-	RETURN(*this);
+    LOGCALL(API, Xapian::Registry &, "Xapian::Registry::operator=", other);
+    internal = other.internal;
+    RETURN(*this);
 }
 
 Registry::Registry()
-		: internal(new Registry::Internal())
+	: internal(new Registry::Internal())
 {
-	LOGCALL_CTOR(API, "Registry", NO_ARGS);
+    LOGCALL_CTOR(API, "Registry", NO_ARGS);
 }
 
 Registry::~Registry()
 {
-	LOGCALL_DTOR(API, "Registry");
+    LOGCALL_DTOR(API, "Registry");
 
-	// Note - we don't need to do anything special in this destructor, but it
-	// does need to be explicitly defined because the definition of the
-	// internals is not visible externally, which results in an error if the
-	// compiler tries to generate a default destructor.
+    // Note - we don't need to do anything special in this destructor, but it
+    // does need to be explicitly defined because the definition of the
+    // internals is not visible externally, which results in an error if the
+    // compiler tries to generate a default destructor.
 }
 
 void
 Registry::register_weighting_scheme(const Xapian::Weight &wt)
 {
-	LOGCALL_VOID(API, "Xapian::Registry::register_weighting_scheme", wt.name());
-	register_object(internal->wtschemes, wt);
+    LOGCALL_VOID(API, "Xapian::Registry::register_weighting_scheme", wt.name());
+    register_object(internal->wtschemes, wt);
 }
 
 const Xapian::Weight *
 Registry::get_weighting_scheme(const string & name) const
 {
-	LOGCALL(API, const Xapian::Weight *, "Xapian::Registry::get_weighting_scheme", name);
-	RETURN(lookup_object(internal->wtschemes, name));
+    LOGCALL(API, const Xapian::Weight *, "Xapian::Registry::get_weighting_scheme", name);
+    RETURN(lookup_object(internal->wtschemes, name));
 }
 
 void
 Registry::register_posting_source(const Xapian::PostingSource &source)
 {
-	LOGCALL_VOID(API, "Xapian::Registry::register_posting_source", source.name());
-	register_object(internal->postingsources, source);
+    LOGCALL_VOID(API, "Xapian::Registry::register_posting_source", source.name());
+    register_object(internal->postingsources, source);
 }
 
 const Xapian::PostingSource *
 Registry::get_posting_source(const string & name) const
 {
-	LOGCALL(API, const Xapian::PostingSource *, "Xapian::Registry::get_posting_source", name);
-	RETURN(lookup_object(internal->postingsources, name));
+    LOGCALL(API, const Xapian::PostingSource *, "Xapian::Registry::get_posting_source", name);
+    RETURN(lookup_object(internal->postingsources, name));
 }
 
 void
 Registry::register_match_spy(const Xapian::MatchSpy &spy)
 {
-	LOGCALL_VOID(API, "Xapian::Registry::register_match_spy", spy.name());
-	register_object(internal->matchspies, spy);
+    LOGCALL_VOID(API, "Xapian::Registry::register_match_spy", spy.name());
+    register_object(internal->matchspies, spy);
 }
 
 const Xapian::MatchSpy *
 Registry::get_match_spy(const string & name) const
 {
-	LOGCALL(API, const Xapian::MatchSpy *, "Xapian::Registry::get_match_spy", name);
-	RETURN(lookup_object(internal->matchspies, name));
+    LOGCALL(API, const Xapian::MatchSpy *, "Xapian::Registry::get_match_spy", name);
+    RETURN(lookup_object(internal->matchspies, name));
 }
 
 void
 Registry::register_lat_long_metric(const Xapian::LatLongMetric &metric)
 {
-	LOGCALL_VOID(API, "Xapian::Registry::register_lat_long_metric", metric.name());
-	register_object(internal->lat_long_metrics, metric);
+    LOGCALL_VOID(API, "Xapian::Registry::register_lat_long_metric", metric.name());
+    register_object(internal->lat_long_metrics, metric);
 }
 
 const Xapian::LatLongMetric *
 Registry::get_lat_long_metric(const string & name) const
 {
-	LOGCALL(API, const Xapian::LatLongMetric *, "Xapian::Registry::get_lat_long_metric", name);
-	RETURN(lookup_object(internal->lat_long_metrics, name));
+    LOGCALL(API, const Xapian::LatLongMetric *, "Xapian::Registry::get_lat_long_metric", name);
+    RETURN(lookup_object(internal->lat_long_metrics, name));
 }
 
 }
+

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -626,6 +626,7 @@ class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
     {
 	if (param_k1 < 0) param_k1 = 0;
 	if (param_k3 < 0) param_k3 = 0;
+	if (param_delta < 0) param_delta = 0;
 	if (param_b < 0) {
 	    param_b = 0;
 	} else if (param_b > 1) {
@@ -643,7 +644,6 @@ class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
 	}
 	if (param_k1 != 0 && param_b != 0) need_stat(DOC_LENGTH);
 	if (param_k3 != 0) need_stat(WQF);
-	if (param_delta < 0) param_delta = 0;
 	if (param_delta != 0) {
 	    need_stat(AVERAGE_LENGTH);
 	    need_stat(DOC_LENGTH);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -33,8 +33,8 @@ namespace Xapian {
 /** Abstract base class for weighting schemes. */
 class XAPIAN_VISIBILITY_DEFAULT Weight {
   protected:
-    /// Stats which the weighting scheme can use (see @a need_stat()).
-    typedef enum {
+	/// Stats which the weighting scheme can use (see @a need_stat()).
+	typedef enum {
 	/// Number of documents in the collection.
 	COLLECTION_SIZE = 1,
 	/// Number of documents in the RSet.
@@ -63,313 +63,313 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
 	COLLECTION_FREQ = 4096,
 	/// Number of unique terms in the current document.
 	UNIQUE_TERMS = 8192
-    } stat_flags;
+	} stat_flags;
 
-    /** Tell Xapian that your subclass will want a particular statistic.
-     *
-     *  Some of the statistics can be costly to fetch or calculate, so
-     *  Xapian needs to know which are actually going to be used.  You
-     *  should call need_stat() from your constructor for each such
-     *  statistic.
-     *
-     * @param flag  The stat_flags value for a required statistic.
-     */
-    void need_stat(stat_flags flag) {
+	/** Tell Xapian that your subclass will want a particular statistic.
+	 *
+	 *  Some of the statistics can be costly to fetch or calculate, so
+	 *  Xapian needs to know which are actually going to be used.  You
+	 *  should call need_stat() from your constructor for each such
+	 *  statistic.
+	 *
+	 * @param flag  The stat_flags value for a required statistic.
+	 */
+	void need_stat(stat_flags flag) {
 	stats_needed = stat_flags(stats_needed | flag);
-    }
+	}
 
-    /** Allow the subclass to perform any initialisation it needs to.
-     *
-     *  @param factor	  Any scaling factor (e.g. from OP_SCALE_WEIGHT).
-     *			  If the Weight object is for the term-independent
-     *			  weight supplied by get_sumextra()/get_maxextra(),
-     *			  then init(0.0) is called (starting from Xapian
-     *			  1.2.11 and 1.3.1 - earlier versions failed to
-     *			  call init() for such Weight objects).
-     */
-    virtual void init(double factor) = 0;
+	/** Allow the subclass to perform any initialisation it needs to.
+	 *
+	 *  @param factor	 Any scaling factor (e.g. from OP_SCALE_WEIGHT).
+	 *			If the Weight object is for the term-independent
+	 *			weight supplied by get_sumextra()/get_maxextra(),
+	 *			then init(0.0) is called (starting from Xapian
+	 *			1.2.11 and 1.3.1 - earlier versions failed to
+	 *			call init() for such Weight objects).
+	 */
+	virtual void init(double factor) = 0;
 
   private:
-    /// Don't allow assignment.
-    void operator=(const Weight &);
+	/// Don't allow assignment.
+	void operator=(const Weight &);
 
-    /// A bitmask of the statistics this weighting scheme needs.
-    stat_flags stats_needed;
+	/// A bitmask of the statistics this weighting scheme needs.
+	stat_flags stats_needed;
 
-    /// The number of documents in the collection.
-    Xapian::doccount collection_size_;
+	/// The number of documents in the collection.
+	Xapian::doccount collection_size_;
 
-    /// The number of documents marked as relevant.
-    Xapian::doccount rset_size_;
+	/// The number of documents marked as relevant.
+	Xapian::doccount rset_size_;
 
-    /// The average length of a document in the collection.
-    Xapian::doclength average_length_;
+	/// The average length of a document in the collection.
+	Xapian::doclength average_length_;
 
-    /// The number of documents which this term indexes.
-    Xapian::doccount termfreq_;
+	/// The number of documents which this term indexes.
+	Xapian::doccount termfreq_;
 
-    // The collection frequency of the term.
-    Xapian::termcount collectionfreq_;
+	// The collection frequency of the term.
+	Xapian::termcount collectionfreq_;
 
-    /// The number of relevant documents which this term indexes.
-    Xapian::doccount reltermfreq_;
+	/// The number of relevant documents which this term indexes.
+	Xapian::doccount reltermfreq_;
 
-    /// The length of the query.
-    Xapian::termcount query_length_;
+	/// The length of the query.
+	Xapian::termcount query_length_;
 
-    /// The within-query-frequency of this term.
-    Xapian::termcount wqf_;
+	/// The within-query-frequency of this term.
+	Xapian::termcount wqf_;
 
-    /// A lower bound on the minimum length of any document in the database.
-    Xapian::termcount doclength_lower_bound_;
+	/// A lower bound on the minimum length of any document in the database.
+	Xapian::termcount doclength_lower_bound_;
 
-    /// An upper bound on the maximum length of any document in the database.
-    Xapian::termcount doclength_upper_bound_;
+	/// An upper bound on the maximum length of any document in the database.
+	Xapian::termcount doclength_upper_bound_;
 
-    /// An upper bound on the wdf of this term.
-    Xapian::termcount wdf_upper_bound_;
+	/// An upper bound on the wdf of this term.
+	Xapian::termcount wdf_upper_bound_;
 
   public:
 
-    /// Default constructor, needed by subclass constructors.
-    Weight() : stats_needed() { }
+	/// Default constructor, needed by subclass constructors.
+	Weight() : stats_needed() { }
 
-    /** Type of smoothing to use with the Language Model Weighting scheme.
-     *
-     *  Default is TWO_STAGE_SMOOTHING.
-     */
-    typedef enum {
+	/** Type of smoothing to use with the Language Model Weighting scheme.
+	 *
+	 *  Default is TWO_STAGE_SMOOTHING.
+	 */
+	typedef enum {
 	TWO_STAGE_SMOOTHING = 1,
 	DIRICHLET_SMOOTHING = 2,
 	ABSOLUTE_DISCOUNT_SMOOTHING = 3,
 	JELINEK_MERCER_SMOOTHING = 4
-    } type_smoothing;
+	} type_smoothing;
 
-    class Internal;
+	class Internal;
 
-    /** Virtual destructor, because we have virtual methods. */
-    virtual ~Weight();
+	/** Virtual destructor, because we have virtual methods. */
+	virtual ~Weight();
 
-    /** Clone this object.
-     *
-     *  This method allocates and returns a copy of the object it is called on.
-     *
-     *  If your subclass is called FooWeight and has parameters a and b, then
-     *  you would implement FooWeight::clone() like so:
-     *
-     *  FooWeight * FooWeight::clone() const { return new FooWeight(a, b); }
-     *
-     *  Note that the returned object will be deallocated by Xapian after use
-     *  with "delete".  If you want to handle the deletion in a special way
-     *  (for example when wrapping the Xapian API for use from another
-     *  language) then you can define a static <code>operator delete</code>
-     *  method in your subclass as shown here:
-     *  https://trac.xapian.org/ticket/554#comment:1
-     */
-    virtual Weight * clone() const = 0;
+	/** Clone this object.
+	 *
+	 *  This method allocates and returns a copy of the object it is called on.
+	 *
+	 *  If your subclass is called FooWeight and has parameters a and b, then
+	 *  you would implement FooWeight::clone() like so:
+	 *
+	 *  FooWeight * FooWeight::clone() const { return new FooWeight(a, b); }
+	 *
+	 *  Note that the returned object will be deallocated by Xapian after use
+	 *  with "delete".  If you want to handle the deletion in a special way
+	 *  (for example when wrapping the Xapian API for use from another
+	 *  language) then you can define a static <code>operator delete</code>
+	 *  method in your subclass as shown here:
+	 *  https://trac.xapian.org/ticket/554#comment:1
+	 */
+	virtual Weight * clone() const = 0;
 
-    /** Return the name of this weighting scheme.
-     *
-     *  This name is used by the remote backend.  It is passed along with the
-     *  serialised parameters to the remote server so that it knows which class
-     *  to create.
-     *
-     *  Return the full namespace-qualified name of your class here - if
-     *  your class is called FooWeight, return "FooWeight" from this method
-     *  (Xapian::BM25Weight returns "Xapian::BM25Weight" here).
-     *
-     *  If you don't want to support the remote backend, you can use the
-     *  default implementation which simply returns an empty string.
-     */
-    virtual std::string name() const;
+	/** Return the name of this weighting scheme.
+	 *
+	 *  This name is used by the remote backend.  It is passed along with the
+	 *  serialised parameters to the remote server so that it knows which class
+	 *  to create.
+	 *
+	 *  Return the full namespace-qualified name of your class here - if
+	 *  your class is called FooWeight, return "FooWeight" from this method
+	 *  (Xapian::BM25Weight returns "Xapian::BM25Weight" here).
+	 *
+	 *  If you don't want to support the remote backend, you can use the
+	 *  default implementation which simply returns an empty string.
+	 */
+	virtual std::string name() const;
 
-    /** Return this object's parameters serialised as a single string.
-     *
-     *  If you don't want to support the remote backend, you can use the
-     *  default implementation which simply throws Xapian::UnimplementedError.
-     */
-    virtual std::string serialise() const;
+	/** Return this object's parameters serialised as a single string.
+	 *
+	 *  If you don't want to support the remote backend, you can use the
+	 *  default implementation which simply throws Xapian::UnimplementedError.
+	 */
+	virtual std::string serialise() const;
 
-    /** Unserialise parameters.
-     *
-     *  This method unserialises parameters serialised by the @a serialise()
-     *  method and allocates and returns a new object initialised with them.
-     *
-     *  If you don't want to support the remote backend, you can use the
-     *  default implementation which simply throws Xapian::UnimplementedError.
-     *
-     *  Note that the returned object will be deallocated by Xapian after use
-     *  with "delete".  If you want to handle the deletion in a special way
-     *  (for example when wrapping the Xapian API for use from another
-     *  language) then you can define a static <code>operator delete</code>
-     *  method in your subclass as shown here:
-     *  https://trac.xapian.org/ticket/554#comment:1
-     *
-     *  @param serialised	A string containing the serialised parameters.
-     */
-    virtual Weight * unserialise(const std::string & serialised) const;
+	/** Unserialise parameters.
+	 *
+	 *  This method unserialises parameters serialised by the @a serialise()
+	 *  method and allocates and returns a new object initialised with them.
+	 *
+	 *  If you don't want to support the remote backend, you can use the
+	 *  default implementation which simply throws Xapian::UnimplementedError.
+	 *
+	 *  Note that the returned object will be deallocated by Xapian after use
+	 *  with "delete".  If you want to handle the deletion in a special way
+	 *  (for example when wrapping the Xapian API for use from another
+	 *  language) then you can define a static <code>operator delete</code>
+	 *  method in your subclass as shown here:
+	 *  https://trac.xapian.org/ticket/554#comment:1
+	 *
+	 *  @param serialised   A string containing the serialised parameters.
+	 */
+	virtual Weight * unserialise(const std::string & serialised) const;
 
-    /** Calculate the weight contribution for this object's term to a document.
-     *
-     *  The parameters give information about the document which may be used
-     *  in the calculations:
-     *
-     *  @param wdf    The within document frequency of the term in the document.
-     *  @param doclen The document's length (unnormalised).
-     *  @param uniqterms	Number of unique terms in the document (used
-     *				for absolute smoothing).
-     */
-    virtual double get_sumpart(Xapian::termcount wdf,
-			       Xapian::termcount doclen,
-			       Xapian::termcount uniqterms) const = 0;
+	/** Calculate the weight contribution for this object's term to a document.
+	 *
+	 *  The parameters give information about the document which may be used
+	 *  in the calculations:
+	 *
+	 *  @param wdf	The within document frequency of the term in the document.
+	 *  @param doclen The document's length (unnormalised).
+	 *  @param uniqterms	Number of unique terms in the document (used
+	 *			  for absolute smoothing).
+	 */
+	virtual double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const = 0;
 
-    /** Return an upper bound on what get_sumpart() can return for any document.
-     *
-     *  This information is used by the matcher to perform various
-     *  optimisations, so strive to make the bound as tight as possible.
-     */
-    virtual double get_maxpart() const = 0;
+	/** Return an upper bound on what get_sumpart() can return for any document.
+	 *
+	 *  This information is used by the matcher to perform various
+	 *  optimisations, so strive to make the bound as tight as possible.
+	 */
+	virtual double get_maxpart() const = 0;
 
-    /** Calculate the term-independent weight component for a document.
-     *
-     *  The parameter gives information about the document which may be used
-     *  in the calculations:
-     *
-     *  @param doclen The document's length (unnormalised).
-     *  @param uniqterms The number of unique terms in the document.
-     */
-    virtual double get_sumextra(Xapian::termcount doclen,
-				Xapian::termcount uniqterms) const = 0;
+	/** Calculate the term-independent weight component for a document.
+	 *
+	 *  The parameter gives information about the document which may be used
+	 *  in the calculations:
+	 *
+	 *  @param doclen The document's length (unnormalised).
+	 *  @param uniqterms The number of unique terms in the document.
+	 */
+	virtual double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const = 0;
 
-    /** Return an upper bound on what get_sumextra() can return for any
-     *  document.
-     *
-     *  This information is used by the matcher to perform various
-     *  optimisations, so strive to make the bound as tight as possible.
-     */
-    virtual double get_maxextra() const = 0;
+	/** Return an upper bound on what get_sumextra() can return for any
+	 *  document.
+	 *
+	 *  This information is used by the matcher to perform various
+	 *  optimisations, so strive to make the bound as tight as possible.
+	 */
+	virtual double get_maxextra() const = 0;
 
-    /** @private @internal Initialise this object to calculate weights for term
-     *  @a term.
-     *
-     *  @param stats	  Source of statistics.
-     *  @param query_len_ Query length.
-     *  @param term	  The term for the new object.
-     *  @param wqf_	  The within-query-frequency of @a term.
-     *  @param factor	  Any scaling factor (e.g. from OP_SCALE_WEIGHT).
-     */
-    void init_(const Internal & stats, Xapian::termcount query_len_,
-	       const std::string & term, Xapian::termcount wqf_,
-	       double factor);
+	/** @private @internal Initialise this object to calculate weights for term
+	 *  @a term.
+	 *
+	 *  @param stats	  Source of statistics.
+	 *  @param query_len_ Query length.
+	 *  @param term   The term for the new object.
+	 *  @param wqf_   The within-query-frequency of @a term.
+	 *  @param factor	 Any scaling factor (e.g. from OP_SCALE_WEIGHT).
+	 */
+	void init_(const Internal & stats, Xapian::termcount query_len_,
+	   const std::string & term, Xapian::termcount wqf_,
+	   double factor);
 
-    /** @private @internal Initialise this object to calculate weights for a
-     *  synonym.
-     *
-     *  @param stats	   Source of statistics.
-     *  @param query_len_  Query length.
-     *  @param factor	   Any scaling factor (e.g. from OP_SCALE_WEIGHT).
-     *  @param termfreq    The termfreq to use.
-     *  @param reltermfreq The reltermfreq to use.
-     *  @param collection_freq The collection frequency to use.
-     */
-    void init_(const Internal & stats, Xapian::termcount query_len_,
-	       double factor, Xapian::doccount termfreq,
-	       Xapian::doccount reltermfreq, Xapian::termcount collection_freq);
+	/** @private @internal Initialise this object to calculate weights for a
+	 *  synonym.
+	 *
+	 *  @param stats	   Source of statistics.
+	 *  @param query_len_  Query length.
+	 *  @param factor	  Any scaling factor (e.g. from OP_SCALE_WEIGHT).
+	 *  @param termfreq	The termfreq to use.
+	 *  @param reltermfreq The reltermfreq to use.
+	 *  @param collection_freq The collection frequency to use.
+	 */
+	void init_(const Internal & stats, Xapian::termcount query_len_,
+	   double factor, Xapian::doccount termfreq,
+	   Xapian::doccount reltermfreq, Xapian::termcount collection_freq);
 
-    /** @private @internal Initialise this object to calculate the extra weight
-     *  component.
-     *
-     *  @param stats	  Source of statistics.
-     *  @param query_len_ Query length.
-     */
-    void init_(const Internal & stats, Xapian::termcount query_len_);
+	/** @private @internal Initialise this object to calculate the extra weight
+	 *  component.
+	 *
+	 *  @param stats	  Source of statistics.
+	 *  @param query_len_ Query length.
+	 */
+	void init_(const Internal & stats, Xapian::termcount query_len_);
 
-    /** @private @internal Return true if the document length is needed.
-     *
-     *  If this method returns true, then the document length will be fetched
-     *  and passed to @a get_sumpart().  Otherwise 0 may be passed for the
-     *  document length.
-     */
-    bool get_sumpart_needs_doclength_() const {
+	/** @private @internal Return true if the document length is needed.
+	 *
+	 *  If this method returns true, then the document length will be fetched
+	 *  and passed to @a get_sumpart().  Otherwise 0 may be passed for the
+	 *  document length.
+	 */
+	bool get_sumpart_needs_doclength_() const {
 	return stats_needed & DOC_LENGTH;
-    }
+	}
 
-    /** @private @internal Return true if the WDF is needed.
-     *
-     *  If this method returns true, then the WDF will be fetched and passed to
-     *  @a get_sumpart().  Otherwise 0 may be passed for the wdf.
-     */
-    bool get_sumpart_needs_wdf_() const {
+	/** @private @internal Return true if the WDF is needed.
+	 *
+	 *  If this method returns true, then the WDF will be fetched and passed to
+	 *  @a get_sumpart().  Otherwise 0 may be passed for the wdf.
+	 */
+	bool get_sumpart_needs_wdf_() const {
 	return stats_needed & WDF;
-    }
+	}
 
-    /** @private @internal Return true if the number of unique terms is needed.
-     *
-     *  If this method returns true, then the number of unique terms will be
-     *  fetched and passed to @a get_sumpart().  Otherwise 0 may be passed for
-     *  the number of unique terms.
-     */
-    bool get_sumpart_needs_uniqueterms_() const {
+	/** @private @internal Return true if the number of unique terms is needed.
+	 *
+	 *  If this method returns true, then the number of unique terms will be
+	 *  fetched and passed to @a get_sumpart().  Otherwise 0 may be passed for
+	 *  the number of unique terms.
+	 */
+	bool get_sumpart_needs_uniqueterms_() const {
 	return stats_needed & UNIQUE_TERMS;
-    }
+	}
 
   protected:
-    /** Don't allow copying.
-     *
-     *  This would ideally be private, but that causes a compilation error
-     *  with GCC 4.1 (which appears to be a bug).
-     */
-    Weight(const Weight &);
+	/** Don't allow copying.
+	 *
+	 *  This would ideally be private, but that causes a compilation error
+	 *  with GCC 4.1 (which appears to be a bug).
+	 */
+	Weight(const Weight &);
 
-    /// The number of documents in the collection.
-    Xapian::doccount get_collection_size() const { return collection_size_; }
+	/// The number of documents in the collection.
+	Xapian::doccount get_collection_size() const { return collection_size_; }
 
-    /// The number of documents marked as relevant.
-    Xapian::doccount get_rset_size() const { return rset_size_; }
+	/// The number of documents marked as relevant.
+	Xapian::doccount get_rset_size() const { return rset_size_; }
 
-    /// The average length of a document in the collection.
-    Xapian::doclength get_average_length() const { return average_length_; }
+	/// The average length of a document in the collection.
+	Xapian::doclength get_average_length() const { return average_length_; }
 
-    /// The number of documents which this term indexes.
-    Xapian::doccount get_termfreq() const { return termfreq_; }
+	/// The number of documents which this term indexes.
+	Xapian::doccount get_termfreq() const { return termfreq_; }
 
-    /// The number of relevant documents which this term indexes.
-    Xapian::doccount get_reltermfreq() const { return reltermfreq_; }
+	/// The number of relevant documents which this term indexes.
+	Xapian::doccount get_reltermfreq() const { return reltermfreq_; }
 
-    // The collection frequency of the term.
-    Xapian::termcount get_collection_freq() const { return collectionfreq_; }
+	// The collection frequency of the term.
+	Xapian::termcount get_collection_freq() const { return collectionfreq_; }
 
-    /// The length of the query.
-    Xapian::termcount get_query_length() const { return query_length_; }
+	/// The length of the query.
+	Xapian::termcount get_query_length() const { return query_length_; }
 
-    /// The within-query-frequency of this term.
-    Xapian::termcount get_wqf() const { return wqf_; }
+	/// The within-query-frequency of this term.
+	Xapian::termcount get_wqf() const { return wqf_; }
 
-    /** An upper bound on the maximum length of any document in the database.
-     *
-     *  This should only be used by get_maxpart() and get_maxextra().
-     */
-    Xapian::termcount get_doclength_upper_bound() const {
+	/** An upper bound on the maximum length of any document in the database.
+	 *
+	 *  This should only be used by get_maxpart() and get_maxextra().
+	 */
+	Xapian::termcount get_doclength_upper_bound() const {
 	return doclength_upper_bound_;
-    }
+	}
 
-    /** A lower bound on the minimum length of any document in the database.
-     *
-     *  This bound does not include any zero-length documents.
-     *
-     *  This should only be used by get_maxpart() and get_maxextra().
-     */
-    Xapian::termcount get_doclength_lower_bound() const {
+	/** A lower bound on the minimum length of any document in the database.
+	 *
+	 *  This bound does not include any zero-length documents.
+	 *
+	 *  This should only be used by get_maxpart() and get_maxextra().
+	 */
+	Xapian::termcount get_doclength_lower_bound() const {
 	return doclength_lower_bound_;
-    }
+	}
 
-    /** An upper bound on the wdf of this term.
-     *
-     *  This should only be used by get_maxpart() and get_maxextra().
-     */
-    Xapian::termcount get_wdf_upper_bound() const {
+	/** An upper bound on the wdf of this term.
+	 *
+	 *  This should only be used by get_maxpart() and get_maxextra().
+	 */
+	Xapian::termcount get_wdf_upper_bound() const {
 	return wdf_upper_bound_;
-    }
+	}
 };
 
 /** Class implementing a "boolean" weighting scheme.
@@ -377,172 +377,172 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
  *  This weighting scheme gives all documents zero weight.
  */
 class XAPIAN_VISIBILITY_DEFAULT BoolWeight : public Weight {
-    BoolWeight * clone() const;
+	BoolWeight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct a BoolWeight. */
-    BoolWeight() { }
+	/** Construct a BoolWeight. */
+	BoolWeight() { }
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    BoolWeight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	BoolWeight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 /// Xapian::Weight subclass implementing the tf-idf weighting scheme.
 class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
-    /* Three character string indicating the normalizations for tf(wdf), idf and
-       tfidf weight. */
-    std::string normalizations;
+	/* Three character string indicating the normalizations for tf(wdf), idf and
+	   tfidf weight. */
+	std::string normalizations;
 
-    /// The factor to multiply with the weight.
-    double factor;
+	/// The factor to multiply with the weight.
+	double factor;
 
-    TfIdfWeight * clone() const;
+	TfIdfWeight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
-    /* When additional normalizations are implemented in the future, the additional statistics for them
-       should be accessed by these functions. */
-    double get_wdfn(Xapian::termcount wdf, char c) const;
-    double get_idfn(Xapian::doccount termfreq, char c) const;
-    double get_wtn(double wt, char c) const;
+	/* When additional normalizations are implemented in the future, the additional statistics for them
+	   should be accessed by these functions. */
+	double get_wdfn(Xapian::termcount wdf, char c) const;
+	double get_idfn(Xapian::doccount termfreq, char c) const;
+	double get_wtn(double wt, char c) const;
 
   public:
-    /** Construct a TfIdfWeight
-     *
-     *  @param normalizations	A three character string indicating the
-     *				normalizations to be used for the tf(wdf), idf
-     *				and document weight.  (default: "ntn")
-     *
-     * The @a normalizations string works like so:
-     *
-     * @li The first character specifies the normalization for the wdf.  The
-     *     following normalizations are currently supported:
-     *
-     *     @li 'n': None.      wdfn=wdf
-     *     @li 'b': Boolean    wdfn=1 if term in document else wdfn=0
-     *     @li 's': Square     wdfn=wdf*wdf
-     *     @li 'l': Logarithmic wdfn=1+log<sub>e</sub>(wdf)
-     *
-     *     The Max-wdf and Augmented Max wdf normalizations haven't yet been
-     *     implemented.
-     *
-     * @li The second character indicates the normalization for the idf.  The
-     *     following normalizations are currently supported:
-     *
-     *     @li 'n': None    idfn=1
-     *     @li 't': TfIdf   idfn=log(N/Termfreq) where N is the number of
-     *         documents in collection and Termfreq is the number of documents
-     *         which are indexed by the term t.
-     *     @li 'p': Prob    idfn=log((N-Termfreq)/Termfreq)
-     *     @li 'f': Freq    idfn=1/Termfreq
-     *     @li 's': Squared idfn=log(N/Termfreq)^2
-     *
-     * @li The third and the final character indicates the normalization for
-     *     the document weight.  The following normalizations are currently
-     *     supported:
-     *
-     *     @li 'n': None wtn=tfn*idfn
-     *
-     * Implementing support for more normalizations of each type would require
-     * extending the backend to track more statistics.
-     */
-    explicit TfIdfWeight(const std::string &normalizations);
+	/** Construct a TfIdfWeight
+	 *
+	 *  @param normalizations   A three character string indicating the
+	 *			  normalizations to be used for the tf(wdf), idf
+	 *			  and document weight.  (default: "ntn")
+	 *
+	 * The @a normalizations string works like so:
+	 *
+	 * @li The first character specifies the normalization for the wdf.  The
+	 *	 following normalizations are currently supported:
+	 *
+	 *	 @li 'n': None.	  wdfn=wdf
+	 *	 @li 'b': Boolean	wdfn=1 if term in document else wdfn=0
+	 *	 @li 's': Square	 wdfn=wdf*wdf
+	 *	 @li 'l': Logarithmic wdfn=1+log<sub>e</sub>(wdf)
+	 *
+	 *	 The Max-wdf and Augmented Max wdf normalizations haven't yet been
+	 *	 implemented.
+	 *
+	 * @li The second character indicates the normalization for the idf.  The
+	 *	 following normalizations are currently supported:
+	 *
+	 *	 @li 'n': None	idfn=1
+	 *	 @li 't': TfIdf   idfn=log(N/Termfreq) where N is the number of
+	 *		 documents in collection and Termfreq is the number of documents
+	 *		 which are indexed by the term t.
+	 *	 @li 'p': Prob	idfn=log((N-Termfreq)/Termfreq)
+	 *	 @li 'f': Freq	idfn=1/Termfreq
+	 *	 @li 's': Squared idfn=log(N/Termfreq)^2
+	 *
+	 * @li The third and the final character indicates the normalization for
+	 *	 the document weight.  The following normalizations are currently
+	 *	 supported:
+	 *
+	 *	 @li 'n': None wtn=tfn*idfn
+	 *
+	 * Implementing support for more normalizations of each type would require
+	 * extending the backend to track more statistics.
+	 */
+	explicit TfIdfWeight(const std::string &normalizations);
 
-    TfIdfWeight()
-    : normalizations("ntn")
-    {
+	TfIdfWeight()
+	: normalizations("ntn")
+	{
 	need_stat(TERMFREQ);
 	need_stat(WDF);
 	need_stat(WDF_MAX);
 	need_stat(COLLECTION_SIZE);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    TfIdfWeight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	TfIdfWeight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterm) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 
 /// Xapian::Weight subclass implementing the BM25 probabilistic formula.
 class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
-    /// Factor to multiply the document length by.
-    mutable Xapian::doclength len_factor;
+	/// Factor to multiply the document length by.
+	mutable Xapian::doclength len_factor;
 
-    /// Factor combining all the document independent factors.
-    mutable double termweight;
+	/// Factor combining all the document independent factors.
+	mutable double termweight;
 
-    /// The BM25 parameters.
-    double param_k1, param_k2, param_k3, param_b;
+	/// The BM25 parameters.
+	double param_k1, param_k2, param_k3, param_b;
 
-    /// The minimum normalised document length value.
-    Xapian::doclength param_min_normlen;
+	/// The minimum normalised document length value.
+	Xapian::doclength param_min_normlen;
 
-    BM25Weight * clone() const;
+	BM25Weight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct a BM25Weight.
-     *
-     *  @param k1  A non-negative parameter controlling how influential
-     *		   within-document-frequency (wdf) is.  k1=0 means that
-     *		   wdf doesn't affect the weights.  The larger k1 is, the more
-     *		   wdf influences the weights.  (default 1)
-     *
-     *  @param k2  A non-negative parameter which controls the strength of a
-     *		   correction factor which depends upon query length and
-     *		   normalised document length.  k2=0 disable this factor; larger
-     *		   k2 makes it stronger.  (default 0)
-     *
-     *  @param k3  A non-negative parameter controlling how influential
-     *		   within-query-frequency (wqf) is.  k3=0 means that wqf
-     *		   doesn't affect the weights.  The larger k3 is, the more
-     *		   wqf influences the weights.  (default 1)
-     *
-     *  @param b   A parameter between 0 and 1, controlling how strong the
-     *		   document length normalisation of wdf is.  0 means no
-     *		   normalisation; 1 means full normalisation.  (default 0.5)
-     *
-     *  @param min_normlen  A parameter specifying a minimum value for
-     *		   normalised document length.  Normalised document length
-     *		   values less than this will be clamped to this value, helping
-     *		   to prevent very short documents getting large weights.
-     *		   (default 0.5)
-     */
-    BM25Weight(double k1, double k2, double k3, double b, double min_normlen)
+	/** Construct a BM25Weight.
+	 *
+	 *  @param k1  A non-negative parameter controlling how influential
+	 *		within-document-frequency (wdf) is.  k1=0 means that
+	 *		 wdf doesn't affect the weights.  The larger k1 is, the more
+	 *		 wdf influences the weights.  (default 1)
+	 *
+	 *  @param k2  A non-negative parameter which controls the strength of a
+	 *		 correction factor which depends upon query length and
+	 *		 normalised document length.  k2=0 disable this factor; larger
+	 *		 k2 makes it stronger.  (default 0)
+	 *
+	 *  @param k3  A non-negative parameter controlling how influential
+	 *		 within-query-frequency (wqf) is.  k3=0 means that wqf
+	 *		 doesn't affect the weights.  The larger k3 is, the more
+	 *		 wqf influences the weights.  (default 1)
+	 *
+	 *  @param b   A parameter between 0 and 1, controlling how strong the
+	 *		 document length normalisation of wdf is.  0 means no
+	 *		 normalisation; 1 means full normalisation.  (default 0.5)
+	 *
+	 *  @param min_normlen  A parameter specifying a minimum value for
+	 *		 normalised document length.  Normalised document length
+	 *		 values less than this will be clamped to this value, helping
+	 *		 to prevent very short documents getting large weights.
+	 *		 (default 0.5)
+	 */
+	BM25Weight(double k1, double k2, double k3, double b, double min_normlen)
 	: param_k1(k1), param_k2(k2), param_k3(k3), param_b(b),
 	  param_min_normlen(min_normlen)
-    {
+	{
 	if (param_k1 < 0) param_k1 = 0;
 	if (param_k2 < 0) param_k2 = 0;
 	if (param_k3 < 0) param_k3 = 0;
 	if (param_b < 0) {
-	    param_b = 0;
+		param_b = 0;
 	} else if (param_b > 1) {
-	    param_b = 1;
+		param_b = 1;
 	}
 	need_stat(COLLECTION_SIZE);
 	need_stat(RSET_SIZE);
@@ -551,18 +551,18 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
 	need_stat(WDF);
 	need_stat(WDF_MAX);
 	if (param_k2 != 0 || (param_k1 != 0 && param_b != 0)) {
-	    need_stat(DOC_LENGTH_MIN);
-	    need_stat(AVERAGE_LENGTH);
+		need_stat(DOC_LENGTH_MIN);
+		need_stat(AVERAGE_LENGTH);
 	}
 	if (param_k1 != 0 && param_b != 0) need_stat(DOC_LENGTH);
 	if (param_k2 != 0) need_stat(QUERY_LENGTH);
 	if (param_k3 != 0) need_stat(WQF);
-    }
+	}
 
-    BM25Weight()
+	BM25Weight()
 	: param_k1(1), param_k2(0), param_k3(1), param_b(0.5),
 	  param_min_normlen(0.5)
-    {
+	{
 	need_stat(COLLECTION_SIZE);
 	need_stat(RSET_SIZE);
 	need_stat(TERMFREQ);
@@ -573,21 +573,122 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(WQF);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    BM25Weight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	BM25Weight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterm) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
+
+  protected:
+	// BM25+ is disabled.
+	bool bm25_plus = 0;
+};
+
+/// Xapian::Weight subclass implementing the BM25+ probabilistic formula.
+class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
+
+  public:
+	/** Construct a BM25PlusWeight.
+	 *
+	 *  @param delta  A parameter for pseudo tf value to control the scale
+	 *		 of the tf lower bound. Delta(δ) can be tuned for e.g from 0.0
+	 *		 to 1.5 but BM25+ can still work effectively across collections
+	 *		 with a fixed δ = 1.0. (default 1.0)
+	 */
+	BM25PlusWeight(double k1, double k2, double k3, double b, double min_normlen, double delta)
+	: param_k1(k1), param_k2(k2), param_k3(k3), param_b(b),
+	param_min_normlen(min_normlen), param_delta(delta)
+	{
+	if (param_k1 < 0) param_k1 = 0;
+	if (param_k2 < 0) param_k2 = 0;
+	if (param_k3 < 0) param_k3 = 0;
+	if (param_b < 0) {
+	param_b = 0;
+	} else if (param_b > 1) {
+	param_b = 1;
+	}
+	need_stat(COLLECTION_SIZE);
+	need_stat(RSET_SIZE);
+	need_stat(TERMFREQ);
+	need_stat(RELTERMFREQ);
+	need_stat(WDF);
+	need_stat(WDF_MAX);
+	if (param_k2 != 0 || (param_k1 != 0 && param_b != 0)) {
+	need_stat(DOC_LENGTH_MIN);
+	need_stat(AVERAGE_LENGTH);
+	}
+	if (param_k1 != 0 && param_b != 0) need_stat(DOC_LENGTH);
+	if (param_k2 != 0) need_stat(QUERY_LENGTH);
+	if (param_k3 != 0) need_stat(WQF);
+	if (param_delta < 0) param_delta = 0;
+	if (param_delta != 0) {
+	need_stat(AVERAGE_LENGTH);
+	need_stat(DOC_LENGTH);
+	need_stat(WQF);
+	}
+	}
+
+	BM25PlusWeight()
+	: param_k1(1), param_k2(0), param_k3(1), param_b(0.5),
+	  param_min_normlen(0.5), param_delta(1)
+	{
+	need_stat(COLLECTION_SIZE);
+	need_stat(RSET_SIZE);
+	need_stat(TERMFREQ);
+	need_stat(RELTERMFREQ);
+	need_stat(WDF);
+	need_stat(WDF_MAX);
+	need_stat(DOC_LENGTH_MIN);
+	need_stat(AVERAGE_LENGTH);
+	need_stat(DOC_LENGTH);
+	need_stat(WQF);
+	}
+	std::string name() const;
+
+	std::string serialise() const;
+	BM25PlusWeight * unserialise(const std::string & serialised) const;
+
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterm) const;
+	double get_maxpart() const;
+
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
+
+  protected:
+	/// Factor to multiply the document length by.
+	mutable Xapian::doclength len_factor;
+
+	/// Factor combining all the document independent factors.
+	mutable double termweight;
+
+	/// The BM25 parameters.
+	double param_k1, param_k2, param_k3, param_b;
+
+	/// The minimum normalised document length value.
+	Xapian::doclength param_min_normlen;
+
+	/// Additional parameter delta in the BM25+ formula.
+	double param_delta;
+
+	BM25PlusWeight * clone() const;
+
+	void init(double factor);
+
+	// BM25+ is enabled.
+	bool bm25_plus = 1;
 };
 
 /** Xapian::Weight subclass implementing the traditional probabilistic formula.
@@ -600,32 +701,32 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
  * the latter returns weights (k+1) times larger.
  */
 class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
-    /// Factor to multiply the document length by.
-    mutable Xapian::doclength len_factor;
+	/// Factor to multiply the document length by.
+	mutable Xapian::doclength len_factor;
 
-    /// Factor combining all the document independent factors.
-    mutable double termweight;
+	/// Factor combining all the document independent factors.
+	mutable double termweight;
 
-    /// The parameter in the formula.
-    double param_k;
+	/// The parameter in the formula.
+	double param_k;
 
-    TradWeight * clone() const;
+	TradWeight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct a TradWeight.
-     *
-     *  @param k  A non-negative parameter controlling how influential
-     *		  within-document-frequency (wdf) and document length are.
-     *		  k=0 means that wdf and document length don't affect the
-     *		  weights.  The larger k is, the more they do.  (default 1)
-     */
-    explicit TradWeight(double k = 1.0) : param_k(k) {
+	/** Construct a TradWeight.
+	 *
+	 *  @param k  A non-negative parameter controlling how influential
+	 *		within-document-frequency (wdf) and document length are.
+	 *		k=0 means that wdf and document length don't affect the
+	 *		weights.  The larger k is, the more they do.  (default 1)
+	 */
+	explicit TradWeight(double k = 1.0) : param_k(k) {
 	if (param_k < 0) param_k = 0;
 	if (param_k != 0.0) {
-	    need_stat(AVERAGE_LENGTH);
-	    need_stat(DOC_LENGTH);
+	need_stat(AVERAGE_LENGTH);
+	need_stat(DOC_LENGTH);
 	}
 	need_stat(COLLECTION_SIZE);
 	need_stat(RSET_SIZE);
@@ -634,21 +735,21 @@ class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
 	need_stat(DOC_LENGTH_MIN);
 	need_stat(WDF);
 	need_stat(WDF_MAX);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    TradWeight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	TradWeight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqueterms) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqueterms) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 /** This class implements the InL2 weighting scheme.
@@ -670,34 +771,34 @@ class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
  *  pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
-    /// The wdf normalization parameter in the formula.
-    double param_c;
+	/// The wdf normalization parameter in the formula.
+	double param_c;
 
-    /// The upper bound on the weight a term can give to a document.
-    double upper_bound;
+	/// The upper bound on the weight a term can give to a document.
+	double upper_bound;
 
-    /// The constant values which are used on every call to get_sumpart().
-    double wqf_product_idf;
-    double c_product_avlen;
+	/// The constant values which are used on every call to get_sumpart().
+	double wqf_product_idf;
+	double c_product_avlen;
 
-    InL2Weight * clone() const;
+	InL2Weight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct an InL2Weight.
-     *
-     *  @param c  A non-negative and non zero parameter controlling the extent
-     *		  of the normalization of the wdf to the document length. The
-     *		  default value of 1 is suitable for longer queries but it may
-     *		  need to be changed for shorter queries. For more information,
-     *		  please refer to Gianni Amati's PHD thesis.
-     */
-    explicit InL2Weight(double c);
+	/** Construct an InL2Weight.
+	 *
+	 *  @param c  A non-negative and non zero parameter controlling the extent
+	 *		of the normalization of the wdf to the document length. The
+	 *		default value of 1 is suitable for longer queries but it may
+	 *		need to be changed for shorter queries. For more information,
+	 *		please refer to Gianni Amati's PHD thesis.
+	 */
+	explicit InL2Weight(double c);
 
-    InL2Weight()
-    : param_c(1.0)
-    {
+	InL2Weight()
+	: param_c(1.0)
+	{
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -707,21 +808,21 @@ class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(WQF);
 	need_stat(TERMFREQ);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    InL2Weight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	InL2Weight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 /** This class implements the IfB2 weighting scheme.
@@ -741,35 +842,35 @@ class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
  *  pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
-    /// The wdf normalization parameter in the formula.
-    double param_c;
+	/// The wdf normalization parameter in the formula.
+	double param_c;
 
-    /// The upper bound on the weight.
-    double upper_bound;
+	/// The upper bound on the weight.
+	double upper_bound;
 
-    /// The constant values which are used for calculations in get_sumpart().
-    double wqf_product_idf;
-    double c_product_avlen;
-    double B_constant;
+	/// The constant values which are used for calculations in get_sumpart().
+	double wqf_product_idf;
+	double c_product_avlen;
+	double B_constant;
 
-    IfB2Weight * clone() const;
+	IfB2Weight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct an IfB2Weight.
-     *
-     *  @param c  A non-negative and non zero parameter controlling the extent
-     *		  of the normalization of the wdf to the document length. The
-     *		  default value of 1 is suitable for longer queries but it may
-     *		  need to be changed for shorter queries. For more information,
-     *		  please refer to Gianni Amati's PHD thesis titled
-     *		  Probabilistic Models for Information Retrieval based on
-     *		  Divergence from Randomness.
-     */
-    explicit IfB2Weight(double c);
+	/** Construct an IfB2Weight.
+	 *
+	 *  @param c  A non-negative and non zero parameter controlling the extent
+	 *		of the normalization of the wdf to the document length. The
+	 *		default value of 1 is suitable for longer queries but it may
+	 *		need to be changed for shorter queries. For more information,
+	 *		please refer to Gianni Amati's PHD thesis titled
+	 *		Probabilistic Models for Information Retrieval based on
+	 *		Divergence from Randomness.
+	 */
+	explicit IfB2Weight(double c);
 
-    IfB2Weight( ) : param_c(1.0) {
+	IfB2Weight( ) : param_c(1.0) {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -780,21 +881,21 @@ class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(WQF);
 	need_stat(TERMFREQ);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    IfB2Weight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	IfB2Weight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterm) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 /** This class implements the IneB2 weighting scheme.
@@ -814,33 +915,33 @@ class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
  *  pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
-    /// The wdf normalization parameter in the formula.
-    double param_c;
+	/// The wdf normalization parameter in the formula.
+	double param_c;
 
-    /// The upper bound of the weight.
-    double upper_bound;
+	/// The upper bound of the weight.
+	double upper_bound;
 
-    /// Constant values used in get_sumpart().
-    double wqf_product_idf;
-    double c_product_avlen;
-    double B_constant;
+	/// Constant values used in get_sumpart().
+	double wqf_product_idf;
+	double c_product_avlen;
+	double B_constant;
 
-    IneB2Weight * clone() const;
+	IneB2Weight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct an IneB2Weight.
-     *
-     *  @param c  A non-negative and non zero parameter controlling the extent
-     *		  of the normalization of the wdf to the document length. The
-     *		  default value of 1 is suitable for longer queries but it may
-     *		  need to be changed for shorter queries. For more information,
-     *		  please refer to Gianni Amati's PHD thesis.
-     */
-    explicit IneB2Weight(double c);
+	/** Construct an IneB2Weight.
+	 *
+	 *  @param c  A non-negative and non zero parameter controlling the extent
+	 *		of the normalization of the wdf to the document length. The
+	 *		default value of 1 is suitable for longer queries but it may
+	 *		need to be changed for shorter queries. For more information,
+	 *		please refer to Gianni Amati's PHD thesis.
+	 */
+	explicit IneB2Weight(double c);
 
-    IneB2Weight( ) : param_c(1.0) {
+	IneB2Weight( ) : param_c(1.0) {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -851,21 +952,21 @@ class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
 	need_stat(WQF);
 	need_stat(COLLECTION_FREQ);
 	need_stat(TERMFREQ);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    IneB2Weight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	IneB2Weight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 /** This class implements the BB2 weighting scheme.
@@ -886,37 +987,37 @@ class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
  *  pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
-    /// The wdf normalization parameter in the formula.
-    double param_c;
+	/// The wdf normalization parameter in the formula.
+	double param_c;
 
-    /// The upper bound on the weight.
-    double upper_bound;
+	/// The upper bound on the weight.
+	double upper_bound;
 
-    /// The constant values to be used in get_sumpart().
-    double c_product_avlen;
-    double B_constant;
-    double wt;
-    double stirling_constant_1;
-    double stirling_constant_2;
+	/// The constant values to be used in get_sumpart().
+	double c_product_avlen;
+	double B_constant;
+	double wt;
+	double stirling_constant_1;
+	double stirling_constant_2;
 
-    BB2Weight * clone() const;
+	BB2Weight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct a BB2Weight.
-     *
-     *  @param c  A non-negative and non zero parameter controlling the extent
-     *		  of the normalization of the wdf to the document length. A
-     *		  default value of 1 is suitable for longer queries but it may
-     *		  need to be changed for shorter queries. For more information,
-     *		  please refer to Gianni Amati's PHD thesis titled
-     *		  Probabilistic Models for Information Retrieval based on
-     *		  Divergence from Randomness.
-     */
-    explicit BB2Weight(double c);
+	/** Construct a BB2Weight.
+	 *
+	 *  @param c  A non-negative and non zero parameter controlling the extent
+	 *		of the normalization of the wdf to the document length. A
+	 *		default value of 1 is suitable for longer queries but it may
+	 *		need to be changed for shorter queries. For more information,
+	 *		please refer to Gianni Amati's PHD thesis titled
+	 *		Probabilistic Models for Information Retrieval based on
+	 *		Divergence from Randomness.
+	 */
+	explicit BB2Weight(double c);
 
-    BB2Weight( ) : param_c(1.0) {
+	BB2Weight( ) : param_c(1.0) {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -927,21 +1028,21 @@ class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(WQF);
 	need_stat(TERMFREQ);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    BB2Weight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	BB2Weight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 /** This class implements the DLH weighting scheme, which is a representative
@@ -962,22 +1063,22 @@ class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
  *  Proceedings of the 16th Text REtrieval Conference (TREC-2007), 2008.
  */
 class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
-    /// The lower bound on the weight.
-    double lower_bound;
+	/// The lower bound on the weight.
+	double lower_bound;
 
-    /// The upper bound on the weight.
-    double upper_bound;
+	/// The upper bound on the weight.
+	double upper_bound;
 
-    /// The constant value to be used in get_sumpart().
-    double log_constant;
-    double wqf_product_factor;
+	/// The constant value to be used in get_sumpart().
+	double log_constant;
+	double wqf_product_factor;
 
-    DLHWeight * clone() const;
+	DLHWeight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    DLHWeight() {
+	DLHWeight() {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(COLLECTION_SIZE);
@@ -987,21 +1088,21 @@ class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(DOC_LENGTH_MIN);
 	need_stat(DOC_LENGTH_MAX);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    DLHWeight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	DLHWeight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 /** This class implements the PL2 weighting scheme.
@@ -1023,39 +1124,39 @@ class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
  *  ACM Transactions on Information Systems (TOIS) 20, (4), 2002, pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
-    /// The wdf normalization parameter in the formula.
-    double param_c;
+	/// The wdf normalization parameter in the formula.
+	double param_c;
 
-    /// The lower bound of the weight.
-    double lower_bound;
+	/// The lower bound of the weight.
+	double lower_bound;
 
-    /// The upper bound on the weight.
-    double upper_bound;
+	/// The upper bound on the weight.
+	double upper_bound;
 
-    /// Constants for a given term in a given query.
-    double P1, P2;
+	/// Constants for a given term in a given query.
+	double P1, P2;
 
-    /// Set by init() to (param_c * get_average_length())
-    double cl;
+	/// Set by init() to (param_c * get_average_length())
+	double cl;
 
-    PL2Weight * clone() const;
+	PL2Weight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct a PL2Weight.
-     *
-     *  @param c  A non-negative and non zero parameter controlling the extent
-     *		  of the normalization of the wdf to the document length. The
-     *		  default value of 1 is suitable for longer queries but it may
-     *		  need to be changed for shorter queries. For more information,
-     *		  please refer to Gianni Amati's PHD thesis titled
-     *		  Probabilistic Models for Information Retrieval based on
-     *		  Divergence from Randomness.
-     */
-    explicit PL2Weight(double c);
+	/** Construct a PL2Weight.
+	 *
+	 *  @param c  A non-negative and non zero parameter controlling the extent
+	 *		of the normalization of the wdf to the document length. The
+	 *		default value of 1 is suitable for longer queries but it may
+	 *		need to be changed for shorter queries. For more information,
+	 *		please refer to Gianni Amati's PHD thesis titled
+	 *		Probabilistic Models for Information Retrieval based on
+	 *		Divergence from Randomness.
+	 */
+	explicit PL2Weight(double c);
 
-    PL2Weight( ) : param_c(1.0) {
+	PL2Weight( ) : param_c(1.0) {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -1065,21 +1166,21 @@ class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
 	need_stat(WDF);
 	need_stat(WDF_MAX);
 	need_stat(WQF);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    PL2Weight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	PL2Weight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 /** This class implements the DPH weighting scheme.
@@ -1102,23 +1203,23 @@ class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
  *  Proceedings of the 16th Text Retrieval Conference (TREC-2007), 2008.
  */
 class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
-    /// The upper bound on the weight.
-    double upper_bound;
+	/// The upper bound on the weight.
+	double upper_bound;
 
-    /// The lower bound on the weight.
-    double lower_bound;
+	/// The lower bound on the weight.
+	double lower_bound;
 
-    /// The constant value used in get_sumpart() .
-    double log_constant;
-    double wqf_product_factor;
+	/// The constant value used in get_sumpart() .
+	double log_constant;
+	double wqf_product_factor;
 
-    DPHWeight * clone() const;
+	DPHWeight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct a DPHWeight. */
-    DPHWeight() {
+	/** Construct a DPHWeight. */
+	DPHWeight() {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(COLLECTION_SIZE);
@@ -1128,21 +1229,21 @@ class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(DOC_LENGTH_MIN);
 	need_stat(DOC_LENGTH_MAX);
-    }
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    DPHWeight * unserialise(const std::string & serialised) const;
+	std::string serialise() const;
+	DPHWeight * unserialise(const std::string & serialised) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterms) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen,
+		Xapian::termcount uniqterms) const;
+	double get_maxextra() const;
 };
 
 
@@ -1157,57 +1258,57 @@ class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
  */
 class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 
-    /** The type of smoothing to use. */
-    type_smoothing select_smoothing;
+	/** The type of smoothing to use. */
+	type_smoothing select_smoothing;
 
-    // Parameters for handling negative value of log, and for smoothing.
-    double param_log, param_smoothing1, param_smoothing2;
+	// Parameters for handling negative value of log, and for smoothing.
+	double param_log, param_smoothing1, param_smoothing2;
 
-    // Collection weight.
-    double weight_collection;
+	// Collection weight.
+	double weight_collection;
 
-    LMWeight * clone() const;
+	LMWeight * clone() const;
 
-    void init(double factor);
+	void init(double factor);
 
   public:
-    /** Construct a LMWeight.
-     *
-     *  @param param_log_	A non-negative parameter controlling how much
-     *				to clamp negative values returned by the log.
-     *				The log is calculated by multiplying the
-     *				actual weight by param_log.  If param_log is
-     *				0.0, then the document length upper bound will
-     *				be used (default: document length upper	bound)
-     *
-     *  @param select_smoothing_	A parameter of type enum
-     *					type_smoothing.  This parameter
-     *					controls which smoothing type to use.
-     *					(default: TWO_STAGE_SMOOTHING)
-     *
-     *  @param param_smoothing1_	A non-negative parameter for smoothing
-     *					whose meaning depends on
-     *					select_smoothing_.  In
-     *					JELINEK_MERCER_SMOOTHING, it plays the
-     *					role of estimation and in
-     *					DIRICHLET_SMOOTHING the role of query
-     *					modelling. (default JELINEK_MERCER,
-     *					ABSOLUTE, TWOSTAGE(0.7),
-     *					DIRCHLET(2000))
-     *
-     *  @param param_smoothing2_	A non-negative parameter which is used
-     *					only with TWO_STAGE_SMOOTHING as
-     *					parameter for Dirichlet's smoothing.
-     *					(default: 2000)
-     */
-    // Unigram LM Constructor to specifically mention all parameters for handling negative log value and smoothing.
-    explicit LMWeight(double param_log_ = 0.0,
-		      type_smoothing select_smoothing_ = TWO_STAGE_SMOOTHING,
-		      double param_smoothing1_ = 0.7,
-		      double param_smoothing2_ = 2000.0)
+	/** Construct a LMWeight.
+	 *
+	 *  @param param_log_   A non-negative parameter controlling how much
+	 *			  to clamp negative values returned by the log.
+	 *			  The log is calculated by multiplying the
+	 *			  actual weight by param_log.  If param_log is
+	 *			  0.0, then the document length upper bound will
+	 *			  be used (default: document length upper bound)
+	 *
+	 *  @param select_smoothing_	A parameter of type enum
+	 *				  type_smoothing.  This parameter
+	 *				  controls which smoothing type to use.
+	 *				  (default: TWO_STAGE_SMOOTHING)
+	 *
+	 *  @param param_smoothing1_	A non-negative parameter for smoothing
+	 *				  whose meaning depends on
+	 *				  select_smoothing_.  In
+	 *				  JELINEK_MERCER_SMOOTHING, it plays the
+	 *				  role of estimation and in
+	 *				  DIRICHLET_SMOOTHING the role of query
+	 *				  modelling. (default JELINEK_MERCER,
+	 *				  ABSOLUTE, TWOSTAGE(0.7),
+	 *				  DIRCHLET(2000))
+	 *
+	 *  @param param_smoothing2_	A non-negative parameter which is used
+	 *				  only with TWO_STAGE_SMOOTHING as
+	 *				  parameter for Dirichlet's smoothing.
+	 *				  (default: 2000)
+	 */
+	// Unigram LM Constructor to specifically mention all parameters for handling negative log value and smoothing.
+	explicit LMWeight(double param_log_ = 0.0,
+		  type_smoothing select_smoothing_ = TWO_STAGE_SMOOTHING,
+		  double param_smoothing1_ = 0.7,
+		  double param_smoothing2_ = 2000.0)
 	: select_smoothing(select_smoothing_), param_log(param_log_), param_smoothing1(param_smoothing1_),
 	  param_smoothing2(param_smoothing2_)
-    {
+	{
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(COLLECTION_SIZE);
@@ -1219,21 +1320,21 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(COLLECTION_FREQ);
 	if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING)
-	    need_stat(UNIQUE_TERMS);
-    }
+	need_stat(UNIQUE_TERMS);
+	}
 
-    std::string name() const;
+	std::string name() const;
 
-    std::string serialise() const;
-    LMWeight * unserialise(const std::string & s) const;
+	std::string serialise() const;
+	LMWeight * unserialise(const std::string & s) const;
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
-    double get_maxpart() const;
+	double get_sumpart(Xapian::termcount wdf,
+		   Xapian::termcount doclen,
+		   Xapian::termcount uniqterm) const;
+	double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const;
-    double get_maxextra() const;
+	double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const;
+	double get_maxextra() const;
 };
 
 }

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -33,8 +33,8 @@ namespace Xapian {
 /** Abstract base class for weighting schemes. */
 class XAPIAN_VISIBILITY_DEFAULT Weight {
   protected:
-	/// Stats which the weighting scheme can use (see @a need_stat()).
-	typedef enum {
+    /// Stats which the weighting scheme can use (see @a need_stat()).
+    typedef enum {
 	/// Number of documents in the collection.
 	COLLECTION_SIZE = 1,
 	/// Number of documents in the RSet.
@@ -63,313 +63,313 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
 	COLLECTION_FREQ = 4096,
 	/// Number of unique terms in the current document.
 	UNIQUE_TERMS = 8192
-	} stat_flags;
+    } stat_flags;
 
-	/** Tell Xapian that your subclass will want a particular statistic.
-	 *
-	 *  Some of the statistics can be costly to fetch or calculate, so
-	 *  Xapian needs to know which are actually going to be used.  You
-	 *  should call need_stat() from your constructor for each such
-	 *  statistic.
-	 *
-	 * @param flag  The stat_flags value for a required statistic.
-	 */
-	void need_stat(stat_flags flag) {
+    /** Tell Xapian that your subclass will want a particular statistic.
+     *
+     *  Some of the statistics can be costly to fetch or calculate, so
+     *  Xapian needs to know which are actually going to be used.  You
+     *  should call need_stat() from your constructor for each such
+     *  statistic.
+     *
+     * @param flag  The stat_flags value for a required statistic.
+     */
+    void need_stat(stat_flags flag) {
 	stats_needed = stat_flags(stats_needed | flag);
-	}
+    }
 
-	/** Allow the subclass to perform any initialisation it needs to.
-	 *
-	 *  @param factor	 Any scaling factor (e.g. from OP_SCALE_WEIGHT).
-	 *			If the Weight object is for the term-independent
-	 *			weight supplied by get_sumextra()/get_maxextra(),
-	 *			then init(0.0) is called (starting from Xapian
-	 *			1.2.11 and 1.3.1 - earlier versions failed to
-	 *			call init() for such Weight objects).
-	 */
-	virtual void init(double factor) = 0;
+    /** Allow the subclass to perform any initialisation it needs to.
+     *
+     *  @param factor	  Any scaling factor (e.g. from OP_SCALE_WEIGHT).
+     *			  If the Weight object is for the term-independent
+     *			  weight supplied by get_sumextra()/get_maxextra(),
+     *			  then init(0.0) is called (starting from Xapian
+     *			  1.2.11 and 1.3.1 - earlier versions failed to
+     *			  call init() for such Weight objects).
+     */
+    virtual void init(double factor) = 0;
 
   private:
-	/// Don't allow assignment.
-	void operator=(const Weight &);
+    /// Don't allow assignment.
+    void operator=(const Weight &);
 
-	/// A bitmask of the statistics this weighting scheme needs.
-	stat_flags stats_needed;
+    /// A bitmask of the statistics this weighting scheme needs.
+    stat_flags stats_needed;
 
-	/// The number of documents in the collection.
-	Xapian::doccount collection_size_;
+    /// The number of documents in the collection.
+    Xapian::doccount collection_size_;
 
-	/// The number of documents marked as relevant.
-	Xapian::doccount rset_size_;
+    /// The number of documents marked as relevant.
+    Xapian::doccount rset_size_;
 
-	/// The average length of a document in the collection.
-	Xapian::doclength average_length_;
+    /// The average length of a document in the collection.
+    Xapian::doclength average_length_;
 
-	/// The number of documents which this term indexes.
-	Xapian::doccount termfreq_;
+    /// The number of documents which this term indexes.
+    Xapian::doccount termfreq_;
 
-	// The collection frequency of the term.
-	Xapian::termcount collectionfreq_;
+    // The collection frequency of the term.
+    Xapian::termcount collectionfreq_;
 
-	/// The number of relevant documents which this term indexes.
-	Xapian::doccount reltermfreq_;
+    /// The number of relevant documents which this term indexes.
+    Xapian::doccount reltermfreq_;
 
-	/// The length of the query.
-	Xapian::termcount query_length_;
+    /// The length of the query.
+    Xapian::termcount query_length_;
 
-	/// The within-query-frequency of this term.
-	Xapian::termcount wqf_;
+    /// The within-query-frequency of this term.
+    Xapian::termcount wqf_;
 
-	/// A lower bound on the minimum length of any document in the database.
-	Xapian::termcount doclength_lower_bound_;
+    /// A lower bound on the minimum length of any document in the database.
+    Xapian::termcount doclength_lower_bound_;
 
-	/// An upper bound on the maximum length of any document in the database.
-	Xapian::termcount doclength_upper_bound_;
+    /// An upper bound on the maximum length of any document in the database.
+    Xapian::termcount doclength_upper_bound_;
 
-	/// An upper bound on the wdf of this term.
-	Xapian::termcount wdf_upper_bound_;
+    /// An upper bound on the wdf of this term.
+    Xapian::termcount wdf_upper_bound_;
 
   public:
 
-	/// Default constructor, needed by subclass constructors.
-	Weight() : stats_needed() { }
+    /// Default constructor, needed by subclass constructors.
+    Weight() : stats_needed() { }
 
-	/** Type of smoothing to use with the Language Model Weighting scheme.
-	 *
-	 *  Default is TWO_STAGE_SMOOTHING.
-	 */
-	typedef enum {
+    /** Type of smoothing to use with the Language Model Weighting scheme.
+     *
+     *  Default is TWO_STAGE_SMOOTHING.
+     */
+    typedef enum {
 	TWO_STAGE_SMOOTHING = 1,
 	DIRICHLET_SMOOTHING = 2,
 	ABSOLUTE_DISCOUNT_SMOOTHING = 3,
 	JELINEK_MERCER_SMOOTHING = 4
-	} type_smoothing;
+    } type_smoothing;
 
-	class Internal;
+    class Internal;
 
-	/** Virtual destructor, because we have virtual methods. */
-	virtual ~Weight();
+    /** Virtual destructor, because we have virtual methods. */
+    virtual ~Weight();
 
-	/** Clone this object.
-	 *
-	 *  This method allocates and returns a copy of the object it is called on.
-	 *
-	 *  If your subclass is called FooWeight and has parameters a and b, then
-	 *  you would implement FooWeight::clone() like so:
-	 *
-	 *  FooWeight * FooWeight::clone() const { return new FooWeight(a, b); }
-	 *
-	 *  Note that the returned object will be deallocated by Xapian after use
-	 *  with "delete".  If you want to handle the deletion in a special way
-	 *  (for example when wrapping the Xapian API for use from another
-	 *  language) then you can define a static <code>operator delete</code>
-	 *  method in your subclass as shown here:
-	 *  https://trac.xapian.org/ticket/554#comment:1
-	 */
-	virtual Weight * clone() const = 0;
+    /** Clone this object.
+     *
+     *  This method allocates and returns a copy of the object it is called on.
+     *
+     *  If your subclass is called FooWeight and has parameters a and b, then
+     *  you would implement FooWeight::clone() like so:
+     *
+     *  FooWeight * FooWeight::clone() const { return new FooWeight(a, b); }
+     *
+     *  Note that the returned object will be deallocated by Xapian after use
+     *  with "delete".  If you want to handle the deletion in a special way
+     *  (for example when wrapping the Xapian API for use from another
+     *  language) then you can define a static <code>operator delete</code>
+     *  method in your subclass as shown here:
+     *  https://trac.xapian.org/ticket/554#comment:1
+     */
+    virtual Weight * clone() const = 0;
 
-	/** Return the name of this weighting scheme.
-	 *
-	 *  This name is used by the remote backend.  It is passed along with the
-	 *  serialised parameters to the remote server so that it knows which class
-	 *  to create.
-	 *
-	 *  Return the full namespace-qualified name of your class here - if
-	 *  your class is called FooWeight, return "FooWeight" from this method
-	 *  (Xapian::BM25Weight returns "Xapian::BM25Weight" here).
-	 *
-	 *  If you don't want to support the remote backend, you can use the
-	 *  default implementation which simply returns an empty string.
-	 */
-	virtual std::string name() const;
+    /** Return the name of this weighting scheme.
+     *
+     *  This name is used by the remote backend.  It is passed along with the
+     *  serialised parameters to the remote server so that it knows which class
+     *  to create.
+     *
+     *  Return the full namespace-qualified name of your class here - if
+     *  your class is called FooWeight, return "FooWeight" from this method
+     *  (Xapian::BM25Weight returns "Xapian::BM25Weight" here).
+     *
+     *  If you don't want to support the remote backend, you can use the
+     *  default implementation which simply returns an empty string.
+     */
+    virtual std::string name() const;
 
-	/** Return this object's parameters serialised as a single string.
-	 *
-	 *  If you don't want to support the remote backend, you can use the
-	 *  default implementation which simply throws Xapian::UnimplementedError.
-	 */
-	virtual std::string serialise() const;
+    /** Return this object's parameters serialised as a single string.
+     *
+     *  If you don't want to support the remote backend, you can use the
+     *  default implementation which simply throws Xapian::UnimplementedError.
+     */
+    virtual std::string serialise() const;
 
-	/** Unserialise parameters.
-	 *
-	 *  This method unserialises parameters serialised by the @a serialise()
-	 *  method and allocates and returns a new object initialised with them.
-	 *
-	 *  If you don't want to support the remote backend, you can use the
-	 *  default implementation which simply throws Xapian::UnimplementedError.
-	 *
-	 *  Note that the returned object will be deallocated by Xapian after use
-	 *  with "delete".  If you want to handle the deletion in a special way
-	 *  (for example when wrapping the Xapian API for use from another
-	 *  language) then you can define a static <code>operator delete</code>
-	 *  method in your subclass as shown here:
-	 *  https://trac.xapian.org/ticket/554#comment:1
-	 *
-	 *  @param serialised   A string containing the serialised parameters.
-	 */
-	virtual Weight * unserialise(const std::string & serialised) const;
+    /** Unserialise parameters.
+     *
+     *  This method unserialises parameters serialised by the @a serialise()
+     *  method and allocates and returns a new object initialised with them.
+     *
+     *  If you don't want to support the remote backend, you can use the
+     *  default implementation which simply throws Xapian::UnimplementedError.
+     *
+     *  Note that the returned object will be deallocated by Xapian after use
+     *  with "delete".  If you want to handle the deletion in a special way
+     *  (for example when wrapping the Xapian API for use from another
+     *  language) then you can define a static <code>operator delete</code>
+     *  method in your subclass as shown here:
+     *  https://trac.xapian.org/ticket/554#comment:1
+     *
+     *  @param serialised	A string containing the serialised parameters.
+     */
+    virtual Weight * unserialise(const std::string & serialised) const;
 
-	/** Calculate the weight contribution for this object's term to a document.
-	 *
-	 *  The parameters give information about the document which may be used
-	 *  in the calculations:
-	 *
-	 *  @param wdf	The within document frequency of the term in the document.
-	 *  @param doclen The document's length (unnormalised).
-	 *  @param uniqterms	Number of unique terms in the document (used
-	 *			  for absolute smoothing).
-	 */
-	virtual double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const = 0;
+    /** Calculate the weight contribution for this object's term to a document.
+     *
+     *  The parameters give information about the document which may be used
+     *  in the calculations:
+     *
+     *  @param wdf    The within document frequency of the term in the document.
+     *  @param doclen The document's length (unnormalised).
+     *  @param uniqterms	Number of unique terms in the document (used
+     *				for absolute smoothing).
+     */
+    virtual double get_sumpart(Xapian::termcount wdf,
+			       Xapian::termcount doclen,
+			       Xapian::termcount uniqterms) const = 0;
 
-	/** Return an upper bound on what get_sumpart() can return for any document.
-	 *
-	 *  This information is used by the matcher to perform various
-	 *  optimisations, so strive to make the bound as tight as possible.
-	 */
-	virtual double get_maxpart() const = 0;
+    /** Return an upper bound on what get_sumpart() can return for any document.
+     *
+     *  This information is used by the matcher to perform various
+     *  optimisations, so strive to make the bound as tight as possible.
+     */
+    virtual double get_maxpart() const = 0;
 
-	/** Calculate the term-independent weight component for a document.
-	 *
-	 *  The parameter gives information about the document which may be used
-	 *  in the calculations:
-	 *
-	 *  @param doclen The document's length (unnormalised).
-	 *  @param uniqterms The number of unique terms in the document.
-	 */
-	virtual double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const = 0;
+    /** Calculate the term-independent weight component for a document.
+     *
+     *  The parameter gives information about the document which may be used
+     *  in the calculations:
+     *
+     *  @param doclen The document's length (unnormalised).
+     *  @param uniqterms The number of unique terms in the document.
+     */
+    virtual double get_sumextra(Xapian::termcount doclen,
+				Xapian::termcount uniqterms) const = 0;
 
-	/** Return an upper bound on what get_sumextra() can return for any
-	 *  document.
-	 *
-	 *  This information is used by the matcher to perform various
-	 *  optimisations, so strive to make the bound as tight as possible.
-	 */
-	virtual double get_maxextra() const = 0;
+    /** Return an upper bound on what get_sumextra() can return for any
+     *  document.
+     *
+     *  This information is used by the matcher to perform various
+     *  optimisations, so strive to make the bound as tight as possible.
+     */
+    virtual double get_maxextra() const = 0;
 
-	/** @private @internal Initialise this object to calculate weights for term
-	 *  @a term.
-	 *
-	 *  @param stats	  Source of statistics.
-	 *  @param query_len_ Query length.
-	 *  @param term   The term for the new object.
-	 *  @param wqf_   The within-query-frequency of @a term.
-	 *  @param factor	 Any scaling factor (e.g. from OP_SCALE_WEIGHT).
-	 */
-	void init_(const Internal & stats, Xapian::termcount query_len_,
-	   const std::string & term, Xapian::termcount wqf_,
-	   double factor);
+    /** @private @internal Initialise this object to calculate weights for term
+     *  @a term.
+     *
+     *  @param stats	  Source of statistics.
+     *  @param query_len_ Query length.
+     *  @param term	  The term for the new object.
+     *  @param wqf_	  The within-query-frequency of @a term.
+     *  @param factor	  Any scaling factor (e.g. from OP_SCALE_WEIGHT).
+     */
+    void init_(const Internal & stats, Xapian::termcount query_len_,
+	       const std::string & term, Xapian::termcount wqf_,
+	       double factor);
 
-	/** @private @internal Initialise this object to calculate weights for a
-	 *  synonym.
-	 *
-	 *  @param stats	   Source of statistics.
-	 *  @param query_len_  Query length.
-	 *  @param factor	  Any scaling factor (e.g. from OP_SCALE_WEIGHT).
-	 *  @param termfreq	The termfreq to use.
-	 *  @param reltermfreq The reltermfreq to use.
-	 *  @param collection_freq The collection frequency to use.
-	 */
-	void init_(const Internal & stats, Xapian::termcount query_len_,
-	   double factor, Xapian::doccount termfreq,
-	   Xapian::doccount reltermfreq, Xapian::termcount collection_freq);
+    /** @private @internal Initialise this object to calculate weights for a
+     *  synonym.
+     *
+     *  @param stats	   Source of statistics.
+     *  @param query_len_  Query length.
+     *  @param factor	   Any scaling factor (e.g. from OP_SCALE_WEIGHT).
+     *  @param termfreq    The termfreq to use.
+     *  @param reltermfreq The reltermfreq to use.
+     *  @param collection_freq The collection frequency to use.
+     */
+    void init_(const Internal & stats, Xapian::termcount query_len_,
+	       double factor, Xapian::doccount termfreq,
+	       Xapian::doccount reltermfreq, Xapian::termcount collection_freq);
 
-	/** @private @internal Initialise this object to calculate the extra weight
-	 *  component.
-	 *
-	 *  @param stats	  Source of statistics.
-	 *  @param query_len_ Query length.
-	 */
-	void init_(const Internal & stats, Xapian::termcount query_len_);
+    /** @private @internal Initialise this object to calculate the extra weight
+     *  component.
+     *
+     *  @param stats	  Source of statistics.
+     *  @param query_len_ Query length.
+     */
+    void init_(const Internal & stats, Xapian::termcount query_len_);
 
-	/** @private @internal Return true if the document length is needed.
-	 *
-	 *  If this method returns true, then the document length will be fetched
-	 *  and passed to @a get_sumpart().  Otherwise 0 may be passed for the
-	 *  document length.
-	 */
-	bool get_sumpart_needs_doclength_() const {
+    /** @private @internal Return true if the document length is needed.
+     *
+     *  If this method returns true, then the document length will be fetched
+     *  and passed to @a get_sumpart().  Otherwise 0 may be passed for the
+     *  document length.
+     */
+    bool get_sumpart_needs_doclength_() const {
 	return stats_needed & DOC_LENGTH;
-	}
+    }
 
-	/** @private @internal Return true if the WDF is needed.
-	 *
-	 *  If this method returns true, then the WDF will be fetched and passed to
-	 *  @a get_sumpart().  Otherwise 0 may be passed for the wdf.
-	 */
-	bool get_sumpart_needs_wdf_() const {
+    /** @private @internal Return true if the WDF is needed.
+     *
+     *  If this method returns true, then the WDF will be fetched and passed to
+     *  @a get_sumpart().  Otherwise 0 may be passed for the wdf.
+     */
+    bool get_sumpart_needs_wdf_() const {
 	return stats_needed & WDF;
-	}
+    }
 
-	/** @private @internal Return true if the number of unique terms is needed.
-	 *
-	 *  If this method returns true, then the number of unique terms will be
-	 *  fetched and passed to @a get_sumpart().  Otherwise 0 may be passed for
-	 *  the number of unique terms.
-	 */
-	bool get_sumpart_needs_uniqueterms_() const {
+    /** @private @internal Return true if the number of unique terms is needed.
+     *
+     *  If this method returns true, then the number of unique terms will be
+     *  fetched and passed to @a get_sumpart().  Otherwise 0 may be passed for
+     *  the number of unique terms.
+     */
+    bool get_sumpart_needs_uniqueterms_() const {
 	return stats_needed & UNIQUE_TERMS;
-	}
+    }
 
   protected:
-	/** Don't allow copying.
-	 *
-	 *  This would ideally be private, but that causes a compilation error
-	 *  with GCC 4.1 (which appears to be a bug).
-	 */
-	Weight(const Weight &);
+    /** Don't allow copying.
+     *
+     *  This would ideally be private, but that causes a compilation error
+     *  with GCC 4.1 (which appears to be a bug).
+     */
+    Weight(const Weight &);
 
-	/// The number of documents in the collection.
-	Xapian::doccount get_collection_size() const { return collection_size_; }
+    /// The number of documents in the collection.
+    Xapian::doccount get_collection_size() const { return collection_size_; }
 
-	/// The number of documents marked as relevant.
-	Xapian::doccount get_rset_size() const { return rset_size_; }
+    /// The number of documents marked as relevant.
+    Xapian::doccount get_rset_size() const { return rset_size_; }
 
-	/// The average length of a document in the collection.
-	Xapian::doclength get_average_length() const { return average_length_; }
+    /// The average length of a document in the collection.
+    Xapian::doclength get_average_length() const { return average_length_; }
 
-	/// The number of documents which this term indexes.
-	Xapian::doccount get_termfreq() const { return termfreq_; }
+    /// The number of documents which this term indexes.
+    Xapian::doccount get_termfreq() const { return termfreq_; }
 
-	/// The number of relevant documents which this term indexes.
-	Xapian::doccount get_reltermfreq() const { return reltermfreq_; }
+    /// The number of relevant documents which this term indexes.
+    Xapian::doccount get_reltermfreq() const { return reltermfreq_; }
 
-	// The collection frequency of the term.
-	Xapian::termcount get_collection_freq() const { return collectionfreq_; }
+    // The collection frequency of the term.
+    Xapian::termcount get_collection_freq() const { return collectionfreq_; }
 
-	/// The length of the query.
-	Xapian::termcount get_query_length() const { return query_length_; }
+    /// The length of the query.
+    Xapian::termcount get_query_length() const { return query_length_; }
 
-	/// The within-query-frequency of this term.
-	Xapian::termcount get_wqf() const { return wqf_; }
+    /// The within-query-frequency of this term.
+    Xapian::termcount get_wqf() const { return wqf_; }
 
-	/** An upper bound on the maximum length of any document in the database.
-	 *
-	 *  This should only be used by get_maxpart() and get_maxextra().
-	 */
-	Xapian::termcount get_doclength_upper_bound() const {
+    /** An upper bound on the maximum length of any document in the database.
+     *
+     *  This should only be used by get_maxpart() and get_maxextra().
+     */
+    Xapian::termcount get_doclength_upper_bound() const {
 	return doclength_upper_bound_;
-	}
+    }
 
-	/** A lower bound on the minimum length of any document in the database.
-	 *
-	 *  This bound does not include any zero-length documents.
-	 *
-	 *  This should only be used by get_maxpart() and get_maxextra().
-	 */
-	Xapian::termcount get_doclength_lower_bound() const {
+    /** A lower bound on the minimum length of any document in the database.
+     *
+     *  This bound does not include any zero-length documents.
+     *
+     *  This should only be used by get_maxpart() and get_maxextra().
+     */
+    Xapian::termcount get_doclength_lower_bound() const {
 	return doclength_lower_bound_;
-	}
+    }
 
-	/** An upper bound on the wdf of this term.
-	 *
-	 *  This should only be used by get_maxpart() and get_maxextra().
-	 */
-	Xapian::termcount get_wdf_upper_bound() const {
+    /** An upper bound on the wdf of this term.
+     *
+     *  This should only be used by get_maxpart() and get_maxextra().
+     */
+    Xapian::termcount get_wdf_upper_bound() const {
 	return wdf_upper_bound_;
-	}
+    }
 };
 
 /** Class implementing a "boolean" weighting scheme.
@@ -377,172 +377,172 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
  *  This weighting scheme gives all documents zero weight.
  */
 class XAPIAN_VISIBILITY_DEFAULT BoolWeight : public Weight {
-	BoolWeight * clone() const;
+    BoolWeight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct a BoolWeight. */
-	BoolWeight() { }
+    /** Construct a BoolWeight. */
+    BoolWeight() { }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	BoolWeight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    BoolWeight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterms) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /// Xapian::Weight subclass implementing the tf-idf weighting scheme.
 class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
-	/* Three character string indicating the normalizations for tf(wdf), idf and
-	   tfidf weight. */
-	std::string normalizations;
+    /* Three character string indicating the normalizations for tf(wdf), idf and
+       tfidf weight. */
+    std::string normalizations;
 
-	/// The factor to multiply with the weight.
-	double factor;
+    /// The factor to multiply with the weight.
+    double factor;
 
-	TfIdfWeight * clone() const;
+    TfIdfWeight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
-	/* When additional normalizations are implemented in the future, the additional statistics for them
-	   should be accessed by these functions. */
-	double get_wdfn(Xapian::termcount wdf, char c) const;
-	double get_idfn(Xapian::doccount termfreq, char c) const;
-	double get_wtn(double wt, char c) const;
+    /* When additional normalizations are implemented in the future, the additional statistics for them
+       should be accessed by these functions. */
+    double get_wdfn(Xapian::termcount wdf, char c) const;
+    double get_idfn(Xapian::doccount termfreq, char c) const;
+    double get_wtn(double wt, char c) const;
 
   public:
-	/** Construct a TfIdfWeight
-	 *
-	 *  @param normalizations   A three character string indicating the
-	 *			  normalizations to be used for the tf(wdf), idf
-	 *			  and document weight.  (default: "ntn")
-	 *
-	 * The @a normalizations string works like so:
-	 *
-	 * @li The first character specifies the normalization for the wdf.  The
-	 *	 following normalizations are currently supported:
-	 *
-	 *	 @li 'n': None.	  wdfn=wdf
-	 *	 @li 'b': Boolean	wdfn=1 if term in document else wdfn=0
-	 *	 @li 's': Square	 wdfn=wdf*wdf
-	 *	 @li 'l': Logarithmic wdfn=1+log<sub>e</sub>(wdf)
-	 *
-	 *	 The Max-wdf and Augmented Max wdf normalizations haven't yet been
-	 *	 implemented.
-	 *
-	 * @li The second character indicates the normalization for the idf.  The
-	 *	 following normalizations are currently supported:
-	 *
-	 *	 @li 'n': None	idfn=1
-	 *	 @li 't': TfIdf   idfn=log(N/Termfreq) where N is the number of
-	 *		 documents in collection and Termfreq is the number of documents
-	 *		 which are indexed by the term t.
-	 *	 @li 'p': Prob	idfn=log((N-Termfreq)/Termfreq)
-	 *	 @li 'f': Freq	idfn=1/Termfreq
-	 *	 @li 's': Squared idfn=log(N/Termfreq)^2
-	 *
-	 * @li The third and the final character indicates the normalization for
-	 *	 the document weight.  The following normalizations are currently
-	 *	 supported:
-	 *
-	 *	 @li 'n': None wtn=tfn*idfn
-	 *
-	 * Implementing support for more normalizations of each type would require
-	 * extending the backend to track more statistics.
-	 */
-	explicit TfIdfWeight(const std::string &normalizations);
+    /** Construct a TfIdfWeight
+     *
+     *  @param normalizations	A three character string indicating the
+     *				normalizations to be used for the tf(wdf), idf
+     *				and document weight.  (default: "ntn")
+     *
+     * The @a normalizations string works like so:
+     *
+     * @li The first character specifies the normalization for the wdf.  The
+     *     following normalizations are currently supported:
+     *
+     *     @li 'n': None.      wdfn=wdf
+     *     @li 'b': Boolean    wdfn=1 if term in document else wdfn=0
+     *     @li 's': Square     wdfn=wdf*wdf
+     *     @li 'l': Logarithmic wdfn=1+log<sub>e</sub>(wdf)
+     *
+     *     The Max-wdf and Augmented Max wdf normalizations haven't yet been
+     *     implemented.
+     *
+     * @li The second character indicates the normalization for the idf.  The
+     *     following normalizations are currently supported:
+     *
+     *     @li 'n': None    idfn=1
+     *     @li 't': TfIdf   idfn=log(N/Termfreq) where N is the number of
+     *         documents in collection and Termfreq is the number of documents
+     *         which are indexed by the term t.
+     *     @li 'p': Prob    idfn=log((N-Termfreq)/Termfreq)
+     *     @li 'f': Freq    idfn=1/Termfreq
+     *     @li 's': Squared idfn=log(N/Termfreq)^2
+     *
+     * @li The third and the final character indicates the normalization for
+     *     the document weight.  The following normalizations are currently
+     *     supported:
+     *
+     *     @li 'n': None wtn=tfn*idfn
+     *
+     * Implementing support for more normalizations of each type would require
+     * extending the backend to track more statistics.
+     */
+    explicit TfIdfWeight(const std::string &normalizations);
 
-	TfIdfWeight()
-	: normalizations("ntn")
-	{
+    TfIdfWeight()
+    : normalizations("ntn")
+    {
 	need_stat(TERMFREQ);
 	need_stat(WDF);
 	need_stat(WDF_MAX);
 	need_stat(COLLECTION_SIZE);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	TfIdfWeight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    TfIdfWeight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterm) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterm) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 
 /// Xapian::Weight subclass implementing the BM25 probabilistic formula.
 class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
-	/// Factor to multiply the document length by.
-	mutable Xapian::doclength len_factor;
+    /// Factor to multiply the document length by.
+    mutable Xapian::doclength len_factor;
 
-	/// Factor combining all the document independent factors.
-	mutable double termweight;
+    /// Factor combining all the document independent factors.
+    mutable double termweight;
 
-	/// The BM25 parameters.
-	double param_k1, param_k2, param_k3, param_b;
+    /// The BM25 parameters.
+    double param_k1, param_k2, param_k3, param_b;
 
-	/// The minimum normalised document length value.
-	Xapian::doclength param_min_normlen;
+    /// The minimum normalised document length value.
+    Xapian::doclength param_min_normlen;
 
-	BM25Weight * clone() const;
+    BM25Weight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct a BM25Weight.
-	 *
-	 *  @param k1  A non-negative parameter controlling how influential
-	 *		within-document-frequency (wdf) is.  k1=0 means that
-	 *		 wdf doesn't affect the weights.  The larger k1 is, the more
-	 *		 wdf influences the weights.  (default 1)
-	 *
-	 *  @param k2  A non-negative parameter which controls the strength of a
-	 *		 correction factor which depends upon query length and
-	 *		 normalised document length.  k2=0 disable this factor; larger
-	 *		 k2 makes it stronger.  (default 0)
-	 *
-	 *  @param k3  A non-negative parameter controlling how influential
-	 *		 within-query-frequency (wqf) is.  k3=0 means that wqf
-	 *		 doesn't affect the weights.  The larger k3 is, the more
-	 *		 wqf influences the weights.  (default 1)
-	 *
-	 *  @param b   A parameter between 0 and 1, controlling how strong the
-	 *		 document length normalisation of wdf is.  0 means no
-	 *		 normalisation; 1 means full normalisation.  (default 0.5)
-	 *
-	 *  @param min_normlen  A parameter specifying a minimum value for
-	 *		 normalised document length.  Normalised document length
-	 *		 values less than this will be clamped to this value, helping
-	 *		 to prevent very short documents getting large weights.
-	 *		 (default 0.5)
-	 */
-	BM25Weight(double k1, double k2, double k3, double b, double min_normlen)
+    /** Construct a BM25Weight.
+     *
+     *  @param k1  A non-negative parameter controlling how influential
+     *		   within-document-frequency (wdf) is.  k1=0 means that
+     *		   wdf doesn't affect the weights.  The larger k1 is, the more
+     *		   wdf influences the weights.  (default 1)
+     *
+     *  @param k2  A non-negative parameter which controls the strength of a
+     *		   correction factor which depends upon query length and
+     *		   normalised document length.  k2=0 disable this factor; larger
+     *		   k2 makes it stronger.  (default 0)
+     *
+     *  @param k3  A non-negative parameter controlling how influential
+     *		   within-query-frequency (wqf) is.  k3=0 means that wqf
+     *		   doesn't affect the weights.  The larger k3 is, the more
+     *		   wqf influences the weights.  (default 1)
+     *
+     *  @param b   A parameter between 0 and 1, controlling how strong the
+     *		   document length normalisation of wdf is.  0 means no
+     *		   normalisation; 1 means full normalisation.  (default 0.5)
+     *
+     *  @param min_normlen  A parameter specifying a minimum value for
+     *		   normalised document length.  Normalised document length
+     *		   values less than this will be clamped to this value, helping
+     *		   to prevent very short documents getting large weights.
+     *		   (default 0.5)
+     */
+    BM25Weight(double k1, double k2, double k3, double b, double min_normlen)
 	: param_k1(k1), param_k2(k2), param_k3(k3), param_b(b),
 	  param_min_normlen(min_normlen)
-	{
+    {
 	if (param_k1 < 0) param_k1 = 0;
 	if (param_k2 < 0) param_k2 = 0;
 	if (param_k3 < 0) param_k3 = 0;
 	if (param_b < 0) {
-		param_b = 0;
+	    param_b = 0;
 	} else if (param_b > 1) {
-		param_b = 1;
+	    param_b = 1;
 	}
 	need_stat(COLLECTION_SIZE);
 	need_stat(RSET_SIZE);
@@ -551,18 +551,18 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
 	need_stat(WDF);
 	need_stat(WDF_MAX);
 	if (param_k2 != 0 || (param_k1 != 0 && param_b != 0)) {
-		need_stat(DOC_LENGTH_MIN);
-		need_stat(AVERAGE_LENGTH);
+	    need_stat(DOC_LENGTH_MIN);
+	    need_stat(AVERAGE_LENGTH);
 	}
 	if (param_k1 != 0 && param_b != 0) need_stat(DOC_LENGTH);
 	if (param_k2 != 0) need_stat(QUERY_LENGTH);
 	if (param_k3 != 0) need_stat(WQF);
-	}
+    }
 
-	BM25Weight()
+    BM25Weight()
 	: param_k1(1), param_k2(0), param_k3(1), param_b(0.5),
 	  param_min_normlen(0.5)
-	{
+    {
 	need_stat(COLLECTION_SIZE);
 	need_stat(RSET_SIZE);
 	need_stat(TERMFREQ);
@@ -573,49 +573,45 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(WQF);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	BM25Weight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    BM25Weight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterm) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterm) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
-
-  protected:
-	// BM25+ is disabled.
-	bool bm25_plus = 0;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /// Xapian::Weight subclass implementing the BM25+ probabilistic formula.
 class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
 
   public:
-	/** Construct a BM25PlusWeight.
-	 *
-	 *  @param delta  A parameter for pseudo tf value to control the scale
-	 *		 of the tf lower bound. Delta(δ) can be tuned for e.g from 0.0
-	 *		 to 1.5 but BM25+ can still work effectively across collections
-	 *		 with a fixed δ = 1.0. (default 1.0)
-	 */
-	BM25PlusWeight(double k1, double k2, double k3, double b, double min_normlen, double delta)
+    /** Construct a BM25PlusWeight.
+     *
+     *  @param delta  A parameter for pseudo tf value to control the scale
+     *		      of the tf lower bound. Delta(δ) can be tuned for e.g
+     *		      from 0.0 to 1.5 but BM25+ can still work effectively
+     *		      across collections with a fixed δ = 1.0. (default 1.0)
+     */
+    BM25PlusWeight(double k1, double k2, double k3, double b, double min_normlen, double delta)
 	: param_k1(k1), param_k2(k2), param_k3(k3), param_b(b),
-	param_min_normlen(min_normlen), param_delta(delta)
-	{
+	  param_min_normlen(min_normlen), param_delta(delta)
+    {
 	if (param_k1 < 0) param_k1 = 0;
 	if (param_k2 < 0) param_k2 = 0;
 	if (param_k3 < 0) param_k3 = 0;
 	if (param_b < 0) {
-	param_b = 0;
+	    param_b = 0;
 	} else if (param_b > 1) {
-	param_b = 1;
+	    param_b = 1;
 	}
 	need_stat(COLLECTION_SIZE);
 	need_stat(RSET_SIZE);
@@ -624,24 +620,24 @@ class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
 	need_stat(WDF);
 	need_stat(WDF_MAX);
 	if (param_k2 != 0 || (param_k1 != 0 && param_b != 0)) {
-	need_stat(DOC_LENGTH_MIN);
-	need_stat(AVERAGE_LENGTH);
+	    need_stat(DOC_LENGTH_MIN);
+	    need_stat(AVERAGE_LENGTH);
 	}
 	if (param_k1 != 0 && param_b != 0) need_stat(DOC_LENGTH);
 	if (param_k2 != 0) need_stat(QUERY_LENGTH);
 	if (param_k3 != 0) need_stat(WQF);
 	if (param_delta < 0) param_delta = 0;
 	if (param_delta != 0) {
-	need_stat(AVERAGE_LENGTH);
-	need_stat(DOC_LENGTH);
-	need_stat(WQF);
+	    need_stat(AVERAGE_LENGTH);
+	    need_stat(DOC_LENGTH);
+	    need_stat(WQF);
 	}
-	}
+    }
 
-	BM25PlusWeight()
+    BM25PlusWeight()
 	: param_k1(1), param_k2(0), param_k3(1), param_b(0.5),
 	  param_min_normlen(0.5), param_delta(1)
-	{
+    {
 	need_stat(COLLECTION_SIZE);
 	need_stat(RSET_SIZE);
 	need_stat(TERMFREQ);
@@ -652,43 +648,41 @@ class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(WQF);
-	}
-	std::string name() const;
+    }
 
-	std::string serialise() const;
-	BM25PlusWeight * unserialise(const std::string & serialised) const;
+    std::string name() const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterm) const;
-	double get_maxpart() const;
+    std::string serialise() const;
+    BM25PlusWeight * unserialise(const std::string & serialised) const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterm) const;
+    double get_maxpart() const;
+
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 
   protected:
-	/// Factor to multiply the document length by.
-	mutable Xapian::doclength len_factor;
+    /// Factor to multiply the document length by.
+    mutable Xapian::doclength len_factor;
 
-	/// Factor combining all the document independent factors.
-	mutable double termweight;
+    /// Factor combining all the document independent factors.
+    mutable double termweight;
 
-	/// The BM25 parameters.
-	double param_k1, param_k2, param_k3, param_b;
+    /// The BM25 parameters.
+    double param_k1, param_k2, param_k3, param_b;
 
-	/// The minimum normalised document length value.
-	Xapian::doclength param_min_normlen;
+    /// The minimum normalised document length value.
+    Xapian::doclength param_min_normlen;
 
-	/// Additional parameter delta in the BM25+ formula.
-	double param_delta;
+    /// Additional parameter delta in the BM25+ formula.
+    double param_delta;
 
-	BM25PlusWeight * clone() const;
+    BM25PlusWeight * clone() const;
 
-	void init(double factor);
-
-	// BM25+ is enabled.
-	bool bm25_plus = 1;
+    void init(double factor);
 };
 
 /** Xapian::Weight subclass implementing the traditional probabilistic formula.
@@ -701,32 +695,32 @@ class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
  * the latter returns weights (k+1) times larger.
  */
 class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
-	/// Factor to multiply the document length by.
-	mutable Xapian::doclength len_factor;
+    /// Factor to multiply the document length by.
+    mutable Xapian::doclength len_factor;
 
-	/// Factor combining all the document independent factors.
-	mutable double termweight;
+    /// Factor combining all the document independent factors.
+    mutable double termweight;
 
-	/// The parameter in the formula.
-	double param_k;
+    /// The parameter in the formula.
+    double param_k;
 
-	TradWeight * clone() const;
+    TradWeight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct a TradWeight.
-	 *
-	 *  @param k  A non-negative parameter controlling how influential
-	 *		within-document-frequency (wdf) and document length are.
-	 *		k=0 means that wdf and document length don't affect the
-	 *		weights.  The larger k is, the more they do.  (default 1)
-	 */
-	explicit TradWeight(double k = 1.0) : param_k(k) {
+    /** Construct a TradWeight.
+     *
+     *  @param k  A non-negative parameter controlling how influential
+     *		  within-document-frequency (wdf) and document length are.
+     *		  k=0 means that wdf and document length don't affect the
+     *		  weights.  The larger k is, the more they do.  (default 1)
+     */
+    explicit TradWeight(double k = 1.0) : param_k(k) {
 	if (param_k < 0) param_k = 0;
 	if (param_k != 0.0) {
-	need_stat(AVERAGE_LENGTH);
-	need_stat(DOC_LENGTH);
+	    need_stat(AVERAGE_LENGTH);
+	    need_stat(DOC_LENGTH);
 	}
 	need_stat(COLLECTION_SIZE);
 	need_stat(RSET_SIZE);
@@ -735,21 +729,21 @@ class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
 	need_stat(DOC_LENGTH_MIN);
 	need_stat(WDF);
 	need_stat(WDF_MAX);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	TradWeight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    TradWeight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqueterms) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqueterms) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /** This class implements the InL2 weighting scheme.
@@ -771,34 +765,34 @@ class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
  *  pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
-	/// The wdf normalization parameter in the formula.
-	double param_c;
+    /// The wdf normalization parameter in the formula.
+    double param_c;
 
-	/// The upper bound on the weight a term can give to a document.
-	double upper_bound;
+    /// The upper bound on the weight a term can give to a document.
+    double upper_bound;
 
-	/// The constant values which are used on every call to get_sumpart().
-	double wqf_product_idf;
-	double c_product_avlen;
+    /// The constant values which are used on every call to get_sumpart().
+    double wqf_product_idf;
+    double c_product_avlen;
 
-	InL2Weight * clone() const;
+    InL2Weight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct an InL2Weight.
-	 *
-	 *  @param c  A non-negative and non zero parameter controlling the extent
-	 *		of the normalization of the wdf to the document length. The
-	 *		default value of 1 is suitable for longer queries but it may
-	 *		need to be changed for shorter queries. For more information,
-	 *		please refer to Gianni Amati's PHD thesis.
-	 */
-	explicit InL2Weight(double c);
+    /** Construct an InL2Weight.
+     *
+     *  @param c  A non-negative and non zero parameter controlling the extent
+     *		  of the normalization of the wdf to the document length. The
+     *		  default value of 1 is suitable for longer queries but it may
+     *		  need to be changed for shorter queries. For more information,
+     *		  please refer to Gianni Amati's PHD thesis.
+     */
+    explicit InL2Weight(double c);
 
-	InL2Weight()
-	: param_c(1.0)
-	{
+    InL2Weight()
+    : param_c(1.0)
+    {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -808,21 +802,21 @@ class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(WQF);
 	need_stat(TERMFREQ);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	InL2Weight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    InL2Weight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterms) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /** This class implements the IfB2 weighting scheme.
@@ -842,35 +836,35 @@ class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
  *  pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
-	/// The wdf normalization parameter in the formula.
-	double param_c;
+    /// The wdf normalization parameter in the formula.
+    double param_c;
 
-	/// The upper bound on the weight.
-	double upper_bound;
+    /// The upper bound on the weight.
+    double upper_bound;
 
-	/// The constant values which are used for calculations in get_sumpart().
-	double wqf_product_idf;
-	double c_product_avlen;
-	double B_constant;
+    /// The constant values which are used for calculations in get_sumpart().
+    double wqf_product_idf;
+    double c_product_avlen;
+    double B_constant;
 
-	IfB2Weight * clone() const;
+    IfB2Weight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct an IfB2Weight.
-	 *
-	 *  @param c  A non-negative and non zero parameter controlling the extent
-	 *		of the normalization of the wdf to the document length. The
-	 *		default value of 1 is suitable for longer queries but it may
-	 *		need to be changed for shorter queries. For more information,
-	 *		please refer to Gianni Amati's PHD thesis titled
-	 *		Probabilistic Models for Information Retrieval based on
-	 *		Divergence from Randomness.
-	 */
-	explicit IfB2Weight(double c);
+    /** Construct an IfB2Weight.
+     *
+     *  @param c  A non-negative and non zero parameter controlling the extent
+     *		  of the normalization of the wdf to the document length. The
+     *		  default value of 1 is suitable for longer queries but it may
+     *		  need to be changed for shorter queries. For more information,
+     *		  please refer to Gianni Amati's PHD thesis titled
+     *		  Probabilistic Models for Information Retrieval based on
+     *		  Divergence from Randomness.
+     */
+    explicit IfB2Weight(double c);
 
-	IfB2Weight( ) : param_c(1.0) {
+    IfB2Weight( ) : param_c(1.0) {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -881,21 +875,21 @@ class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(WQF);
 	need_stat(TERMFREQ);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	IfB2Weight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    IfB2Weight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterm) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterm) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /** This class implements the IneB2 weighting scheme.
@@ -915,33 +909,33 @@ class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
  *  pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
-	/// The wdf normalization parameter in the formula.
-	double param_c;
+    /// The wdf normalization parameter in the formula.
+    double param_c;
 
-	/// The upper bound of the weight.
-	double upper_bound;
+    /// The upper bound of the weight.
+    double upper_bound;
 
-	/// Constant values used in get_sumpart().
-	double wqf_product_idf;
-	double c_product_avlen;
-	double B_constant;
+    /// Constant values used in get_sumpart().
+    double wqf_product_idf;
+    double c_product_avlen;
+    double B_constant;
 
-	IneB2Weight * clone() const;
+    IneB2Weight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct an IneB2Weight.
-	 *
-	 *  @param c  A non-negative and non zero parameter controlling the extent
-	 *		of the normalization of the wdf to the document length. The
-	 *		default value of 1 is suitable for longer queries but it may
-	 *		need to be changed for shorter queries. For more information,
-	 *		please refer to Gianni Amati's PHD thesis.
-	 */
-	explicit IneB2Weight(double c);
+    /** Construct an IneB2Weight.
+     *
+     *  @param c  A non-negative and non zero parameter controlling the extent
+     *		  of the normalization of the wdf to the document length. The
+     *		  default value of 1 is suitable for longer queries but it may
+     *		  need to be changed for shorter queries. For more information,
+     *		  please refer to Gianni Amati's PHD thesis.
+     */
+    explicit IneB2Weight(double c);
 
-	IneB2Weight( ) : param_c(1.0) {
+    IneB2Weight( ) : param_c(1.0) {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -952,21 +946,21 @@ class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
 	need_stat(WQF);
 	need_stat(COLLECTION_FREQ);
 	need_stat(TERMFREQ);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	IneB2Weight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    IneB2Weight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterms) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /** This class implements the BB2 weighting scheme.
@@ -987,37 +981,37 @@ class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
  *  pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
-	/// The wdf normalization parameter in the formula.
-	double param_c;
+    /// The wdf normalization parameter in the formula.
+    double param_c;
 
-	/// The upper bound on the weight.
-	double upper_bound;
+    /// The upper bound on the weight.
+    double upper_bound;
 
-	/// The constant values to be used in get_sumpart().
-	double c_product_avlen;
-	double B_constant;
-	double wt;
-	double stirling_constant_1;
-	double stirling_constant_2;
+    /// The constant values to be used in get_sumpart().
+    double c_product_avlen;
+    double B_constant;
+    double wt;
+    double stirling_constant_1;
+    double stirling_constant_2;
 
-	BB2Weight * clone() const;
+    BB2Weight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct a BB2Weight.
-	 *
-	 *  @param c  A non-negative and non zero parameter controlling the extent
-	 *		of the normalization of the wdf to the document length. A
-	 *		default value of 1 is suitable for longer queries but it may
-	 *		need to be changed for shorter queries. For more information,
-	 *		please refer to Gianni Amati's PHD thesis titled
-	 *		Probabilistic Models for Information Retrieval based on
-	 *		Divergence from Randomness.
-	 */
-	explicit BB2Weight(double c);
+    /** Construct a BB2Weight.
+     *
+     *  @param c  A non-negative and non zero parameter controlling the extent
+     *		  of the normalization of the wdf to the document length. A
+     *		  default value of 1 is suitable for longer queries but it may
+     *		  need to be changed for shorter queries. For more information,
+     *		  please refer to Gianni Amati's PHD thesis titled
+     *		  Probabilistic Models for Information Retrieval based on
+     *		  Divergence from Randomness.
+     */
+    explicit BB2Weight(double c);
 
-	BB2Weight( ) : param_c(1.0) {
+    BB2Weight( ) : param_c(1.0) {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -1028,21 +1022,21 @@ class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(WQF);
 	need_stat(TERMFREQ);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	BB2Weight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    BB2Weight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterms) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /** This class implements the DLH weighting scheme, which is a representative
@@ -1063,22 +1057,22 @@ class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
  *  Proceedings of the 16th Text REtrieval Conference (TREC-2007), 2008.
  */
 class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
-	/// The lower bound on the weight.
-	double lower_bound;
+    /// The lower bound on the weight.
+    double lower_bound;
 
-	/// The upper bound on the weight.
-	double upper_bound;
+    /// The upper bound on the weight.
+    double upper_bound;
 
-	/// The constant value to be used in get_sumpart().
-	double log_constant;
-	double wqf_product_factor;
+    /// The constant value to be used in get_sumpart().
+    double log_constant;
+    double wqf_product_factor;
 
-	DLHWeight * clone() const;
+    DLHWeight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	DLHWeight() {
+    DLHWeight() {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(COLLECTION_SIZE);
@@ -1088,21 +1082,21 @@ class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(DOC_LENGTH_MIN);
 	need_stat(DOC_LENGTH_MAX);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	DLHWeight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    DLHWeight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterms) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /** This class implements the PL2 weighting scheme.
@@ -1124,39 +1118,39 @@ class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
  *  ACM Transactions on Information Systems (TOIS) 20, (4), 2002, pp. 357-389.
  */
 class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
-	/// The wdf normalization parameter in the formula.
-	double param_c;
+    /// The wdf normalization parameter in the formula.
+    double param_c;
 
-	/// The lower bound of the weight.
-	double lower_bound;
+    /// The lower bound of the weight.
+    double lower_bound;
 
-	/// The upper bound on the weight.
-	double upper_bound;
+    /// The upper bound on the weight.
+    double upper_bound;
 
-	/// Constants for a given term in a given query.
-	double P1, P2;
+    /// Constants for a given term in a given query.
+    double P1, P2;
 
-	/// Set by init() to (param_c * get_average_length())
-	double cl;
+    /// Set by init() to (param_c * get_average_length())
+    double cl;
 
-	PL2Weight * clone() const;
+    PL2Weight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct a PL2Weight.
-	 *
-	 *  @param c  A non-negative and non zero parameter controlling the extent
-	 *		of the normalization of the wdf to the document length. The
-	 *		default value of 1 is suitable for longer queries but it may
-	 *		need to be changed for shorter queries. For more information,
-	 *		please refer to Gianni Amati's PHD thesis titled
-	 *		Probabilistic Models for Information Retrieval based on
-	 *		Divergence from Randomness.
-	 */
-	explicit PL2Weight(double c);
+    /** Construct a PL2Weight.
+     *
+     *  @param c  A non-negative and non zero parameter controlling the extent
+     *		  of the normalization of the wdf to the document length. The
+     *		  default value of 1 is suitable for longer queries but it may
+     *		  need to be changed for shorter queries. For more information,
+     *		  please refer to Gianni Amati's PHD thesis titled
+     *		  Probabilistic Models for Information Retrieval based on
+     *		  Divergence from Randomness.
+     */
+    explicit PL2Weight(double c);
 
-	PL2Weight( ) : param_c(1.0) {
+    PL2Weight( ) : param_c(1.0) {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
@@ -1166,21 +1160,21 @@ class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
 	need_stat(WDF);
 	need_stat(WDF_MAX);
 	need_stat(WQF);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	PL2Weight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    PL2Weight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterms) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 /** This class implements the DPH weighting scheme.
@@ -1203,23 +1197,23 @@ class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
  *  Proceedings of the 16th Text Retrieval Conference (TREC-2007), 2008.
  */
 class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
-	/// The upper bound on the weight.
-	double upper_bound;
+    /// The upper bound on the weight.
+    double upper_bound;
 
-	/// The lower bound on the weight.
-	double lower_bound;
+    /// The lower bound on the weight.
+    double lower_bound;
 
-	/// The constant value used in get_sumpart() .
-	double log_constant;
-	double wqf_product_factor;
+    /// The constant value used in get_sumpart() .
+    double log_constant;
+    double wqf_product_factor;
 
-	DPHWeight * clone() const;
+    DPHWeight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct a DPHWeight. */
-	DPHWeight() {
+    /** Construct a DPHWeight. */
+    DPHWeight() {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(COLLECTION_SIZE);
@@ -1229,21 +1223,21 @@ class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(DOC_LENGTH_MIN);
 	need_stat(DOC_LENGTH_MAX);
-	}
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	DPHWeight * unserialise(const std::string & serialised) const;
+    std::string serialise() const;
+    DPHWeight * unserialise(const std::string & serialised) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterms) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterms) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen,
-		Xapian::termcount uniqterms) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount uniqterms) const;
+    double get_maxextra() const;
 };
 
 
@@ -1258,57 +1252,57 @@ class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
  */
 class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 
-	/** The type of smoothing to use. */
-	type_smoothing select_smoothing;
+    /** The type of smoothing to use. */
+    type_smoothing select_smoothing;
 
-	// Parameters for handling negative value of log, and for smoothing.
-	double param_log, param_smoothing1, param_smoothing2;
+    // Parameters for handling negative value of log, and for smoothing.
+    double param_log, param_smoothing1, param_smoothing2;
 
-	// Collection weight.
-	double weight_collection;
+    // Collection weight.
+    double weight_collection;
 
-	LMWeight * clone() const;
+    LMWeight * clone() const;
 
-	void init(double factor);
+    void init(double factor);
 
   public:
-	/** Construct a LMWeight.
-	 *
-	 *  @param param_log_   A non-negative parameter controlling how much
-	 *			  to clamp negative values returned by the log.
-	 *			  The log is calculated by multiplying the
-	 *			  actual weight by param_log.  If param_log is
-	 *			  0.0, then the document length upper bound will
-	 *			  be used (default: document length upper bound)
-	 *
-	 *  @param select_smoothing_	A parameter of type enum
-	 *				  type_smoothing.  This parameter
-	 *				  controls which smoothing type to use.
-	 *				  (default: TWO_STAGE_SMOOTHING)
-	 *
-	 *  @param param_smoothing1_	A non-negative parameter for smoothing
-	 *				  whose meaning depends on
-	 *				  select_smoothing_.  In
-	 *				  JELINEK_MERCER_SMOOTHING, it plays the
-	 *				  role of estimation and in
-	 *				  DIRICHLET_SMOOTHING the role of query
-	 *				  modelling. (default JELINEK_MERCER,
-	 *				  ABSOLUTE, TWOSTAGE(0.7),
-	 *				  DIRCHLET(2000))
-	 *
-	 *  @param param_smoothing2_	A non-negative parameter which is used
-	 *				  only with TWO_STAGE_SMOOTHING as
-	 *				  parameter for Dirichlet's smoothing.
-	 *				  (default: 2000)
-	 */
-	// Unigram LM Constructor to specifically mention all parameters for handling negative log value and smoothing.
-	explicit LMWeight(double param_log_ = 0.0,
-		  type_smoothing select_smoothing_ = TWO_STAGE_SMOOTHING,
-		  double param_smoothing1_ = 0.7,
-		  double param_smoothing2_ = 2000.0)
+    /** Construct a LMWeight.
+     *
+     *  @param param_log_	A non-negative parameter controlling how much
+     *				to clamp negative values returned by the log.
+     *				The log is calculated by multiplying the
+     *				actual weight by param_log.  If param_log is
+     *				0.0, then the document length upper bound will
+     *				be used (default: document length upper	bound)
+     *
+     *  @param select_smoothing_	A parameter of type enum
+     *					type_smoothing.  This parameter
+     *					controls which smoothing type to use.
+     *					(default: TWO_STAGE_SMOOTHING)
+     *
+     *  @param param_smoothing1_	A non-negative parameter for smoothing
+     *					whose meaning depends on
+     *					select_smoothing_.  In
+     *					JELINEK_MERCER_SMOOTHING, it plays the
+     *					role of estimation and in
+     *					DIRICHLET_SMOOTHING the role of query
+     *					modelling. (default JELINEK_MERCER,
+     *					ABSOLUTE, TWOSTAGE(0.7),
+     *					DIRCHLET(2000))
+     *
+     *  @param param_smoothing2_	A non-negative parameter which is used
+     *					only with TWO_STAGE_SMOOTHING as
+     *					parameter for Dirichlet's smoothing.
+     *					(default: 2000)
+     */
+    // Unigram LM Constructor to specifically mention all parameters for handling negative log value and smoothing.
+    explicit LMWeight(double param_log_ = 0.0,
+		      type_smoothing select_smoothing_ = TWO_STAGE_SMOOTHING,
+		      double param_smoothing1_ = 0.7,
+		      double param_smoothing2_ = 2000.0)
 	: select_smoothing(select_smoothing_), param_log(param_log_), param_smoothing1(param_smoothing1_),
 	  param_smoothing2(param_smoothing2_)
-	{
+    {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(COLLECTION_SIZE);
@@ -1320,23 +1314,24 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 	need_stat(WDF_MAX);
 	need_stat(COLLECTION_FREQ);
 	if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING)
-	need_stat(UNIQUE_TERMS);
-	}
+	    need_stat(UNIQUE_TERMS);
+    }
 
-	std::string name() const;
+    std::string name() const;
 
-	std::string serialise() const;
-	LMWeight * unserialise(const std::string & s) const;
+    std::string serialise() const;
+    LMWeight * unserialise(const std::string & s) const;
 
-	double get_sumpart(Xapian::termcount wdf,
-		   Xapian::termcount doclen,
-		   Xapian::termcount uniqterm) const;
-	double get_maxpart() const;
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqterm) const;
+    double get_maxpart() const;
 
-	double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const;
-	double get_maxextra() const;
+    double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const;
+    double get_maxextra() const;
 };
 
 }
 
 #endif // XAPIAN_INCLUDED_WEIGHT_H
+

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1334,4 +1334,3 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 }
 
 #endif // XAPIAN_INCLUDED_WEIGHT_H
-

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -592,12 +592,11 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
 
 /// Xapian::Weight subclass implementing the BM25+ probabilistic formula.
 class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
-
   public:
     /** Construct a BM25PlusWeight.
      *
      *  @param delta  A parameter for pseudo tf value to control the scale
-     *		      of the tf lower bound. Delta(δ) can be tuned for e.g
+     *		      of the tf lower bound. Delta(δ) can be tuned for example
      *		      from 0.0 to 1.5 but BM25+ can still work effectively
      *		      across collections with a fixed δ = 1.0. (default 1.0)
      */

--- a/xapian-core/tests/api_nodb.cc
+++ b/xapian-core/tests/api_nodb.cc
@@ -300,14 +300,14 @@ DEFINE_TESTCASE(weight1, !backend) {
     TEST_NOT_EQUAL(bm25weight.serialise(), bm25weight2.serialise());
 
     Xapian::BM25PlusWeight bm25plusweight_dflt;
-    Xapian::BM25PlusWeight bm25plusweight(1, 0, 1, 0.5, 0.5, 1.0);
+    Xapian::BM25PlusWeight bm25plusweight(1, 1, 0.5, 0.5, 1.0);
     TEST_EQUAL(bm25plusweight.name(), "Xapian::BM25PlusWeight");
     TEST_EQUAL(bm25plusweight_dflt.serialise(), bm25plusweight.serialise());
     wt = Xapian::BM25PlusWeight().unserialise(bm25plusweight.serialise());
     TEST_EQUAL(bm25plusweight.serialise(), wt->serialise());
     delete wt;
 
-    Xapian::BM25PlusWeight bm25plusweight2(1, 0, 1, 0.5, 0.5, 2.0);
+    Xapian::BM25PlusWeight bm25plusweight2(1, 1, 0.5, 0.5, 2.0);
     TEST_NOT_EQUAL(bm25plusweight.serialise(), bm25plusweight2.serialise());
 
     Xapian::TfIdfWeight tfidfweight_dflt;

--- a/xapian-core/tests/api_nodb.cc
+++ b/xapian-core/tests/api_nodb.cc
@@ -299,6 +299,17 @@ DEFINE_TESTCASE(weight1, !backend) {
     Xapian::BM25Weight bm25weight2(1, 0.5, 1, 0.5, 0.5);
     TEST_NOT_EQUAL(bm25weight.serialise(), bm25weight2.serialise());
 
+    Xapian::BM25PlusWeight bm25plusweight_dflt;
+    Xapian::BM25PlusWeight bm25plusweight(1, 0, 1, 0.5, 0.5, 1.0);
+    TEST_EQUAL(bm25plusweight.name(), "Xapian::BM25PlusWeight");
+    TEST_EQUAL(bm25plusweight_dflt.serialise(), bm25plusweight.serialise());
+    wt = Xapian::BM25PlusWeight().unserialise(bm25plusweight.serialise());
+    TEST_EQUAL(bm25plusweight.serialise(), wt->serialise());
+    delete wt;
+
+    Xapian::BM25PlusWeight bm25plusweight2(1, 0, 1, 0.5, 0.5, 2.0);
+    TEST_NOT_EQUAL(bm25plusweight.serialise(), bm25plusweight2.serialise());
+
     Xapian::TfIdfWeight tfidfweight_dflt;
     Xapian::TfIdfWeight tfidfweight("ntn");
     TEST_EQUAL(tfidfweight.name(), "Xapian::TfIdfWeight");

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -137,16 +137,16 @@ DEFINE_TESTCASE(bm25weight5, backend) {
 DEFINE_TESTCASE(bm25plusweight1, !backend) {
     Xapian::BM25PlusWeight wt(2.0, 0.5, 1.3, 0.6, 0.01, 0.5);
     try {
-    Xapian::BM25PlusWeight b;
-    Xapian::BM25PlusWeight * b2 = b.unserialise(wt.serialise() + "X");
-    // Make sure we actually use the weight.
-    bool empty = b2->name().empty();
-    delete b2;
-    if (empty)
-	FAIL_TEST("Serialised BM25PlusWeight with junk appended unserialised to empty name!");
-    FAIL_TEST("Serialised BM25PlusWeight with junk appended unserialised OK");
+	Xapian::BM25PlusWeight b;
+	Xapian::BM25PlusWeight * b2 = b.unserialise(wt.serialise() + "X");
+	// Make sure we actually use the weight.
+	bool empty = b2->name().empty();
+	delete b2;
+	if (empty)
+	    FAIL_TEST("Serialised BM25PlusWeight with junk appended unserialised to empty name!");
+	FAIL_TEST("Serialised BM25PlusWeight with junk appended unserialised OK");
     } catch (const Xapian::SerialisationError &) {
-    // Good!
+	// Good!
     }
     return true;
 }

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -134,6 +134,66 @@ DEFINE_TESTCASE(bm25weight5, backend) {
 }
 
 // Test exception for junk after serialised weight.
+DEFINE_TESTCASE(bm25plusweight3, !backend) {
+    Xapian::BM25PlusWeight wt(2.0, 0.5, 1.3, 0.6, 0.01, 0.5);
+    try {
+    Xapian::BM25PlusWeight b;
+    Xapian::BM25PlusWeight * b2 = b.unserialise(wt.serialise() + "X");
+    // Make sure we actually use the weight.
+    bool empty = b2->name().empty();
+    delete b2;
+    if (empty)
+	FAIL_TEST("Serialised BM25PlusWeight with junk appended unserialised to empty name!");
+    FAIL_TEST("Serialised BM25PlusWeight with junk appended unserialised OK");
+    } catch (const Xapian::SerialisationError &) {
+    // Good!
+    }
+    return true;
+}
+
+// Test parameter combinations which should be unaffected by doclength.
+DEFINE_TESTCASE(bm25plusweight4, backend) {
+    Xapian::Database db = get_database("apitest_simpledata");
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("paragraph"));
+    Xapian::MSet mset;
+
+    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(1, 0, 1, 0, 0.5, 1));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 5);
+    // Expect: wdf has an effect on weight, but doclen doesn't.
+    TEST_REL(mset[0].get_weight(),>,mset[1].get_weight());
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), mset[2].get_weight());
+    TEST_REL(mset[2].get_weight(),>,mset[3].get_weight());
+    TEST_EQUAL_DOUBLE(mset[3].get_weight(), mset[4].get_weight());
+
+    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(0, 0, 1, 1, 0.5, 1));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 5);
+    // Expect: neither wdf nor doclen affects weight.
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), mset[4].get_weight());
+
+    return true;
+}
+
+// Test to make sure k2 has no effect on weight. This is necessary because
+// k2 is associated with extra weight component and BM25+ has such no extra weight.
+DEFINE_TESTCASE(bm25plusweight5, backend) {
+    Xapian::Database db = get_database("apitest_simpledata");
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("paragraph"));
+    Xapian::MSet mset;
+
+    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(0, 1, 1, 0.5, 0.5, 1));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 5);
+
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), mset[4].get_weight());
+
+    return true;
+}
+
+// Test exception for junk after serialised weight.
 DEFINE_TESTCASE(inl2weight1, !backend) {
     Xapian::InL2Weight wt(2.0);
     try {

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -176,19 +176,24 @@ DEFINE_TESTCASE(bm25plusweight2, backend) {
     return true;
 }
 
-// Test to make sure k2 has no effect on weight. This is necessary because
-// k2 is associated with extra weight component and BM25+ has such no extra weight.
+// Regression test for a mistake corrected in the BM25+ implementation.
 DEFINE_TESTCASE(bm25plusweight3, backend) {
     Xapian::Database db = get_database("apitest_simpledata");
     Xapian::Enquire enquire(db);
     enquire.set_query(Xapian::Query("paragraph"));
     Xapian::MSet mset;
 
-    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(0, 1, 0.5, 0.5, 1));
+    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(1, 1, 0.5, 0.5, 1));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 5);
 
-    TEST_EQUAL_DOUBLE(mset[0].get_weight(), mset[4].get_weight());
+    // The value of each doc weight calculated manually from the BM25+ formulae
+    // by using the respective document statistics.
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 0.954493799782531);
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 0.945598645461975);
+    TEST_EQUAL_DOUBLE(mset[2].get_weight(), 0.910873608950458);
+    TEST_EQUAL_DOUBLE(mset[3].get_weight(), 0.868853803088924);
+    TEST_EQUAL_DOUBLE(mset[4].get_weight(), 0.868853803088924);
 
     return true;
 }

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -135,7 +135,7 @@ DEFINE_TESTCASE(bm25weight5, backend) {
 
 // Test exception for junk after serialised weight.
 DEFINE_TESTCASE(bm25plusweight1, !backend) {
-    Xapian::BM25PlusWeight wt(2.0, 0.5, 1.3, 0.6, 0.01, 0.5);
+    Xapian::BM25PlusWeight wt(2.0, 1.3, 0.6, 0.01, 0.5);
     try {
 	Xapian::BM25PlusWeight b;
 	Xapian::BM25PlusWeight * b2 = b.unserialise(wt.serialise() + "X");
@@ -158,7 +158,7 @@ DEFINE_TESTCASE(bm25plusweight2, backend) {
     enquire.set_query(Xapian::Query("paragraph"));
     Xapian::MSet mset;
 
-    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(1, 0, 1, 0, 0.5, 1));
+    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(1, 1, 0, 0.5, 1));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 5);
     // Expect: wdf has an effect on weight, but doclen doesn't.
@@ -167,7 +167,7 @@ DEFINE_TESTCASE(bm25plusweight2, backend) {
     TEST_REL(mset[2].get_weight(),>,mset[3].get_weight());
     TEST_EQUAL_DOUBLE(mset[3].get_weight(), mset[4].get_weight());
 
-    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(0, 0, 1, 1, 0.5, 1));
+    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(0, 1, 1, 0.5, 1));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 5);
     // Expect: neither wdf nor doclen affects weight.
@@ -184,7 +184,7 @@ DEFINE_TESTCASE(bm25plusweight3, backend) {
     enquire.set_query(Xapian::Query("paragraph"));
     Xapian::MSet mset;
 
-    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(0, 1, 1, 0.5, 0.5, 1));
+    enquire.set_weighting_scheme(Xapian::BM25PlusWeight(0, 1, 0.5, 0.5, 1));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 5);
 

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -134,7 +134,7 @@ DEFINE_TESTCASE(bm25weight5, backend) {
 }
 
 // Test exception for junk after serialised weight.
-DEFINE_TESTCASE(bm25plusweight3, !backend) {
+DEFINE_TESTCASE(bm25plusweight1, !backend) {
     Xapian::BM25PlusWeight wt(2.0, 0.5, 1.3, 0.6, 0.01, 0.5);
     try {
     Xapian::BM25PlusWeight b;
@@ -152,7 +152,7 @@ DEFINE_TESTCASE(bm25plusweight3, !backend) {
 }
 
 // Test parameter combinations which should be unaffected by doclength.
-DEFINE_TESTCASE(bm25plusweight4, backend) {
+DEFINE_TESTCASE(bm25plusweight2, backend) {
     Xapian::Database db = get_database("apitest_simpledata");
     Xapian::Enquire enquire(db);
     enquire.set_query(Xapian::Query("paragraph"));
@@ -178,7 +178,7 @@ DEFINE_TESTCASE(bm25plusweight4, backend) {
 
 // Test to make sure k2 has no effect on weight. This is necessary because
 // k2 is associated with extra weight component and BM25+ has such no extra weight.
-DEFINE_TESTCASE(bm25plusweight5, backend) {
+DEFINE_TESTCASE(bm25plusweight3, backend) {
     Xapian::Database db = get_database("apitest_simpledata");
     Xapian::Enquire enquire(db);
     enquire.set_query(Xapian::Query("paragraph"));

--- a/xapian-core/weight/Makefile.mk
+++ b/xapian-core/weight/Makefile.mk
@@ -7,6 +7,7 @@ EXTRA_DIST +=\
 lib_src +=\
 	weight/bb2weight.cc\
 	weight/bm25weight.cc\
+	weight/bm25plusweight.cc\
 	weight/boolweight.cc\
 	weight/dlhweight.cc\
 	weight/dphweight.cc\

--- a/xapian-core/weight/Makefile.mk
+++ b/xapian-core/weight/Makefile.mk
@@ -6,8 +6,8 @@ EXTRA_DIST +=\
 
 lib_src +=\
 	weight/bb2weight.cc\
-	weight/bm25weight.cc\
 	weight/bm25plusweight.cc\
+	weight/bm25weight.cc\
 	weight/boolweight.cc\
 	weight/dlhweight.cc\
 	weight/dphweight.cc\
@@ -16,7 +16,7 @@ lib_src +=\
 	weight/inl2weight.cc\
 	weight/lmweight.cc\
 	weight/pl2weight.cc\
-	weight/tradweight.cc\
 	weight/tfidfweight.cc\
+	weight/tradweight.cc\
 	weight/weight.cc\
 	weight/weightinternal.cc

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -109,7 +109,7 @@ BM25PlusWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
     // Parameter delta (δ) is a pseudo tf value to control the scale of the
     // tf lower bound. δ can be tuned for e.g from 0.0 to 1.5 but BM25+ can
     // still work effectively across collections with a fixed δ = 1.0
-    RETURN((termweight * ((((param_k1 + 1) * wdf_double) / denom) + param_delta)));
+    RETURN(termweight * ((param_k1 + 1) * wdf_double / denom + param_delta));
 }
 
 double
@@ -135,7 +135,7 @@ BM25PlusWeight::get_maxpart() const
     double wdf_max = get_wdf_upper_bound();
     denom += wdf_max;
     AssertRel(denom,>,0);
-    RETURN((termweight * ((((param_k1 + 1) * wdf_max) / denom) + param_delta)));
+    RETURN(termweight * ((param_k1 + 1) * wdf_max / denom + param_delta));
 }
 
 // No extra per document component in the BM25+ Weighting formula.

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -62,6 +62,19 @@ BM25PlusWeight::init(double factor)
     }
 
     LOGVALUE(WTCALC, termweight);
+
+    if (param_b == 0 || param_k1 == 0) {
+	// If either param_b or param_k1 is 0 then the document
+	// length doesn't affect the weight.
+	len_factor = 0;
+    } else {
+	len_factor = get_average_length();
+	// len_factor can be zero if all documents are empty (or the database
+	// is empty!)
+	if (len_factor != 0) len_factor = 1 / len_factor;
+    }
+
+    LOGVALUE(WTCALC, len_factor);
 }
 
 string

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -39,7 +39,7 @@ namespace Xapian {
 BM25PlusWeight *
 BM25PlusWeight::clone() const
 {
-    return new BM25PlusWeight(param_k1, param_k2, param_k3, param_b,
+    return new BM25PlusWeight(param_k1, param_k3, param_b,
 			      param_min_normlen, param_delta);
 }
 
@@ -75,7 +75,6 @@ string
 BM25PlusWeight::serialise() const
 {
     string result = serialise_double(param_k1);
-    result += serialise_double(param_k2);
     result += serialise_double(param_k3);
     result += serialise_double(param_b);
     result += serialise_double(param_min_normlen);
@@ -89,14 +88,13 @@ BM25PlusWeight::unserialise(const string & s) const
     const char *ptr = s.data();
     const char *end = ptr + s.size();
     double k1 = unserialise_double(&ptr, end);
-    double k2 = unserialise_double(&ptr, end);
     double k3 = unserialise_double(&ptr, end);
     double b = unserialise_double(&ptr, end);
     double min_normlen = unserialise_double(&ptr, end);
     double delta = unserialise_double(&ptr, end);
     if (rare(ptr != end))
 	throw Xapian::SerialisationError("Extra data in BM25PlusWeight::unserialise()");
-    return new BM25PlusWeight(k1, k2, k3, b, min_normlen, delta);
+    return new BM25PlusWeight(k1, k3, b, min_normlen, delta);
 }
 
 double

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -38,96 +38,91 @@ namespace Xapian {
 BM25PlusWeight *
 BM25PlusWeight::clone() const
 {
-	return new BM25PlusWeight(param_k1, param_k2, param_k3, param_b,
-							  param_min_normlen, param_delta);
-} 
+    return new BM25PlusWeight(param_k1, param_k2, param_k3, param_b,
+			      param_min_normlen, param_delta);
+}
 
 void
 BM25PlusWeight::init(double factor)
 {
-	Xapian::doccount tf = get_termfreq();
+    Xapian::doccount tf = get_termfreq();
 
-	double tw = 0;
-	// BM25+ formula gives termweight = (total_no_of_docs + 1) / tf
-	if (tf != 0) tw = (get_collection_size() + 1) / tf;
+    double tw = 0;
+    // BM25+ formula gives termweight = (total_no_of_docs + 1) / tf
+    if (tf != 0) tw = (get_collection_size() + 1) / tf;
 
-	AssertRel(tw,>,0);
+    AssertRel(tw,>,0);
 
-	if (tw < 2) tw = tw * 0.5 + 1;
-	termweight = log(tw) * factor;
-	if (param_k3 != 0) {
+    if (tw < 2) tw = tw * 0.5 + 1;
+    termweight = log(tw) * factor;
+    if (param_k3 != 0) {
 	double wqf_double = get_wqf();
 	termweight *= (param_k3 + 1) * wqf_double / (param_k3 + wqf_double);
-	}
-	termweight *= (param_k1 + 1);
+    }
+    termweight *= (param_k1 + 1);
 
-	LOGVALUE(WTCALC, termweight);
+    LOGVALUE(WTCALC, termweight);
 
 }
 
 string
 BM25PlusWeight::name() const
 {
-	return "Xapian::BM25PlusWeight";
+    return "Xapian::BM25PlusWeight";
 }
 
 string
 BM25PlusWeight::serialise() const
 {
-	string result = serialise_double(param_k1);
-	result += serialise_double(param_k2);
-	result += serialise_double(param_k3);
-	result += serialise_double(param_b);
-	result += serialise_double(param_min_normlen);
-	result += serialise_double(param_delta);
-	return result;
+    string result = serialise_double(param_k1);
+    result += serialise_double(param_k2);
+    result += serialise_double(param_k3);
+    result += serialise_double(param_b);
+    result += serialise_double(param_min_normlen);
+    result += serialise_double(param_delta);
+    return result;
 }
 
 BM25PlusWeight *
 BM25PlusWeight::unserialise(const string & s) const
 {
-	const char *ptr = s.data();
-	const char *end = ptr + s.size();
-	double k1 = unserialise_double(&ptr, end);
-	double k2 = unserialise_double(&ptr, end);
-	double k3 = unserialise_double(&ptr, end);
-	double b = unserialise_double(&ptr, end);
-	double min_normlen = unserialise_double(&ptr, end);
-	double delta = unserialise_double(&ptr, end);
-	if (rare(ptr != end))
-		throw Xapian::SerialisationError("Extra data in BM25PlusWeight::unserialise()");
-	return new BM25PlusWeight(k1, k2, k3, b, min_normlen, delta);
+    const char *ptr = s.data();
+    const char *end = ptr + s.size();
+    double k1 = unserialise_double(&ptr, end);
+    double k2 = unserialise_double(&ptr, end);
+    double k3 = unserialise_double(&ptr, end);
+    double b = unserialise_double(&ptr, end);
+    double min_normlen = unserialise_double(&ptr, end);
+    double delta = unserialise_double(&ptr, end);
+    if (rare(ptr != end))
+	throw Xapian::SerialisationError("Extra data in BM25PlusWeight::unserialise()");
+    return new BM25PlusWeight(k1, k2, k3, b, min_normlen, delta);
 }
 
 double
 BM25PlusWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
 							Xapian::termcount) const
 {
-	LOGCALL(WTCALC, double, "BM25PlusWeight::get_sumpart", wdf | len);
-	Xapian::doclength normlen = max(len * len_factor, param_min_normlen);
+    LOGCALL(WTCALC, double, "BM25PlusWeight::get_sumpart", wdf | len);
+    Xapian::doclength normlen = max(len * len_factor, param_min_normlen);
 
-	double wdf_double = wdf;
-	double denom = param_k1 * (normlen * param_b + (1 - param_b)) + wdf_double;
-	AssertRel(denom,>,0);
-
-	if (bm25_plus) {
-		// Parameter delta (δ) is a pseudo tf value to control the scale of the
-		// tf lower bound. δ can be tuned for e.g from 0.0 to 1.5 but BM25+ can
-	// still work effectively across collections with a fixed δ = 1.0
-		RETURN((termweight * (wdf_double / denom)) + param_delta);
-	} else {
-		RETURN(termweight * (wdf_double / denom));
-	}
+    double wdf_double = wdf;
+    double denom = param_k1 * (normlen * param_b + (1 - param_b)) + wdf_double;
+    AssertRel(denom,>,0);
+    // Parameter delta (δ) is a pseudo tf value to control the scale of the
+    // tf lower bound. δ can be tuned for e.g from 0.0 to 1.5 but BM25+ can
+    // still work effectively across collections with a fixed δ = 1.0
+    RETURN((termweight * (wdf_double / denom)) + param_delta);
 }
 
 double
 BM25PlusWeight::get_maxpart() const
 {
-	LOGCALL(WTCALC, double, "BM25PlusWeight::get_maxpart", NO_ARGS);
-	double denom = param_k1;
-	if (param_k1 != 0.0) {
+    LOGCALL(WTCALC, double, "BM25PlusWeight::get_maxpart", NO_ARGS);
+    double denom = param_k1;
+    if (param_k1 != 0.0) {
 	if (param_b != 0.0) {
-		// "Upper-bound Approximations for Dynamic Pruning" Craig
+	    // "Upper-bound Approximations for Dynamic Pruning" Craig
 	    // Macdonald, Nicola Tonellotto and Iadh Ounis. ACM Transactions on
 	    // Information Systems. 29(4), 2011 shows that evaluating at
 	    // doclen=wdf_max is a good bound.
@@ -136,32 +131,27 @@ BM25PlusWeight::get_maxpart() const
 	    // better bound can be found by simply evaluating at
 	    // doclen=doclen_min and wdf=wdf_max.
 	    Xapian::doclength normlen_lb =
-			max(max(get_wdf_upper_bound(), get_doclength_lower_bound()) * len_factor, param_min_normlen);
-		denom *= (normlen_lb * param_b + (1 - param_b));
+		 max(max(get_wdf_upper_bound(), get_doclength_lower_bound()) * len_factor, param_min_normlen);
+	    denom *= (normlen_lb * param_b + (1 - param_b));
 	}
-	}
-	double wdf_max = get_wdf_upper_bound();
-	denom += wdf_max;
-	AssertRel(denom,>,0);
-
-	if (bm25_plus) {
-		RETURN((termweight * (wdf_max / denom)) + 1.0);
-	} else {
-		RETURN(termweight * (wdf_max / denom));
-	}
+    }
+    double wdf_max = get_wdf_upper_bound();
+    denom += wdf_max;
+    AssertRel(denom,>,0);
+    RETURN((termweight * (wdf_max / denom)) + 1.0);
 }
 
 // No extra per document component in the BM25+ Weighting formula.
 double
 BM25PlusWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
 {
-	return 0;
+    return 0;
 }
 
 double
 BM25PlusWeight::get_maxextra() const
 {
-	return 0;
+    return 0;
 }
 
 }

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -63,7 +63,6 @@ BM25PlusWeight::init(double factor)
     termweight *= (param_k1 + 1);
 
     LOGVALUE(WTCALC, termweight);
-
 }
 
 string
@@ -102,7 +101,7 @@ BM25PlusWeight::unserialise(const string & s) const
 
 double
 BM25PlusWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-							Xapian::termcount) const
+			    Xapian::termcount) const
 {
     LOGCALL(WTCALC, double, "BM25PlusWeight::get_sumpart", wdf | len);
     Xapian::doclength normlen = max(len * len_factor, param_min_normlen);

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -1,7 +1,8 @@
 /** @file bm25plusweight.cc
  * @brief Xapian::BM25PlusWeight class - the BM25+ probabilistic formula
  */
-/* Copyright (C) 2016  Vivek Pal
+/* Copyright (C) 2009,2010,2011,2012,2014,2015 Olly Betts
+ * Copyright (C) 2016  Vivek Pal
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -1,0 +1,167 @@
+/** @file bm25plusweight.cc
+ * @brief Xapian::BM25PlusWeight class - the BM25+ probabilistic formula
+ */
+/* Copyright (C) 2016  Vivek Pal
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "xapian/weight.h"
+
+#include "debuglog.h"
+#include "omassert.h"
+#include "serialise-double.h"
+
+#include "xapian/error.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace std;
+
+namespace Xapian {
+
+BM25PlusWeight *
+BM25PlusWeight::clone() const
+{
+	return new BM25PlusWeight(param_k1, param_k2, param_k3, param_b,
+							  param_min_normlen, param_delta);
+} 
+
+void
+BM25PlusWeight::init(double factor)
+{
+	Xapian::doccount tf = get_termfreq();
+
+	double tw = 0;
+	// BM25+ formula gives termweight = (total_no_of_docs + 1) / tf
+	if (tf != 0) tw = (get_collection_size() + 1) / tf;
+
+	AssertRel(tw,>,0);
+
+	if (tw < 2) tw = tw * 0.5 + 1;
+	termweight = log(tw) * factor;
+	if (param_k3 != 0) {
+	double wqf_double = get_wqf();
+	termweight *= (param_k3 + 1) * wqf_double / (param_k3 + wqf_double);
+	}
+	termweight *= (param_k1 + 1);
+
+	LOGVALUE(WTCALC, termweight);
+
+}
+
+string
+BM25PlusWeight::name() const
+{
+	return "Xapian::BM25PlusWeight";
+}
+
+string
+BM25PlusWeight::serialise() const
+{
+	string result = serialise_double(param_k1);
+	result += serialise_double(param_k2);
+	result += serialise_double(param_k3);
+	result += serialise_double(param_b);
+	result += serialise_double(param_min_normlen);
+	result += serialise_double(param_delta);
+	return result;
+}
+
+BM25PlusWeight *
+BM25PlusWeight::unserialise(const string & s) const
+{
+	const char *ptr = s.data();
+	const char *end = ptr + s.size();
+	double k1 = unserialise_double(&ptr, end);
+	double k2 = unserialise_double(&ptr, end);
+	double k3 = unserialise_double(&ptr, end);
+	double b = unserialise_double(&ptr, end);
+	double min_normlen = unserialise_double(&ptr, end);
+	double delta = unserialise_double(&ptr, end);
+	if (rare(ptr != end))
+		throw Xapian::SerialisationError("Extra data in BM25PlusWeight::unserialise()");
+	return new BM25PlusWeight(k1, k2, k3, b, min_normlen, delta);
+}
+
+double
+BM25PlusWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
+							Xapian::termcount) const
+{
+	LOGCALL(WTCALC, double, "BM25PlusWeight::get_sumpart", wdf | len);
+	Xapian::doclength normlen = max(len * len_factor, param_min_normlen);
+
+	double wdf_double = wdf;
+	double denom = param_k1 * (normlen * param_b + (1 - param_b)) + wdf_double;
+	AssertRel(denom,>,0);
+
+	if (bm25_plus) {
+		// Parameter delta (δ) is a pseudo tf value to control the scale of the
+		// tf lower bound. δ can be tuned for e.g from 0.0 to 1.5 but BM25+ can
+	// still work effectively across collections with a fixed δ = 1.0
+		RETURN((termweight * (wdf_double / denom)) + param_delta);
+	} else {
+		RETURN(termweight * (wdf_double / denom));
+	}
+}
+
+double
+BM25PlusWeight::get_maxpart() const
+{
+	LOGCALL(WTCALC, double, "BM25PlusWeight::get_maxpart", NO_ARGS);
+	double denom = param_k1;
+	if (param_k1 != 0.0) {
+	if (param_b != 0.0) {
+		// "Upper-bound Approximations for Dynamic Pruning" Craig
+	    // Macdonald, Nicola Tonellotto and Iadh Ounis. ACM Transactions on
+	    // Information Systems. 29(4), 2011 shows that evaluating at
+	    // doclen=wdf_max is a good bound.
+	    //
+	    // However, we can do better if doclen_min > wdf_max since then a
+	    // better bound can be found by simply evaluating at
+	    // doclen=doclen_min and wdf=wdf_max.
+	    Xapian::doclength normlen_lb =
+			max(max(get_wdf_upper_bound(), get_doclength_lower_bound()) * len_factor, param_min_normlen);
+		denom *= (normlen_lb * param_b + (1 - param_b));
+	}
+	}
+	double wdf_max = get_wdf_upper_bound();
+	denom += wdf_max;
+	AssertRel(denom,>,0);
+
+	if (bm25_plus) {
+		RETURN((termweight * (wdf_max / denom)) + 1.0);
+	} else {
+		RETURN(termweight * (wdf_max / denom));
+	}
+}
+
+// No extra per document component in the BM25+ Weighting formula.
+double
+BM25PlusWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+{
+	return 0;
+}
+
+double
+BM25PlusWeight::get_maxextra() const
+{
+	return 0;
+}
+
+}

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -60,7 +60,6 @@ BM25PlusWeight::init(double factor)
 	double wqf_double = get_wqf();
 	termweight *= (param_k3 + 1) * wqf_double / (param_k3 + wqf_double);
     }
-    termweight *= (param_k1 + 1);
 
     LOGVALUE(WTCALC, termweight);
 }
@@ -110,7 +109,7 @@ BM25PlusWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
     // Parameter delta (δ) is a pseudo tf value to control the scale of the
     // tf lower bound. δ can be tuned for e.g from 0.0 to 1.5 but BM25+ can
     // still work effectively across collections with a fixed δ = 1.0
-    RETURN((termweight * (wdf_double / denom)) + param_delta);
+    RETURN((termweight * ((((param_k1 + 1) * wdf_double) / denom) + param_delta)));
 }
 
 double
@@ -136,7 +135,7 @@ BM25PlusWeight::get_maxpart() const
     double wdf_max = get_wdf_upper_bound();
     denom += wdf_max;
     AssertRel(denom,>,0);
-    RETURN((termweight * (wdf_max / denom)) + 1.0);
+    RETURN((termweight * ((((param_k1 + 1) * wdf_max) / denom) + param_delta)));
 }
 
 // No extra per document component in the BM25+ Weighting formula.

--- a/xapian-core/weight/bm25weight.cc
+++ b/xapian-core/weight/bm25weight.cc
@@ -228,4 +228,3 @@ BM25Weight::get_maxextra() const
 }
 
 }
-

--- a/xapian-core/weight/bm25weight.cc
+++ b/xapian-core/weight/bm25weight.cc
@@ -38,8 +38,8 @@ namespace Xapian {
 BM25Weight *
 BM25Weight::clone() const
 {
-	return new BM25Weight(param_k1, param_k2, param_k3, param_b,
-			      param_min_normlen);
+    return new BM25Weight(param_k1, param_k2, param_k3, param_b,
+			  param_min_normlen);
 }
 
 void
@@ -71,8 +71,8 @@ BM25Weight::init(double factor)
 	double numerator = (reltermfreq + 0.5) * (Q - tf + 0.5);
 	double denom = (reldocs_not_indexed + 0.5) * (nonreldocs_indexed + 0.5);
 	tw = numerator / denom;
-	} else {
-	     tw = (get_collection_size() - tf + 0.5) / (tf + 0.5);
+    } else {
+	tw = (get_collection_size() - tf + 0.5) / (tf + 0.5);
     }
 
     AssertRel(tw,>,0);
@@ -164,13 +164,13 @@ double
 BM25Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
 			Xapian::termcount) const
 {
-	LOGCALL(WTCALC, double, "BM25Weight::get_sumpart", wdf | len);
-	Xapian::doclength normlen = max(len * len_factor, param_min_normlen);
+    LOGCALL(WTCALC, double, "BM25Weight::get_sumpart", wdf | len);
+    Xapian::doclength normlen = max(len * len_factor, param_min_normlen);
 
-	double wdf_double = wdf;
-	double denom = param_k1 * (normlen * param_b + (1 - param_b)) + wdf_double;
-	AssertRel(denom,>,0);
-	RETURN(termweight * (wdf_double / denom));
+    double wdf_double = wdf;
+    double denom = param_k1 * (normlen * param_b + (1 - param_b)) + wdf_double;
+    AssertRel(denom,>,0);
+    RETURN(termweight * (wdf_double / denom));
 }
 
 double
@@ -196,7 +196,7 @@ BM25Weight::get_maxpart() const
     double wdf_max = get_wdf_upper_bound();
     denom += wdf_max;
     AssertRel(denom,>,0);
-	RETURN(termweight * (wdf_max / denom));
+    RETURN(termweight * (wdf_max / denom));
 }
 
 /* The BM25 formula gives:
@@ -228,3 +228,4 @@ BM25Weight::get_maxextra() const
 }
 
 }
+

--- a/xapian-core/weight/bm25weight.cc
+++ b/xapian-core/weight/bm25weight.cc
@@ -38,8 +38,8 @@ namespace Xapian {
 BM25Weight *
 BM25Weight::clone() const
 {
-    return new BM25Weight(param_k1, param_k2, param_k3, param_b,
-			  param_min_normlen);
+	return new BM25Weight(param_k1, param_k2, param_k3, param_b,
+			      param_min_normlen);
 }
 
 void
@@ -71,8 +71,8 @@ BM25Weight::init(double factor)
 	double numerator = (reltermfreq + 0.5) * (Q - tf + 0.5);
 	double denom = (reldocs_not_indexed + 0.5) * (nonreldocs_indexed + 0.5);
 	tw = numerator / denom;
-    } else {
-	tw = (get_collection_size() - tf + 0.5) / (tf + 0.5);
+	} else {
+	     tw = (get_collection_size() - tf + 0.5) / (tf + 0.5);
     }
 
     AssertRel(tw,>,0);
@@ -164,13 +164,13 @@ double
 BM25Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
 			Xapian::termcount) const
 {
-    LOGCALL(WTCALC, double, "BM25Weight::get_sumpart", wdf | len);
-    Xapian::doclength normlen = max(len * len_factor, param_min_normlen);
+	LOGCALL(WTCALC, double, "BM25Weight::get_sumpart", wdf | len);
+	Xapian::doclength normlen = max(len * len_factor, param_min_normlen);
 
-    double wdf_double = wdf;
-    double denom = param_k1 * (normlen * param_b + (1 - param_b)) + wdf_double;
-    AssertRel(denom,>,0);
-    RETURN(termweight * (wdf_double / denom));
+	double wdf_double = wdf;
+	double denom = param_k1 * (normlen * param_b + (1 - param_b)) + wdf_double;
+	AssertRel(denom,>,0);
+	RETURN(termweight * (wdf_double / denom));
 }
 
 double
@@ -196,7 +196,7 @@ BM25Weight::get_maxpart() const
     double wdf_max = get_wdf_upper_bound();
     denom += wdf_max;
     AssertRel(denom,>,0);
-    RETURN(termweight * (wdf_max / denom));
+	RETURN(termweight * (wdf_max / denom));
 }
 
 /* The BM25 formula gives:


### PR DESCRIPTION
- The original `bm25weight.cc` file that contains implementation of BM25 weighting function is modified to add support for BM25+ weighting function without disturbing existing functionalities of BM25 function. 
- Also, modified existing test cases of BM25 to extend test coverage for BM25+ function.
- Added API support in `weight.h` for the same.

Issue marked as "FIXME" about dealing with negative weights in `bm25weight.cc` that Olly mentioned on IRC is fixed by default when BM25+ is used.  BM25+ can never assign a negative termweight as in BM25+ termweight is calculated as `N+1 / df(t)` which translates to `(total doc in collection + 1) / termfreq` in Xapian terminology. Since, term frequency can't possibly be greater than N so `log((total doc in collection + 1) / termfreq)` can never be negative. I'd say it can be regarded as one of the benefits of BM25+ function.

Please note that I haven't run any automated tests yet using `make check`. Just wanted to get the code reviewed first. Will make sure to run all the tests after getting feedback.