### PR TITLE
python bindings: sphinx-build is an executable

### DIFF
--- a/xapian-bindings/python/Makefile.am
+++ b/xapian-bindings/python/Makefile.am
@@ -163,4 +163,4 @@ install-data-local:
 all-local: $(sphinxdocs)
 
 $(sphinxdocs): xapian/__init__.py xapian/_xapian$(PYTHON2_SO) docs/conf.py $(RST_DOCS) $(dist_exampledata_DATA)
-	PYTHONPATH=..:$$PYTHONPATH $(PYTHON2) $(SPHINX_BUILD) -b html -d doctrees -c docs $(srcdir)/docs docs/html
+	PYTHONPATH=..:$$PYTHONPATH $(SPHINX_BUILD) -b html -d doctrees -c docs $(srcdir)/docs docs/html

--- a/xapian-bindings/python3/Makefile.am
+++ b/xapian-bindings/python3/Makefile.am
@@ -168,4 +168,4 @@ install-data-local:
 all-local: $(sphinxdocs)
 
 $(sphinxdocs): xapian/__init__.py xapian/_xapian$(PYTHON3_SO) docs/conf.py $(RST_DOCS) $(dist_exampledata_DATA)
-	PYTHONPATH=..:$$PYTHONPATH $(PYTHON3) $(SPHINX_BUILD) -b html -d doctrees -c docs $(srcdir)/docs docs/html
+	PYTHONPATH=..:$$PYTHONPATH $(SPHINX_BUILD) -b html -d doctrees -c docs $(srcdir)/docs docs/html


### PR DESCRIPTION
sphinx-build can be run directly (it is a Python executable with a
shebang), so it is sometimes replaced by a Bash wrapper script.  Trying
to run it as a Python script will break in those situations.

See e.g. https://github.com/Homebrew/homebrew-core/issues/6660#issuecomment-258699832