### PR TITLE
Fix Travis builds for clang configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ matrix:
     - os: osx
       before_install:
         - brew update
-        - brew install doxygen help2man graphviz pngcrush libmagic pcre libsvm lua mono python3
+        - brew install doxygen --HEAD
+        - brew install help2man graphviz pngcrush libmagic pcre libsvm lua mono python3
         - pip install sphinx docutils
         - pip3 install sphinx
         - mkdir -p /tmp/xapian-libsvm-fixed-include

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         - pip install sphinx docutils
         - pip3 install sphinx
         - mkdir -p /tmp/xapian-libsvm-fixed-include
-        - ln -sF /usr/local/Cellar/libsvm/3.21/include /tmp/xapian-libsvm-fixed-include/libsvm
+        - ln -sF /usr/local/Cellar/libsvm/3.22/include /tmp/xapian-libsvm-fixed-include/libsvm
       env: CXXFLAGS=-Wno-error=reserved-user-defined-literal CPPFLAGS=-I/tmp/xapian-libsvm-fixed-include confargs=--prefix=/Users/travis/XapianInstall installcore='make -C xapian-core install'
 
 before_script:


### PR DESCRIPTION
The libsvm3 package has been upgraded from 3.21 to 3.22 for the clang build image, so /tmp/xapian-libsvm-fixed-include/libsvm needs to point to the new version (https://travis-ci.org/xapian/xapian/jobs/192285478#L2315).

Fixing this, I see Travis fail with a doxygen segmentation fault (e.g. https://travis-ci.org/xapian/xapian/jobs/192290918#L5247), so this PR might still require more commits to make Travis pass clang builds.
