### PR TITLE
BM25+ fixes

### DIFF
--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -591,7 +591,7 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
 };
 
 /// Xapian::Weight subclass implementing the BM25+ probabilistic formula.
-class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public BM25Weight {
+class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public Weight {
   public:
     /** Construct a BM25PlusWeight.
      *

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -189,11 +189,11 @@ DEFINE_TESTCASE(bm25plusweight3, backend) {
 
     // The value of each doc weight calculated manually from the BM25+ formulae
     // by using the respective document statistics.
-    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 0.954493799782531);
-    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 0.945598645461975);
-    TEST_EQUAL_DOUBLE(mset[2].get_weight(), 0.910873608950458);
-    TEST_EQUAL_DOUBLE(mset[3].get_weight(), 0.868853803088924);
-    TEST_EQUAL_DOUBLE(mset[4].get_weight(), 0.868853803088924);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 0.7920796567487473);
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 0.7846980783848447);
+    TEST_EQUAL_DOUBLE(mset[2].get_weight(), 0.7558817623365934);
+    TEST_EQUAL_DOUBLE(mset[3].get_weight(), 0.7210119356168847);
+    TEST_EQUAL_DOUBLE(mset[4].get_weight(), 0.7210119356168847);
 
     return true;
 }

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -48,17 +48,16 @@ BM25PlusWeight::init(double factor)
 {
     Xapian::doccount tf = get_termfreq();
 
-    double tw = 0;
-    // BM25+ formula gives termweight = (total_no_of_docs + 1) / tf
-    if (tf != 0) tw = (get_collection_size() + 1) / tf;
-
-    AssertRel(tw,>,0);
-
-    if (tw < 2) tw = tw * 0.5 + 1;
-    termweight = log(tw) * factor;
-    if (param_k3 != 0) {
-	double wqf_double = get_wqf();
-	termweight *= (param_k3 + 1) * wqf_double / (param_k3 + wqf_double);
+    if (rare(tf == 0)) {
+	termweight = 0;
+    } else {
+	// BM25+ formula uses IDF = log((total_no_of_docs + 1) / tf)
+	termweight = log(double(get_collection_size() + 1) / tf);
+	termweight *= factor;
+	if (param_k3 != 0) {
+	    double wqf_double = get_wqf();
+	    termweight *= (param_k3 + 1) * wqf_double / (param_k3 + wqf_double);
+	}
     }
 
     LOGVALUE(WTCALC, termweight);


### PR DESCRIPTION
There are essentially three changes here, but I've bundled two of them together in a commit since they involve recomputing the hand-computed weights so the tests pass, and it seemed pointless extra work to do that twice.

- `BM25PlusWeight` now inherits from `Weight`
- `(get_collection_size() + 1) / tf` performs an integer division as `get_collection_size()` and `tf` are both integer types - we need to ensure at least one argument of the division is a `double` to get a floating point division
- Eliminate the fudge to avoid negative term weights, inherited from our BM25 implementation