### PR TITLE
Fix compilation on Darwin

### DIFF
--- a/xapian-core/api/omenquire.cc
+++ b/xapian-core/api/omenquire.cc
@@ -44,6 +44,8 @@
 #include "str.h"
 #include "weight/weightinternal.h"
 
+#include "exp10.h"
+
 #include <algorithm>
 #include "autoptr.h"
 #include <cfloat>
@@ -255,7 +257,7 @@ MSet::get_matches_estimated() const
 	return e;
     }
 
-    Xapian::doccount r = Xapian::doccount(exp10(int(log10(D))) + 0.5);
+    Xapian::doccount r = Xapian::doccount(EXP10(int(log10(D))) + 0.5);
     while (r > e) r /= 10;
 
     Xapian::doccount R = e / r * r;

--- a/xapian-core/common/exp10.h
+++ b/xapian-core/common/exp10.h
@@ -1,0 +1,33 @@
+/** @file exp10.h
+ * @brief Defines an exp10() function depending on how the system defines it.
+ */
+/* Copyright (C) 2017 Sébastien Le Callonnec
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_EXP10_H
+#define XAPIAN_INCLUDED_EXP10_H
+
+#include <cmath>
+#ifdef HAVE_DECL_GNU_EXP10
+#define EXP10(X) exp10(X)
+#elif defined HAVE_DECL_APPLE_EXP10
+#define EXP10(X) __exp10(X)
+#else
+#define EXP10(X) pow(10, X)
+#endif
+
+#endif // XAPIAN_INCLUDED_EXP10_H

--- a/xapian-core/configure.ac
+++ b/xapian-core/configure.ac
@@ -967,6 +967,13 @@ AC_CHECK_FUNCS([fsync])
 AC_CHECK_FUNCS([posix_fadvise])
 AC_CHECK_FUNCS([ftruncate])
 
+dnl Darwin defines __exp10 rather than exp10
+AC_CHECK_FUNC([exp10],
+    [AC_DEFINE([HAVE_DECL_GNU_EXP10], [1], [GNU C defines exp10])],
+    [AC_CHECK_FUNC([__exp10],
+        [AC_DEFINE([HAVE_DECL_APPLE_EXP10], [1], [Darwin defines __exp10])])
+])
+
 dnl HP-UX has pread and pwrite, but they don't work!  Apparently this problem
 dnl manifests when largefile support is enabled, and we definitely want that
 dnl so don't use pread or pwrite on HP-UX.


### PR DESCRIPTION
OSX doesn't have the `exp10` function.