### PR TITLE
Add EMPTY_NOMATCH flag to return empty string for non-matching snippets

### DIFF
--- a/xapian-core/include/xapian/mset.h
+++ b/xapian-core/include/xapian/mset.h
@@ -164,7 +164,14 @@ class XAPIAN_VISIBILITY_DEFAULT MSet {
 	 *  it has found a "good enough" snippet, which will generally reduce
 	 *  the time taken to generate a snippet.
 	 */
-	SNIPPET_EXHAUSTIVE = 2
+	SNIPPET_EXHAUSTIVE = 2,
+	/** Return the empty string if no term got matched.
+	 *
+	 *  If enabled, snippet() returns an empty string if not a single match
+	 *  was found in text. If not enabled, snippet() returns a (sub)string
+	 *  of text without any highlighted terms.
+	 */
+	SNIPPET_EMPTY_WITHOUT_MATCH = 4
     };
 
     /** Generate a snippet.

--- a/xapian-core/queryparser/termgenerator_internal.cc
+++ b/xapian-core/queryparser/termgenerator_internal.cc
@@ -690,6 +690,7 @@ MSet::Internal::snippet(const string & text,
     vector<string> phrase;
     if (longest_phrase) phrase.resize(longest_phrase - 1);
     size_t phrase_next = 0;
+    bool matchfound = false;
     parse_terms(Utf8Iterator(text), cjk_ngram, true,
 	[&](const string & term, bool positional, const Utf8Iterator & it) {
 	    // FIXME: Don't hardcode this here.
@@ -832,6 +833,8 @@ relevance_done:
 		phrase_next = (phrase_next + 1) % (longest_phrase - 1);
 	    }
 
+	    if (highlight) matchfound = true;
+
 	    if (!snip.pump(relevance, term_end, highlight, flags)) return false;
 
 	    term_start = term_end;
@@ -842,7 +845,9 @@ relevance_done:
 
     // Put together the snippet.
     string result;
-    while (snip.drain(text, hi_start, hi_end, omit, result)) { }
+    if (matchfound || (flags & SNIPPET_EMPTY_WITHOUT_MATCH) == 0) {
+	    while (snip.drain(text, hi_start, hi_end, omit, result)) { }
+    }
 
     return result;
 }


### PR DESCRIPTION
Currently, if MSet::snippet() can't find any matching snippet term it returns the first n bytes of the input text. This patch adds an optional flag to the  snippet generator to return the empty string if no match was found. The current behaviour remains default.