### PR TITLE
Dir+ weighting function implementation.

### DIFF
--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -142,7 +142,8 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
 	TWO_STAGE_SMOOTHING = 1,
 	DIRICHLET_SMOOTHING = 2,
 	ABSOLUTE_DISCOUNT_SMOOTHING = 3,
-	JELINEK_MERCER_SMOOTHING = 4
+	JELINEK_MERCER_SMOOTHING = 4,
+	DIRICHLET_PLUS_SMOOTHING = 5
     } type_smoothing;
 
     class Internal;
@@ -1160,15 +1161,8 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
     /** The type of smoothing to use. */
     type_smoothing select_smoothing;
 
-    // Parameters for handling negative value of log, and for smoothing.
+    // Parameters for handling negative value for smoothing.
     double param_log, param_smoothing1, param_smoothing2;
-
-    // Additional parameter in Dir+ weighting formula.
-    double param_delta;
-
-    // Boolean parameter to control weight calculations when smoothing
-    // is set to Dirichlet.
-    bool enable_dirplus;
 
     // Collection weight.
     double weight_collection;
@@ -1203,28 +1197,19 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
      *					DIRCHLET(2000))
      *
      *  @param param_smoothing2_	A non-negative parameter which is used
-     *					only with TWO_STAGE_SMOOTHING as
-     *					parameter for Dirichlet's smoothing.
-     *					(default: 2000)
+     *					with TWO_STAGE_SMOOTHING as parameter for Dirichlet's
+     *					smoothing (default: 2000) and as parameter delta to
+     *					control the scale of the tf lower bound in the
+     *             			DIRICHLET_PLUS_SMOOTHING (default 0.05).
      *
-     *  @param param_delta_	A non-negative parameter for pseudo tf value to control the scale
-     *		      		of the tf lower bound in the Dir+ scoring funtion. Delta can be tuned
-     *				from 0.0 to 0.15 in increments of 0.01 but it is also advisable to
-     *				fix it to 0.05 for normal use. (default 0.05)
-     *
-     *  @param enable_dirplus_	A boolean parameter to control the weight calculations. It takes
-     *				effect only when smoothing is set to Dirichlet. By default, it is set to
-     *				zero so as to allow normal functioning of Dirichlet smoothing. (default 0)
      */
     // Unigram LM Constructor to specifically mention all parameters for handling negative log value and smoothing.
     explicit LMWeight(double param_log_ = 0.0,
 		      type_smoothing select_smoothing_ = TWO_STAGE_SMOOTHING,
 		      double param_smoothing1_ = 0.7,
-		      double param_smoothing2_ = 2000.0,
-		      double param_delta_ = 0.05,
-		      bool enable_dirplus_ = 0)
+		      double param_smoothing2_ = 2000.0)
 	: select_smoothing(select_smoothing_), param_log(param_log_), param_smoothing1(param_smoothing1_),
-	  param_smoothing2(param_smoothing2_), param_delta(param_delta_), enable_dirplus(enable_dirplus_)
+	  param_smoothing2(param_smoothing2_)
     {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1239,6 +1239,7 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 	if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING)
 	    need_stat(UNIQUE_TERMS);
     }
+
     std::string name() const;
 
     std::string serialise() const;

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1200,7 +1200,7 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
      *					with TWO_STAGE_SMOOTHING as parameter for Dirichlet's
      *					smoothing (default: 2000) and as parameter delta to
      *					control the scale of the tf lower bound in the
-     *             			DIRICHLET_PLUS_SMOOTHING (default 0.05).
+     *					DIRICHLET_PLUS_SMOOTHING (default 0.05).
      *
      */
     // Unigram LM Constructor to specifically mention all parameters for handling negative log value and smoothing.
@@ -1216,7 +1216,7 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 	    if (select_smoothing == TWO_STAGE_SMOOTHING)
 		param_smoothing2 = 2000.0;
 	    else
-	    	param_smoothing2 = 0.05;
+		param_smoothing2 = 0.05;
 	}
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1230,7 +1230,7 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 	if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING)
 	    need_stat(UNIQUE_TERMS);
 	if (select_smoothing == DIRICHLET_PLUS_SMOOTHING)
-	   need_stat(DOC_LENGTH_MIN);
+	    need_stat(DOC_LENGTH_MIN);
     }
 
     std::string name() const;

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1163,6 +1163,13 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
     // Parameters for handling negative value of log, and for smoothing.
     double param_log, param_smoothing1, param_smoothing2;
 
+    // Additional parameter in Dir+ weighting formula.
+    double param_delta;
+
+    // Boolean parameter to control weight calculations when smoothing
+    // is set to Dirichlet.
+    bool enable_dirplus;
+
     // Collection weight.
     double weight_collection;
 
@@ -1199,14 +1206,25 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
      *					only with TWO_STAGE_SMOOTHING as
      *					parameter for Dirichlet's smoothing.
      *					(default: 2000)
+     *
+     *  @param param_delta_	A non-negative parameter for pseudo tf value to control the scale
+     *		      		of the tf lower bound in the Dir+ scoring funtion. Delta can be tuned
+     *				from 0.0 to 0.15 in increments of 0.01 but it is also advisable to
+     *				fix it to 0.05 for normal use. (default 0.05)
+     *
+     *  @param enable_dirplus_	A boolean parameter to control the weight calculations. It takes
+     *				effect only when smoothing is set to Dirichlet. By default, it is set to
+     *				zero so as to allow normal functioning of Dirichlet smoothing. (default 0)
      */
     // Unigram LM Constructor to specifically mention all parameters for handling negative log value and smoothing.
     explicit LMWeight(double param_log_ = 0.0,
 		      type_smoothing select_smoothing_ = TWO_STAGE_SMOOTHING,
 		      double param_smoothing1_ = 0.7,
-		      double param_smoothing2_ = 2000.0)
+		      double param_smoothing2_ = 2000.0,
+		      double param_delta_ = 0.05,
+		      bool enable_dirplus_ = 0)
 	: select_smoothing(select_smoothing_), param_log(param_log_), param_smoothing1(param_smoothing1_),
-	  param_smoothing2(param_smoothing2_)
+	  param_smoothing2(param_smoothing2_), param_delta(param_delta_), enable_dirplus(enable_dirplus_)
     {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
@@ -1221,7 +1239,6 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 	if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING)
 	    need_stat(UNIQUE_TERMS);
     }
-
     std::string name() const;
 
     std::string serialise() const;

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1215,7 +1215,8 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 	if (param_smoothing2 < 0) {
 	    if (select_smoothing == TWO_STAGE_SMOOTHING)
 		param_smoothing2 = 2000.0;
-	    param_smoothing2 = 0.05;
+	    else
+	    	param_smoothing2 = 0.05;
 	}
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1206,11 +1206,17 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
     // Unigram LM Constructor to specifically mention all parameters for handling negative log value and smoothing.
     explicit LMWeight(double param_log_ = 0.0,
 		      type_smoothing select_smoothing_ = TWO_STAGE_SMOOTHING,
-		      double param_smoothing1_ = 0.7,
-		      double param_smoothing2_ = 2000.0)
+		      double param_smoothing1_ = -1.0,
+		      double param_smoothing2_ = -1.0)
 	: select_smoothing(select_smoothing_), param_log(param_log_), param_smoothing1(param_smoothing1_),
 	  param_smoothing2(param_smoothing2_)
     {
+	if (param_smoothing1 < 0) param_smoothing1 = 0.7;
+	if (param_smoothing2 < 0) {
+	    if (select_smoothing == TWO_STAGE_SMOOTHING)
+		param_smoothing2 = 2000.0;
+	    param_smoothing2 = 0.05;
+	}
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(COLLECTION_SIZE);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1161,7 +1161,7 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
     /** The type of smoothing to use. */
     type_smoothing select_smoothing;
 
-    // Parameters for handling negative value for smoothing.
+    // Parameters for handling negative value of log and, for smoothing.
     double param_log, param_smoothing1, param_smoothing2;
 
     // Collection weight.

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -1223,6 +1223,8 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 	need_stat(COLLECTION_FREQ);
 	if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING)
 	    need_stat(UNIQUE_TERMS);
+	if (select_smoothing == DIRICHLET_PLUS_SMOOTHING)
+	   need_stat(DOC_LENGTH_MIN);
     }
 
     std::string name() const;

--- a/xapian-core/tests/api_nodb.cc
+++ b/xapian-core/tests/api_nodb.cc
@@ -378,7 +378,7 @@ DEFINE_TESTCASE(weight1, !backend) {
     delete wt;
 
     Xapian::LMWeight unigramlmweight_dflt;
-    Xapian::LMWeight unigramlmweight(32000, Xapian::Weight::DIRICHLET_SMOOTHING, 2034.0, 0.0);
+    Xapian::LMWeight unigramlmweight(32000, Xapian::Weight::DIRICHLET_SMOOTHING, 2034.0, 0.0, 0.0, 0);
     TEST_EQUAL(unigramlmweight.name(), "Xapian::LMWeight");
     TEST_NOT_EQUAL(unigramlmweight_dflt.serialise(), unigramlmweight.serialise());
     wt = Xapian::LMWeight().unserialise(unigramlmweight.serialise());

--- a/xapian-core/tests/api_nodb.cc
+++ b/xapian-core/tests/api_nodb.cc
@@ -378,7 +378,7 @@ DEFINE_TESTCASE(weight1, !backend) {
     delete wt;
 
     Xapian::LMWeight unigramlmweight_dflt;
-    Xapian::LMWeight unigramlmweight(32000, Xapian::Weight::DIRICHLET_SMOOTHING, 2034.0, 0.0, 0.0, 0);
+    Xapian::LMWeight unigramlmweight(32000, Xapian::Weight::DIRICHLET_SMOOTHING, 2034.0, 0.0);
     TEST_EQUAL(unigramlmweight.name(), "Xapian::LMWeight");
     TEST_NOT_EQUAL(unigramlmweight_dflt.serialise(), unigramlmweight.serialise());
     wt = Xapian::LMWeight().unserialise(unigramlmweight.serialise());

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -53,7 +53,7 @@ DEFINE_TESTCASE(tradweight3, !backend) {
 
 // Test Exception for junk after serialised weight.
 DEFINE_TESTCASE(unigramlmweight3, !backend) {
-    Xapian::LMWeight wt(79898.0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 0.5, 1.0, 0, 0);
+    Xapian::LMWeight wt(79898.0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 0.5, 1.0);
     try {
 	Xapian::LMWeight t;
 	Xapian::LMWeight * t2 = t.unserialise(wt.serialise() + "X");
@@ -847,8 +847,8 @@ DEFINE_TESTCASE(unigramlmweight4, backend) {
     enquire2.set_query(Xapian::Query("paragraph"));
     Xapian::MSet mset2;
     // 5 documents available with term paragraph so mset size should be 5
-    enquire1.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::TWO_STAGE_SMOOTHING, 1, 0, 0, 0));
-    enquire2.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 1, 0, 0, 0));
+    enquire1.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::TWO_STAGE_SMOOTHING, 1, 0));
+    enquire2.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 1, 0));
     mset1 = enquire1.get_mset(0, 10);
     mset2 = enquire2.get_mset(0, 10);
 
@@ -874,10 +874,10 @@ DEFINE_TESTCASE(unigramlmweight5, backend) {
     enquire4.set_query(Xapian::Query("paragraph"));
     Xapian::MSet mset4;
     // 5 documents available with term paragraph so mset size should be 5
-    enquire1.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::TWO_STAGE_SMOOTHING, 0, 0, 0, 0));
-    enquire2.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 0, 0, 0, 0));
-    enquire3.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::ABSOLUTE_DISCOUNT_SMOOTHING, 0, 0, 0, 0));
-    enquire4.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::DIRICHLET_SMOOTHING, 0, 0, 0, 0));
+    enquire1.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::TWO_STAGE_SMOOTHING, 0, 0));
+    enquire2.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 0, 0));
+    enquire3.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::ABSOLUTE_DISCOUNT_SMOOTHING, 0, 0));
+    enquire4.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::DIRICHLET_SMOOTHING, 0, 0));
 
     mset1 = enquire1.get_mset(0, 10);
     mset2 = enquire2.get_mset(0, 10);
@@ -901,7 +901,7 @@ DEFINE_TESTCASE(unigramlmweight5, backend) {
 
 // Test Exception for junk after serialised weight (with Dir+ enabled).
 DEFINE_TESTCASE(unigramlmweight6, !backend) {
-    Xapian::LMWeight wt(0, Xapian::Weight::DIRICHLET_SMOOTHING, 0.5, 1.0, 0.05, 1);
+    Xapian::LMWeight wt(0, Xapian::Weight::DIRICHLET_SMOOTHING, 0.5, 1.0);
     try {
 	Xapian::LMWeight d;
 	Xapian::LMWeight * d2 = d.unserialise(wt.serialise() + "X");
@@ -917,7 +917,6 @@ DEFINE_TESTCASE(unigramlmweight6, !backend) {
     return true;
 }
 
-
 // Feature test for Dir+ function.
 DEFINE_TESTCASE(unigramlmweight7, backend) {
     Xapian::Database db = get_database("apitest_simpledata");
@@ -928,8 +927,8 @@ DEFINE_TESTCASE(unigramlmweight7, backend) {
     Xapian::MSet mset1;
     Xapian::MSet mset2;
 
-    enquire1.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::DIRICHLET_SMOOTHING, 2000, 0, 0, 0));
-    enquire2.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::DIRICHLET_SMOOTHING, 2000, 0, 0.05, 1));
+    enquire1.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::DIRICHLET_SMOOTHING, 2000, 0));
+    enquire2.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::DIRICHLET_PLUS_SMOOTHING, 2000, 0.05));
 
     mset1 = enquire1.get_mset(0, 10);
     mset2 = enquire2.get_mset(0, 10);

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -847,8 +847,8 @@ DEFINE_TESTCASE(unigramlmweight4, backend) {
     enquire2.set_query(Xapian::Query("paragraph"));
     Xapian::MSet mset2;
     // 5 documents available with term paragraph so mset size should be 5
-    enquire1.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::TWO_STAGE_SMOOTHING, 1, 0));
-    enquire2.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 1, 0));
+    enquire1.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::TWO_STAGE_SMOOTHING, 1, 0, 0, 0));
+    enquire2.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 1, 0, 0, 0));
     mset1 = enquire1.get_mset(0, 10);
     mset2 = enquire2.get_mset(0, 10);
 
@@ -896,5 +896,55 @@ DEFINE_TESTCASE(unigramlmweight5, backend) {
 	TEST_EQUAL_DOUBLE(mset1[i].get_weight(), mset4[i].get_weight());
 	TEST_EQUAL_DOUBLE(mset1[i].get_weight(), mset3[i].get_weight());
     }
+    return true;
+}
+
+// Test Exception for junk after serialised weight (with Dir+ enabled).
+DEFINE_TESTCASE(unigramlmweight6, !backend) {
+    Xapian::LMWeight wt(0, Xapian::Weight::DIRICHLET_SMOOTHING, 0.5, 1.0, 0.05, 1);
+    try {
+	Xapian::LMWeight d;
+	Xapian::LMWeight * d2 = d.unserialise(wt.serialise() + "X");
+	// Make sure we actually use the weight.
+	bool empty = d2->name().empty();
+	delete d2;
+	if (empty)
+	    FAIL_TEST("Serialised LMWeight with junk appended unserialised to empty name!");
+	FAIL_TEST("Serialised LMWeight with junk appended unserialised OK");
+    } catch (const Xapian::SerialisationError &) {
+
+    }
+    return true;
+}
+
+
+// Feature test for Dir+ function.
+DEFINE_TESTCASE(unigramlmweight7, backend) {
+    Xapian::Database db = get_database("apitest_simpledata");
+    Xapian::Enquire enquire1(db);
+    Xapian::Enquire enquire2(db);
+    enquire1.set_query(Xapian::Query("paragraph"));
+    enquire2.set_query(Xapian::Query("paragraph"));
+    Xapian::MSet mset1;
+    Xapian::MSet mset2;
+
+    enquire1.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::DIRICHLET_SMOOTHING, 2000, 0, 0, 0));
+    enquire2.set_weighting_scheme(Xapian::LMWeight(0, Xapian::Weight::DIRICHLET_SMOOTHING, 2000, 0, 0.05, 1));
+
+    mset1 = enquire1.get_mset(0, 10);
+    mset2 = enquire2.get_mset(0, 10);
+
+    // mset size should be 5
+    TEST_EQUAL(mset1.size(), 5);
+    TEST_EQUAL(mset2.size(), 5);
+
+    // Expect mset weights associated with Dir+ more than mset weights by Dir
+    // because of the presence of extra weight component in Dir+ function.
+    TEST_REL(mset2[0].get_weight(),>,mset1[0].get_weight());
+    TEST_REL(mset2[1].get_weight(),>,mset1[1].get_weight());
+    TEST_REL(mset2[2].get_weight(),>,mset1[2].get_weight());
+    TEST_REL(mset2[3].get_weight(),>,mset1[3].get_weight());
+    TEST_REL(mset2[4].get_weight(),>,mset1[4].get_weight());
+
     return true;
 }

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -53,7 +53,7 @@ DEFINE_TESTCASE(tradweight3, !backend) {
 
 // Test Exception for junk after serialised weight.
 DEFINE_TESTCASE(unigramlmweight3, !backend) {
-    Xapian::LMWeight wt(79898.0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 0.5, 1.0);
+    Xapian::LMWeight wt(79898.0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 0.5, 1.0, 0, 0);
     try {
 	Xapian::LMWeight t;
 	Xapian::LMWeight * t2 = t.unserialise(wt.serialise() + "X");
@@ -874,10 +874,10 @@ DEFINE_TESTCASE(unigramlmweight5, backend) {
     enquire4.set_query(Xapian::Query("paragraph"));
     Xapian::MSet mset4;
     // 5 documents available with term paragraph so mset size should be 5
-    enquire1.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::TWO_STAGE_SMOOTHING, 0, 0));
-    enquire2.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 0, 0));
-    enquire3.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::ABSOLUTE_DISCOUNT_SMOOTHING, 0, 0));
-    enquire4.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::DIRICHLET_SMOOTHING, 0, 0));
+    enquire1.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::TWO_STAGE_SMOOTHING, 0, 0, 0, 0));
+    enquire2.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::JELINEK_MERCER_SMOOTHING, 0, 0, 0, 0));
+    enquire3.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::ABSOLUTE_DISCOUNT_SMOOTHING, 0, 0, 0, 0));
+    enquire4.set_weighting_scheme(Xapian::LMWeight(10000.0, Xapian::Weight::DIRICHLET_SMOOTHING, 0, 0, 0, 0));
 
     mset1 = enquire1.get_mset(0, 10);
     mset2 = enquire2.get_mset(0, 10);

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -226,7 +226,7 @@ LMWeight::get_maxpart() const
 /* The extra weight component in the Dir+ formula is :-
  *
  * |Q| * log (param_smoothing1 / (|D| + param_smoothing1))
- * 
+ *
  * where, |Q| is total query length.
  *	  |D| is total document length.
  */

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -176,8 +176,7 @@ LMWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
 	     */
 	    weight_sum = (1 + (wdf_double/(param_smoothing1 * weight_collection))) *
 			 (1 + (param_delta/(param_smoothing1 * weight_collection)));
-	}
-	else {
+	} else {
 	    weight_sum = (wdf_double + (param_smoothing1 * weight_collection)) /
 			 (len_double + param_smoothing1);
 	}

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -241,7 +241,7 @@ LMWeight::get_sumextra(Xapian::termcount len, Xapian::termcount) const
 {
     if (enable_dirplus) {
 	double len_double = len;
-	double extra_weight = param_smoothing1 / len_double + param_smoothing1;
+	double extra_weight = param_smoothing1 / (len_double + param_smoothing1);
 	return get_query_length() * log (extra_weight);
     }
     else
@@ -252,7 +252,7 @@ double
 LMWeight::get_maxextra() const
 {
     if (enable_dirplus) {
-	double extra_weight = param_smoothing1 / get_doclength_lower_bound() + param_smoothing1;
+	double extra_weight = param_smoothing1 / (get_doclength_lower_bound() + param_smoothing1);
 	return get_query_length() * log (extra_weight);
     }
     else

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -213,7 +213,7 @@ LMWeight::get_maxpart() const
 	    upper_bound = (1 + (wdf_max/(param_smoothing1 * weight_collection))) *
 			  (1 + (param_delta/(param_smoothing1 * weight_collection)));
 	}
-	else if (!enable_dirplus) {
+	else {
 	    upper_bound = (get_doclength_upper_bound() + (param_smoothing1 * weight_collection)) / (get_doclength_upper_bound() + param_smoothing1);
 	}    
     } else if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING) {

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -169,15 +169,15 @@ LMWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
 	weight_sum = (wdf_double + (param_smoothing1 * weight_collection)) /
 		    (len_double + param_smoothing1);
     } else if (select_smoothing == DIRICHLET_PLUS_SMOOTHING) {
-    /* In the Dir+ weighting formula, sumpart weight contribution is :-
-     *
-     * sum of log of (1 + (wdf/(param_smoothing1 * weight_collection))) and
-     * log of (1 + (delta/param_smoothing1 * weight_collection))).
-     * Since, sum of logs is log of product so weight_sum is calculated as product
-     * of terms in log in the Dir+ formula.
-     */
-    weight_sum = (1 + (wdf_double/(param_smoothing1 * weight_collection))) *
-			 (1 + (param_smoothing2/(param_smoothing1 * weight_collection)));
+	/* In the Dir+ weighting formula, sumpart weight contribution is :-
+	*
+	* sum of log of (1 + (wdf/(param_smoothing1 * weight_collection))) and
+	* log of (1 + (delta/param_smoothing1 * weight_collection))).
+	* Since, sum of logs is log of product so weight_sum is calculated as product
+	* of terms in log in the Dir+ formula.
+	*/
+	weight_sum = (1 + (wdf_double/(param_smoothing1 * weight_collection))) *
+		    (1 + (param_smoothing2/(param_smoothing1 * weight_collection)));
     } else if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING) {
 	double uniqterm_double = uniqterm;
 	weight_sum = ((((wdf_double - param_smoothing1) > 0) ? (wdf_double - param_smoothing1) : 0) / len_double) + ((param_smoothing1 * weight_collection * uniqterm_double) / len_double);
@@ -206,10 +206,10 @@ LMWeight::get_maxpart() const
     if (select_smoothing == JELINEK_MERCER_SMOOTHING) {
 	upper_bound = (param_smoothing1 * weight_collection) + (1 - param_smoothing1);
     } else if (select_smoothing == DIRICHLET_SMOOTHING) {
-	    upper_bound = (get_doclength_upper_bound() + (param_smoothing1 * weight_collection)) / (get_doclength_upper_bound() + param_smoothing1);
+	upper_bound = (get_doclength_upper_bound() + (param_smoothing1 * weight_collection)) / (get_doclength_upper_bound() + param_smoothing1);
     } else if (select_smoothing == DIRICHLET_PLUS_SMOOTHING) {
-	    upper_bound = (1 + (wdf_max/(param_smoothing1 * weight_collection))) *
-			  (1 + (param_smoothing2/(param_smoothing1 * weight_collection)));
+	upper_bound = (1 + (wdf_max / (param_smoothing1 * weight_collection))) *
+		    (1 + (param_smoothing2 / (param_smoothing1 * weight_collection)));
     } else if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING) {
 	upper_bound =  param_smoothing1 * weight_collection + 1;
     } else {
@@ -237,8 +237,7 @@ LMWeight::get_sumextra(Xapian::termcount len, Xapian::termcount) const
 	double extra_weight = param_smoothing1 / (len + param_smoothing1);
 	return get_query_length() * log(extra_weight);
     }
-    else
-	return 0;
+    return 0;
 }
 
 double
@@ -248,8 +247,7 @@ LMWeight::get_maxextra() const
 	double extra_weight = param_smoothing1 / (get_doclength_lower_bound() + param_smoothing1);
 	return get_query_length() * log(extra_weight);
     }
-    else
-	return 0;
+    return 0;
 }
 
 }

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -166,14 +166,14 @@ LMWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
 	// Enabling Dir+ weighting formula.
 	if (enable_dirplus) {
 
-	/* In the Dir+ weighting formula, sumpart weight contribution is :-
-	 *
-	 * sum of log of (1 + (wdf/(param_smoothing1 * weight_collection))) and 
-	 * log of (1 + (delta/param_smoothing1 * weight_collection))). 
-	 
-	 * Since, sum of logs iss log of product so weight_sum is calculated as product
-	 * of terms in log in the Dir+ formula.	
-	 */
+	    /* In the Dir+ weighting formula, sumpart weight contribution is :-
+	     *
+	     * sum of log of (1 + (wdf/(param_smoothing1 * weight_collection))) and
+	     * log of (1 + (delta/param_smoothing1 * weight_collection))).
+
+	     * Since, sum of logs is log of product so weight_sum is calculated as product
+	     * of terms in log in the Dir+ formula.
+	     */
 	    weight_sum = (1 + (wdf_double/(param_smoothing1 * weight_collection))) *
 			 (1 + (param_delta/(param_smoothing1 * weight_collection)));
 	}
@@ -212,8 +212,7 @@ LMWeight::get_maxpart() const
 	if (enable_dirplus) {
 	    upper_bound = (1 + (wdf_max/(param_smoothing1 * weight_collection))) *
 			  (1 + (param_delta/(param_smoothing1 * weight_collection)));
-	}
-	else {
+	} else {
 	    upper_bound = (get_doclength_upper_bound() + (param_smoothing1 * weight_collection)) / (get_doclength_upper_bound() + param_smoothing1);
 	}    
     } else if (select_smoothing == ABSOLUTE_DISCOUNT_SMOOTHING) {
@@ -243,8 +242,7 @@ LMWeight::get_sumextra(Xapian::termcount len, Xapian::termcount) const
 	double len_double = len;
 	double extra_weight = param_smoothing1 / (len_double + param_smoothing1);
 	return get_query_length() * log (extra_weight);
-    }
-    else
+    } else
 	return 0;
 }
 
@@ -254,8 +252,7 @@ LMWeight::get_maxextra() const
     if (enable_dirplus) {
 	double extra_weight = param_smoothing1 / (get_doclength_lower_bound() + param_smoothing1);
 	return get_query_length() * log (extra_weight);
-    }
-    else
+    } else
 	return 0;
 }
 


### PR DESCRIPTION
This implementation is a bit different from the previous implementation of weighting functions, BM25+ and PL2+ because here the existing `LMWeight` class is extended with the additions of two new parameters, `param_delta` and `enable_dirplus` to support new Dir+ function alongside the implementation of existing Dir function. 

Also, the previously written test cases for lmweight are modified accordingly with new parameters so as to make sure it doesn't mess with the functioning of already available weighting functions (smoothings) in `lmweight.cc` -- all tests pass.