### PR TITLE
Maximise query term coverage for snippets

### DIFF
--- a/xapian-core/common/debuglog.h
+++ b/xapian-core/common/debuglog.h
@@ -81,6 +81,9 @@ enum debuglog_categories {
     /// Query stuff.
     DEBUGLOG_CATEGORY_QUERY = ('Y' - '@'),
 
+    /// Termgenerator.
+    DEBUGLOG_CATEGORY_TERMGEN = ('T' - '@'),
+
     /// Messages which are always logged.
     DEBUGLOG_CATEGORY_ALWAYS = 31
 };

--- a/xapian-core/include/xapian/mset.h
+++ b/xapian-core/include/xapian/mset.h
@@ -97,7 +97,18 @@ class XAPIAN_VISIBILITY_DEFAULT MSet {
 
     enum {
 	SNIPPET_BACKGROUND_MODEL = 1,
-	SNIPPET_EXHAUSTIVE = 2
+	SNIPPET_EXHAUSTIVE = 2,
+      /** Attempt to cover all search terms.
+       *
+       * If enabled, snippet() attempts to find a snippet that covers most of
+       * the search terms. The weight of each snippet term contributes only once
+       * to a snippet's cumulated relevance.
+       *
+       * This flag is only useful in search for "loose terms" as occuring in
+       * ORed and ANDed queries. It is ignored for queries containing phrases
+       * or wildcards.
+       */
+	SNIPPET_TERMCOVER = 4
     };
 
     /** Generate a snippet.


### PR DESCRIPTION
This pull request adds a new snippet relevance mechanism to MSet's snippet method. It attempts to find the snippet that covers as many query terms as possible. The commit message contains an example that compares the current snippet generator with the proposed new feature.

The existing snippet generator remains default and the new feature is only activated by setting the newly introduced SNIPPET_TERMCOVER flag.

The added unit tests test for both regression and subtleties introduced by the new feature.
