### PR TITLE
letor: Enable Travis and remove xapian-letor from default bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: cpp
 before_script:
   - ./bootstrap
   - ./configure
-script: make && make check
+  - ./letor-bootstrap
+  - ./letor-configure
+script:
+  - make && make check
+  - make -f Makefile.letor && make check -f Makefile.letor
 sudo: false
 notifications:
   irc: "chat.freenode.net#xapian-devel"
@@ -23,6 +27,7 @@ addons:
       - tcl
       - gcc-4.7
       - g++-4.7
+      - libsvm-dev
 env:
   global:
     - XAPIAN_COMMON_CLONE_URL=https://github.com/xapian/xapian.git

--- a/bootstrap
+++ b/bootstrap
@@ -395,7 +395,7 @@ export ACLOCAL
 
 intree_swig=no
 modules=
-for module in ${@:-xapian-core xapian-applications/omega swig xapian-bindings xapian-letor} ; do
+for module in ${@:-xapian-core xapian-applications/omega swig xapian-bindings} ; do
   d=$module
   if [ -f "$d/configure.ac" -o -f "$d/configure.in" ] ; then
     :

--- a/letor-bootstrap
+++ b/letor-bootstrap
@@ -1,0 +1,692 @@
+#!/bin/sh
+# bootstrap xapian-letor
+#
+# Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010,2011,2012,2013,2014,2015,2016 Olly Betts
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+# USA
+
+if [ "$1" = "--help" ] ; then
+  cat <<__END__
+$0 [--ftp] [--without-autotools|--clean] [MODULE...]
+
+The default is to bootstrap all known modules.  Any modules which have a
+file called ".nobootstrap" in their top-level will be skipped.
+__END__
+  exit 0
+fi
+
+trap 'echo "Bootstrap failed"' EXIT
+set -e
+
+# The variables which specify the autotools to use.
+autotools="AUTORECONF AUTOCONF AUTOHEADER AUTOM4TE AUTOMAKE ACLOCAL LIBTOOLIZE"
+
+# Tool for downloading a file from a URL (currently wget or curl).
+FETCH_URL_TOOL=
+
+check_sha1sum() {
+  checksum=$1
+  tarball=$2
+
+  if [ -z "$SHA1SUM_TOOL" ] ; then
+    for SHA1SUM_TOOL in \
+	'${SHA1SUM-sha1sum} 2>/dev/null|cut -d\  -f1' \
+	'${SHASUM-shasum} 2>/dev/null|cut -d\  -f1' \
+	'$(OPENSSL-openssl} sha1 2>/dev/null|sed "s/.* //"' \
+	'' ; do
+      if [ -z "$SHA1SUM_TOOL" ] ; then
+	echo <<'END'
+Need sha1sum or shasum or openssl installed to check SHA1 checksums.
+Set environment variable SHA1SUM, SHASUM or OPENSSL if the tool isn't on
+your PATH.
+END
+	exit 1
+      fi
+      r=`:|eval "$SHA1SUM_TOOL"`
+      [ X"$r" != Xda39a3ee5e6b4b0d3255bfef95601890afd80709 ] || break
+    done
+  fi
+  r=`< $tarball eval "$SHA1SUM_TOOL"`
+  if [ X"$r" != X"$checksum" ] ; then
+    echo "$tarball: computed SHA1 checksum did NOT match"
+    echo "computed: $r with $SHA1SUM_TOOL"
+    echo "expected: $checksum"
+    ls -l $tarball
+    file $tarball || true
+    mv "$tarball" "$tarball.$r"
+    echo "Renamed $tarball to $tarball.$r"
+    exit 1
+  fi
+}
+
+lazy_build() {
+  package=$1
+  basename=$package-$2
+  ext=$3
+  checksum=$4
+  if [ "$ext" = "tar.xz" ] ; then
+    if [ -z "$xz_ok" ] ; then
+      if ${XZ-xz} --version > /dev/null 2>&1 ; then
+	xz_ok=1
+      else
+	xz_ok=0
+      fi
+    fi
+    if [ "$xz_ok" = 0 ] ; then
+      shift 2
+      ext=$3
+      checksum=$4
+    fi
+  fi
+  if [ "$ext" = "tar.bz2" ] ; then
+    if [ -z "$bz2_ok" ] ; then
+      # bzip2 --version doesn't exit with code 0 in upstream version (though
+      # Debian at least patch this bug), so use --help to check it.
+      if bzip2 --help > /dev/null 2>&1 ; then
+	bz2_ok=1
+      else
+	bz2_ok=0
+      fi
+    fi
+    if [ "$bz2_ok" = 0 ] ; then
+      shift 2
+      ext=$3
+      checksum=$4
+    fi
+  fi
+  tarball=$basename.$ext
+  case $basename in
+    *[24680][a-z]) basename=`echo "$basename"|sed 's/[a-z]$//'` ;;
+  esac
+
+  # Create the stamp file in INST so that rerunning bootstrap after
+  # "rm -rf INST" recovers nicely.
+  stamp=../INST/$package.stamp
+
+  # Download the tarball if required.
+  if [ ! -f "$tarball" ] ; then
+    if [ -z "$FETCH_URL_TOOL" ] ; then
+      if ${WGET-wget} --version > /dev/null 2>&1 ; then
+	FETCH_URL_TOOL="${WGET-wget} -O-"
+      elif ${CURL-curl} --version > /dev/null 2>&1 || [ "$?" = 2 ] ; then
+	# curl --version exits with code 2.
+	# -L is needed to follow HTTP redirects.
+	FETCH_URL_TOOL="${CURL-curl} -L"
+      elif ${LWP_REQUEST-lwp-request} -v > /dev/null 2>&1 || [ "$?" = 9 -o "$?" = 255 ] ; then
+	# lwp-request -v exits with code 9 (5.810) or 255 (6.03)
+	FETCH_URL_TOOL="${LWP_REQUEST-lwp-request} -mGET"
+      else
+	cat <<END >&2
+Neither wget nor curl nor lwp-request found - install one of them or if already
+installed, set WGET, CURL or LWP_REQUEST to the full path.  Alternatively,
+download $url
+to directory `pwd`
+then rerun this script.
+END
+	exit 1
+      fi
+    fi
+    case $basename in
+    file-*)
+      if [ "$use_ftp" = yes ] ; then
+	url="ftp://ftp.astron.com/pub/file/$tarball"
+      else
+	url="http://fossies.org/unix/misc/$tarball"
+      fi ;;
+    *[13579][a-z])
+      # GNU alpha release
+      if [ "$use_ftp" = yes ] ; then
+	url="ftp://alpha.gnu.org/gnu/$package/$tarball"
+      else
+	url="http://alpha.gnu.org/gnu/$package/$tarball"
+      fi ;;
+    *)
+      if [ "$use_ftp" = yes ] ; then
+	url="ftp://ftp.gnu.org/gnu/$package/$tarball"
+      else
+	url="http://ftpmirror.gnu.org/$package/$tarball"
+      fi ;;
+    esac
+    rm -f download.tmp
+    echo "Downloading <$url>"
+    $FETCH_URL_TOOL "$url" > download.tmp && mv download.tmp "$tarball"
+  fi
+
+  if [ -f "$stamp" ] ; then
+    find_stdout=`find "$tarball" ../patches/"$package"/* -newer "$stamp" -print 2> /dev/null||true`
+  else
+    find_stdout=force
+  fi
+
+  if [ -n "$find_stdout" ] ; then
+    # Verify the tarball's checksum before building it.
+    check_sha1sum "$checksum" "$tarball"
+
+    # Remove tarballs of other versions.
+    for f in "$package"-* ; do
+      [ "$f" = "$tarball" ] || rm -rf "$f"
+    done
+
+    case $ext in
+    tar.xz)
+      ${XZ-xz} -dc "$tarball"| tar xf - ;;
+    tar.bz2)
+      bzip2 -dc "$tarball"| tar xf - ;;
+    *)
+      gzip -dc "$tarball"| tar xf - ;;
+    esac
+
+    cd "$basename"
+
+    if [ ! -f "../../patches/$package/series" ] ; then
+      cat <<END >&2
+No patch series file 'patches/$package/series' - if there are no patches,
+this should just be an empty file.
+END
+      exit 1
+    fi
+    echo "Applying patches from $package/series"
+    sed -n 's/[	 ]*\(#.*\)\?$//;/./p' "../../patches/$package/series" | \
+	while read p ; do
+      echo "Applying patch $package/$p"
+      patch -p1 < "../../patches/$package/$p"
+    done
+
+    if test -n "$AUTOCONF" ; then
+      ./configure --prefix "$instdir" AUTOCONF="$AUTOCONF"
+    else
+      ./configure --prefix "$instdir"
+    fi
+    make
+    make install
+    cd ..
+    rm -rf "$basename"
+
+    touch "$stamp"
+  fi
+}
+
+handle_git_external() {
+  path=$1
+  if [ ! -f "$path/.nobootstrap" ] ; then
+    rev=$2
+    url=$3
+    if [ ! -d "$path" ] ; then
+      git clone --no-checkout -- "$url" "$path"
+    elif (cd "$path" && git reflog "$rev" -- 2>/dev/null) ; then
+      : # Already have that revision locally
+    else
+      (cd "$path" && git fetch)
+    fi
+    (cd "$path" && git checkout "$rev")
+  fi
+}
+
+update_config() {
+  from=$1
+  to=$2
+  ts_from=`perl -ne '/^timestamp=(\W?)([-\d]+)$1/ and do {$_=$2;y/-//d;print;exit}' "$from"`
+  ts_to=`perl -ne '/^timestamp=(\W?)([-\d]+)$1/ and do {$_=$2;y/-//d;print;exit}' "$to"`
+  if [ "$ts_from" -gt "$ts_to" ] ; then
+     echo "Updating $to ($ts_to) with $from ($ts_from)"
+     # rm first in case the existing file is a symlink.
+     rm -f "$to"
+     cp "$from" "$to"
+  fi
+}
+
+curdir=`pwd`
+
+# cd to srcdir if we aren't already there.
+srcdir=`echo "$0"|sed 's!/*[^/]*$!!'`
+case $srcdir in
+  ""|.)
+    srcdir=. ;;
+  *)
+    cd "$srcdir" ;;
+esac
+
+# Commit hash to pass to handle_git_external for swig.
+swig_git_commit_hash=bab51398053188a136effd155d7ed8f5d441908e
+
+if [ ! -d .git ] ; then
+  echo "$0: No '.git' directory found - this script should be run from a"
+  echo "git repo cloned from git://git.xapian.org/xapian or a mirror of it"
+  exit 1
+fi
+
+for emptydir in xapian-applications/omega/m4 xapian-bindings/m4 xapian-letor/m4 ; do
+  if test -d "$emptydir" ; then
+    :
+  else
+    parent=`echo "$emptydir"|sed 's,/[^/]*$,,'`
+    if test -d "$parent" ; then
+      mkdir "$emptydir"
+    fi
+  fi
+done
+
+if [ -f .git/info/exclude ] ; then
+  sed '/^\(swig\|xapian-applications\/omega\/common$\)/d' .git/info/exclude > .git/info/exclude~
+else
+  [ -d .git/info ] || mkdir .git/info
+fi
+cat <<END >> .git/info/exclude~
+swig
+xapian-applications/omega/common
+xapian-letor/common
+END
+if [ -f .git/info/exclude ] &&
+   cmp -s .git/info/exclude~ .git/info/exclude ; then
+  rm .git/info/exclude~
+else
+  mv .git/info/exclude~ .git/info/exclude
+fi
+
+# If this tree is checked out from the github mirror, use the same access
+# method for other things checked out from github (e.g. swig) so we avoid
+# firewall issues.  If there's no default remote, the git config command
+# will exit with status 1, so ignore that failure.
+origin_url=`git config remote.origin.url||:`
+case $origin_url in
+  *[@/]github.com[:/]*)
+    github_base_url=`echo "X$origin_url"|sed 's/^X//;s!\([@/]github.com[:/]\).*!\1!'` ;;
+  *)
+    github_base_url=https://github.com/ ;;
+esac
+swig_origin_url=${github_base_url}swig/swig.git
+handle_git_external swig "$swig_git_commit_hash" "$swig_origin_url"
+
+if [ -z "$XAPIAN_COMMON_CLONE_URL" ] ; then
+    xapian_common_clone_url=.
+else
+    xapian_common_clone_url=$XAPIAN_COMMON_CLONE_URL
+fi
+
+# If someone's created a directory for common, leave it be.
+if [ -h xapian-applications/omega/common ] || \
+   [ ! -d xapian-applications/omega/common ] ; then
+  handle_git_external xapian-applications/omega/.common.git bddcf54435286b0363efff94f22529093e85fc89 "$xapian_common_clone_url"
+  ln -sf .common.git/xapian-core/common xapian-applications/omega/common
+fi
+
+# If someone's created a directory for common, leave it be.
+if [ -h xapian-letor/common ] || [ ! -d xapian-letor/common ] ; then
+  handle_git_external xapian-letor/.common.git bddcf54435286b0363efff94f22529093e85fc89 "$xapian_common_clone_url"
+  ln -sf .common.git/xapian-core/common xapian-letor/common
+fi
+
+# Prefer http downloads as they are more likely to work through firewalls.
+use_ftp=no
+if [ "$1" = "--ftp" ] ; then
+  shift
+  use_ftp=yes
+fi
+
+if [ "$1" = "--without-autotools" ] ; then
+  shift
+else
+  if [ "$1" = "--clean" ] ; then
+    shift
+    rm -rf INST
+  fi
+
+  [ -d INST ] || mkdir INST
+  instdir=`pwd`/INST
+
+  [ -d BUILD ] || mkdir BUILD
+  cd BUILD
+
+  # The last field is the SHA1 checksum of the tarball.
+  lazy_build autoconf 2.69 \
+    tar.xz e891c3193029775e83e0534ac0ee0c4c711f6d23 \
+    tar.gz 562471cbcb0dd0fa42a76665acf0dbb68479b78a
+  AUTOCONF=$instdir/bin/autoconf \
+  lazy_build automake 1.15 \
+    tar.xz c279b35ca6c410809dac8ade143b805fb48b7655 \
+    tar.gz b5a840c7ec4321e78fdc9472e476263fa6614ca1
+  lazy_build libtool 2.4.6 \
+    tar.xz 3e7504b832eb2dd23170c91b6af72e15b56eb94e \
+    tar.gz 25b6931265230a06f0fc2146df64c04e5ae6ec33
+  if [ "$1" = "--deps=libmagic" ] ; then
+      shift
+      lazy_build file 5.25 \
+	tar.gz fea78106dd0b7a09a61714cdbe545135563e84bd
+  fi
+
+  for v in $autotools ; do
+     tool=`echo "$v"|tr A-Z a-z`
+     eval "$v=\"\$instdir\"/bin/$tool;export $v"
+  done
+
+  cd ..
+fi
+
+case `${LIBTOOLIZE-libtoolize} --version` in
+"")
+  echo "${LIBTOOLIZE-libtoolize} not found"
+  exit 1 ;;
+"libtoolize (GNU libtool) 1.4.*")
+  echo "${LIBTOOLIZE-libtoolize} is from libtool 1.4 which is too old - libtool 2.2 is required."
+  echo "If you have both installed, set LIBTOOLIZE to point to the correct version."
+  exit 1 ;;
+"libtoolize (GNU libtool) 1.5.*")
+  echo "${LIBTOOLIZE-libtoolize} is from libtool 1.5 which is too old - libtool 2.2 is required."
+  echo "If you have both installed, set LIBTOOLIZE to point to the correct version."
+  exit 1 ;;
+esac
+
+ACLOCAL="${ACLOCAL-aclocal} -I `pwd`/xapian-core/m4-macros"
+export ACLOCAL
+
+intree_swig=no
+modules=
+for module in ${@:-xapian-letor} ; do
+  d=$module
+  if [ -f "$d/configure.ac" -o -f "$d/configure.in" ] ; then
+    :
+  else
+    # Skip any directories we can't bootstrap.
+    continue
+  fi
+  if [ -f "$d/.nobootstrap" ] ; then
+    # Report why to save head scratching when someone forgets they created
+    # a .nobootstrap file.
+    echo "Skipping '$module' due to presence of '$d/.nobootstrap'."
+    continue
+  fi
+  if [ "$d" = swig ] && [ -f "xapian-bindings/.nobootstrap" ] ; then
+    # No point bootstrapping SWIG if we aren't going to use it.
+    echo "Skipping '$d' due to presence of 'xapian-bindings/.nobootstrap'."
+    continue
+  fi
+  echo "Bootstrapping \`$module'"
+  [ -f "$d/preautoreconf" ] && "$d/preautoreconf"
+
+  # If we have a custom INSTALL file, preserve it since autoreconf insists on
+  # replacing INSTALL with "generic installation instructions" when --force
+  # is used.  Be careful to replace it if autoreconf fails.
+  if [ -f "$d/INSTALL" ] ; then
+    if grep 'generic installation instructions' "$d/INSTALL" >/dev/null 2>&1 ; then
+      :
+    else
+      mv -f "$d/INSTALL" "$d/INSTALL.preserved-by-bootstrap"
+    fi
+  fi
+
+  autoreconf_rc=
+  if [ swig = "$module" ] ; then
+    # SWIG provides its own bootstrapping script.
+    curdir=`pwd`
+    cd "$d"
+    ./autogen.sh || autoreconf_rc=$?
+    cd "$curdir"
+    # Use the uninstalled wrapper for the in-tree copy of SWIG.
+    intree_swig=yes
+  else
+    # Use --install as debian's autoconf wrapper uses 2.5X if it sees it
+    # (but it doesn't check for -i).
+    #
+    # Use --force so that we update files if autoconf, automake, or libtool
+    # has been upgraded.
+    ${AUTORECONF-autoreconf} --install --force "$d" || autoreconf_rc=$?
+  fi
+  if [ -f "$d/INSTALL.preserved-by-bootstrap" ] ; then
+    mv -f "$d/INSTALL.preserved-by-bootstrap" "$d/INSTALL"
+  fi
+  if [ -n "$autoreconf_rc" ] ; then
+    exit $autoreconf_rc
+  fi
+  for f in config.guess config.sub ; do
+    if [ -f "$d/$f" ] ; then
+      update_config "config/$f" "$d/$f"
+    fi
+  done
+  modules="$modules $module"
+done
+
+# Generate the top-level configure script.
+rm -f letor-configure.tmp
+cat <<'TOP_OF_CONFIGURE' > letor-configure.tmp
+#!/bin/sh
+# configure xapian-letor
+# Generated by Xapian letor-bootstrap.
+#
+# Copyright (C) 2003,2004,2007,2008 Olly Betts
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+# USA
+
+trap 'echo "configure failed"' EXIT
+set -e
+
+# Produced escaped version of command suitable for pasting back into sh
+cmd=$0
+for a ; do
+ case $a in
+  *[^-A-Za-z0-9_+=:@/.,]*)
+   esc_a=`echo "$a"|sed 's!\([^-A-Za-z0-9_+=:@/.,]\)!\\\\\\1!g'`
+   cmd="$cmd $esc_a" ;;
+  *)
+   cmd="$cmd $a" ;;
+ esac
+done
+
+here=`pwd`
+TOP_OF_CONFIGURE
+
+# Produce an absolute path to srcdir.
+srcdir_abs=`pwd`
+# This section is unquoted so we can substitute variables.
+cat <<MIDDLE_OF_CONFIGURE >> letor-configure.tmp
+srcdir="$srcdir_abs"
+modules="$modules"
+MIDDLE_OF_CONFIGURE
+
+vars=
+if [ yes = "$intree_swig" ] ; then
+  # We want the path to SWIG to point into srcdir, which isn't known until
+  # configure-time, so we need to expand $here in configure.  We can't just set
+  # SWIG here and let the case below handle it as that would escape the value
+  # such that $here didn't get expanded at all.
+  echo ': ${SWIG="$here/swig/preinst-swig"}' >> letor-configure.tmp
+  echo "export SWIG" >> letor-configure.tmp
+  vars=' SWIG=$here/swig/preinst-swig'
+  # Kill any existing setting of SWIG so that we don't try to handle it again
+  # below.
+  SWIG=
+fi
+for tool in SWIG $autotools ; do
+  eval "val=\$$tool"
+  if [ -n "$val" ] ; then
+    echo ': ${'"$tool='$val'"'}' >> letor-configure.tmp
+    echo "export $tool" >> letor-configure.tmp
+    vars="$vars $tool='"`echo "$val"|sed 's/\(['"\\'"']\)/\\\1/g'`"'"
+  fi
+done
+if [ -n "$vars" ] ; then
+  # $vars will always have a leading space.
+  echo "set$vars "'"$@"' >> letor-configure.tmp
+fi
+
+cat <<'END_OF_CONFIGURE' >> letor-configure.tmp
+dirs=
+revdirs=
+XAPIAN_CONFIG=$here/xapian-core/xapian-config
+for d in $modules ; do
+  if [ "$here" = "$srcdir" ] ; then
+    configure=./configure
+    configure_from_here=$d/configure
+  else
+    configure=$srcdir/$d/configure
+    configure_from_here=$configure
+  fi
+  if [ -f "$configure_from_here" ] ; then
+    if [ -d "$d" ] ; then : ; else
+      case $d in
+      xapian-applications/*) [ -d xapian-applications ] || mkdir xapian-applications ;;
+      esac
+      mkdir "$d"
+    fi
+    echo "Configuring \`$d'"
+    # Use a shared config.cache for speed and to save a bit of diskspace, but
+    # don't share it with SWIG just in case it manages to probe and cache
+    # different answers (e.g. because it uses a C compiler).
+    case $d in
+    swig)
+      cd "$d" && "$configure" ${1+"$@"}
+      ;;
+    xapian-core)
+      cd "$d" && "$configure" --enable-maintainer-mode --disable-option-checking --cache-file="$here/config.cache" ${1+"$@"}
+      ;;
+    xapian-applications/omega)
+      cd "$d" && "$configure" --enable-maintainer-mode --disable-option-checking XAPIAN_CONFIG="$XAPIAN_CONFIG" CPPFLAGS="-I$srcdir/INST/include" LDFLAGS="-L$srcdir/INST/lib" ${1+"$@"}
+      ;;
+    *)
+      cd "$d" && "$configure" --enable-maintainer-mode --disable-option-checking --cache-file="$here/config.cache" XAPIAN_CONFIG="$XAPIAN_CONFIG" ${1+"$@"}
+      ;;
+    esac
+    cd "$here"
+    dirs="$dirs $d"
+    revdirs="$d $revdirs"
+  fi
+done
+
+case " $* " in
+  *" --help "*|*" --version "*)
+    # Don't generate Makefile if --help or --version specified.
+    trap - EXIT
+    exit 0
+    ;;
+esac
+
+rm -f Makefile.tmp
+cat <<EOF > Makefile.tmp
+# Makefile generated by:
+CONFIGURE_COMMAND := $cmd
+EOF
+if [ "$srcdir" != . ] ; then
+    cat <<EOF >> Makefile.tmp
+
+VPATH = $srcdir
+EOF
+fi
+targets='all install uninstall install-strip clean distclean mostlyclean maintainer-clean dist check distcheck'
+for target in $targets ; do
+  echo
+  echo "$target:"
+  case $target in
+    uninstall|*clean)
+      # When uninstalling or cleaning, process directories in reverse order, so
+      # that we process a directory after any directories which might use it.
+      list=$revdirs ;;
+    *)
+      list=$dirs ;;
+  esac
+  for d in $list ; do
+    case $d,$target in
+    swig,install*|swig,uninstall)
+      # Nothing to do with swig when installing/uninstalling.
+      ;;
+    swig,dist|swig,check|swig,distcheck|swig,all)
+      # Need to ensure swig is built before "make dist", "make check", etc.
+      echo "	cd $d && \$(MAKE)" ;;
+    swig,mostlyclean)
+      echo "	cd $d && \$(MAKE) clean" ;;
+    xapian-bindings,distcheck)
+      # FIXME: distcheck doesn't currently work for xapian-bindings because
+      # xapian-core isn't installed.
+      echo "	cd $d && \$(MAKE) check && \$(MAKE) dist" ;;
+    *)
+      echo "	cd $d && \$(MAKE) $target" ;;
+    esac
+  done
+  case $target in
+    distclean|maintainer-clean) echo "	rm -f Makefile config.cache" ;;
+  esac
+done >> Makefile.tmp
+cat <<EOF >> Makefile.tmp
+
+recheck:
+	\$(CONFIGURE_COMMAND)
+
+Makefile: $srcdir/configure
+	\$(CONFIGURE_COMMAND)
+
+$srcdir/configure: \\
+END_OF_CONFIGURE
+
+: > letor-configure.tmp2
+
+# We want to rerun bootstrap if a series file changes (patch added or removed)
+# or an existing patch changes.  Since we always have an series file (even if
+# it is empty), this also handles us adding the first patch for something.
+patches=
+for d in patches/* ; do
+  series=$d/series
+  echo "$series:" >> letor-configure.tmp2
+  cat << END
+    $series\\\\
+END
+  sed -n 's/[	 ]*\(#.*\)\?$//;/./p' "$series" |\
+      while read p ; do
+    patch=$d/$p
+    cat << END
+    $patch\\\\
+END
+    # Because there's a pipeline, this is a subshell, so use a temporary file
+    # rather than a variable to compile a list of patches to use below.
+    echo "$patch:" >> letor-configure.tmp2
+  done
+done >> letor-configure.tmp
+
+cat <<'END_OF_CONFIGURE' >> letor-configure.tmp
+    $srcdir/bootstrap
+	$srcdir/bootstrap
+
+.PHONY: $targets recheck
+
+# Dummy dependencies to allow removing patches we no longer need.
+END_OF_CONFIGURE
+
+cat letor-configure.tmp2 >> letor-configure.tmp
+
+cat <<'END_OF_CONFIGURE' >> letor-configure.tmp
+EOF
+mv -f Makefile.tmp Makefile.letor
+trap - EXIT
+echo "Configured successfully - now run \"make -f Makefile.letor\""
+END_OF_CONFIGURE
+
+rm -f letor-configure.tmp2
+
+chmod +x letor-configure.tmp
+mv -f letor-configure.tmp letor-configure
+
+trap - EXIT
+echo "Bootstrapped successfully - now run \"$srcdir/letor-configure\" and \"make -f Makefile.letor\""

--- a/xapian-letor/README
+++ b/xapian-letor/README
@@ -1,4 +1,45 @@
-xapian-letor
-============
+Welcome to Xapian's Learning to Rank Framework
+==============================================
 
-Note: While configuring xapian-letor, make sure that backend build flags are same as those used while configuring xapian-core.
+Building & installing involves the following three steps:
+(*Make sure you are in the top-level directory*)
+
+1) Run "./letor-bootstrap"
+2) Run "./letor-configure", possibly with some extra arguments
+3) Run "make -f Makefile.letor"
+4) Run "make install -f Makefile.letor"
+
+*Note*: While configuring xapian-letor, make sure that backend build flags
+are same as those used while configuring xapian-core.
+
+Prerequisites
+=============
+
+You'll need to install the following prerequisites before you can
+build xapian-letor:
+
+ * xapian-core: We recommend using matching versions of xapian-core and
+   xapian-letor.  If you install xapian-core from a package, make sure you
+   also install the development files which are often packaged separately
+   (e.g. in libxapian-dev or xapian-core-devel).
+
+ * libsvm (http://www.csie.ntu.edu.tw/~cjlin/libsvm/): We developed
+   xapian-letor using libsvm version 3.1, but we've also tested with 3.0
+   and that seems to work fine too.
+
+   If you install libsvm from a package system, make sure you have the
+   headers and other files needed to actually build code that uses libsvm
+   (not just the runtime libraries) - if you have /usr/include/libsvm/svm.h
+   then you are probably good.  Often these files are in a separate
+   package, which is probably named something like libsvm-dev or
+   libsvm-devel.
+
+   On Mac OS X, if you installed libsvm using homebrew but got the following
+   error when running the configure script:
+
+      configure: error: libsvm required but libsvm/svm.h not found
+
+   Suppose you are using libsvm 3.21, you can type the following into terminal
+   and rerun the configure script:
+
+      ln -s /usr/local/Cellar/libsvm/3.21/include/ /usr/local/include/libsvm


### PR DESCRIPTION
This PR does the following:

1. Delete `xapian-letor/.nobootstrap`
2. Remove `xapian-letor` from bootstrap defaults
3. Create `letor-bootstrap` in the top-level directory
4. Update `xapian-letor/README` for new build and install instructions
5. Update `.travis.yml` to add xapian-letor build scripts, and add `libsvm` to package dependency.