### PR TITLE
L wdf normalisation support in TfIdfWeight

### DIFF
--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -423,7 +423,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /* When additional normalizations are implemented in the future, the additional statistics for them
        should be accessed by these functions. */
-    double get_wdfn(Xapian::termcount wdf, Xapian::termcount len, char c) const;
+    double get_wdfn(Xapian::termcount wdf,
+		    Xapian::termcount len,
+		    Xapian::termcount uniqterms, char c) const;
     double get_idfn(char c) const;
     double get_wtn(double wt, char c) const;
 
@@ -444,6 +446,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      *     @li 's': Square     wdfn=wdf*wdf
      *     @li 'l': Logarithmic wdfn=1+log<sub>e</sub>(wdf)
      *     @li 'P': Pivoted     wdfn=(1+log(1+log(wdf)))*(1/(1-slope+(slope*doclen/avg_len)))+delta
+     *     @li 'L': Log average wdfn=(1+log(wdf))/(1+log(doclen/unique_terms))
      *
      *     The Max-wdf and Augmented Max wdf normalizations haven't yet been
      *     implemented.

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -929,6 +929,15 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 	TEST_EQUAL_DOUBLE(mset[i].get_weight(), 0.0);
     }
 
+    // Check for "Lnn".
+    enquire.set_query(Xapian::Query("word"));
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("Lnn"));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), (1+log(8.0)) / (1+log(81.0/56.0)));
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), (1+log(1.0)) / (1+log(31.0/26.0)));
+
     enquire.set_query(Xapian::Query("word"));
     enquire.set_weighting_scheme(Xapian::TfIdfWeight("npn"));
     mset = enquire.get_mset(0, 10);

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -935,8 +935,8 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     mset_expect_order(mset, 2, 4);
-    TEST_EQUAL_DOUBLE(mset[0].get_weight(), (1+log(8.0)) / (1+log(81.0/56.0)));
-    TEST_EQUAL_DOUBLE(mset[1].get_weight(), (1+log(1.0)) / (1+log(31.0/26.0)));
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), (1 + log(8.0)) / (1 + log(81.0 / 56.0)));
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), (1 + log(1.0)) / (1 + log(31.0 / 26.0)));
 
     enquire.set_query(Xapian::Query("word"));
     enquire.set_weighting_scheme(Xapian::TfIdfWeight("npn"));

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -148,8 +148,7 @@ TfIdfWeight::get_maxpart() const
 {
     Xapian::termcount wdf_max = get_wdf_upper_bound();
     Xapian::termcount len_min = get_doclength_lower_bound();
-    Xapian::termcount len_max = get_doclength_upper_bound();
-    double wdfn = get_wdfn(wdf_max, len_min, len_max, normalizations[0]);
+    double wdfn = get_wdfn(wdf_max, len_min, len_min, normalizations[0]);
     return get_wtn(wdfn * idfn, normalizations[2]) * wqf_factor;
 }
 

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -83,13 +83,11 @@ TfIdfWeight::TfIdfWeight(const std::string &normals, double slope, double delta)
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
     }
-    else if (normalizations[0] == 'L') {
+    if (normalizations[0] == 'L') {
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
 	need_stat(DOC_LENGTH_MAX);
 	need_stat(UNIQUE_TERMS);
-	if (normalizations[1] == 'P')
-	    need_stat(AVERAGE_LENGTH);
     }
 }
 

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -51,10 +51,12 @@ TfIdfWeight::TfIdfWeight(const std::string &normals)
     need_stat(WDF);
     need_stat(WDF_MAX);
     need_stat(WQF);
-    need_stat(DOC_LENGTH);
-    need_stat(DOC_LENGTH_MIN);
-    need_stat(DOC_LENGTH_MAX);
-    need_stat(UNIQUE_TERMS);
+    if (normalizations[0] == 'L') {
+	need_stat(DOC_LENGTH);
+	need_stat(DOC_LENGTH_MIN);
+	need_stat(DOC_LENGTH_MAX);
+	need_stat(UNIQUE_TERMS);
+    }
 }
 
 TfIdfWeight::TfIdfWeight(const std::string &normals, double slope, double delta)
@@ -76,12 +78,18 @@ TfIdfWeight::TfIdfWeight(const std::string &normals, double slope, double delta)
     need_stat(WDF);
     need_stat(WDF_MAX);
     need_stat(WQF);
-    need_stat(DOC_LENGTH);
-    need_stat(DOC_LENGTH_MIN);
-    need_stat(DOC_LENGTH_MAX);
-    need_stat(UNIQUE_TERMS);
     if (normalizations[0] == 'P' || normalizations[1] == 'P') {
 	need_stat(AVERAGE_LENGTH);
+	need_stat(DOC_LENGTH);
+	need_stat(DOC_LENGTH_MIN);
+    }
+    else if (normalizations[0] == 'L') {
+	need_stat(DOC_LENGTH);
+	need_stat(DOC_LENGTH_MIN);
+	need_stat(DOC_LENGTH_MAX);
+	need_stat(UNIQUE_TERMS);
+	if (normalizations[1] == 'P')
+	    need_stat(AVERAGE_LENGTH);
     }
 }
 


### PR DESCRIPTION
This PR adds support for the L wdf normalisation in TfIdfWeight. 
* Code builds successfully.
* All tests pass.