### PR TITLE
Change use of atoi/atol to stoi/stol

### DIFF
--- a/xapian-applications/omega/date.cc
+++ b/xapian-applications/omega/date.cc
@@ -24,6 +24,8 @@
 
 #include <config.h>
 
+#include <iostream>
+
 #include "date.h"
 
 #include <vector>
@@ -130,9 +132,15 @@ parse_date(const string & date, int *y, int *m, int *d)
 {
     // FIXME: for now only support YYYYMMDD (e.g. 20011119)
     // and don't error check
-    *y = atoi(date.substr(0, 4).c_str());
-    *m = atoi(date.substr(4, 2).c_str());
-    *d = atoi(date.substr(6, 2).c_str());
+    try {
+    *y = stoi(date.substr(0, 4).c_str(), nullptr); //stoi can be used instead of atoi in this function
+    *m = stoi(date.substr(4, 2).c_str(), nullptr);
+    *d = stoi(date.substr(6, 2).c_str(), nullptr);
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/date.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
 }
 
 Xapian::Query
@@ -141,7 +149,14 @@ date_range_filter(const string & date_start, const string & date_end,
 {
     int y1, m1, d1, y2, m2, d2;
     if (!date_span.empty()) {
-	time_t secs = atoi(date_span.c_str()) * (24 * 60 * 60);
+    time_t secs;
+    try {
+	secs = stoi(date_span.c_str(), nullptr) * (24 * 60 * 60); //stoi can be used instead of atoi
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/date.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
 	if (!date_end.empty()) {
 	    parse_date(date_end, &y2, &m2, &d2);
 	    struct tm t;

--- a/xapian-applications/omega/datevalue.cc
+++ b/xapian-applications/omega/datevalue.cc
@@ -19,6 +19,7 @@
  */
 
 #include <config.h>
+#include <iostream>
 
 #include "datevalue.h"
 
@@ -223,7 +224,14 @@ date_value_range(bool as_time_t,
     DateRangeLimit end(date_end, false);
 
     if (!date_span.empty()) {
-	time_t span = atoi(date_span.c_str()) * (24 * 60 * 60) - 1;
+	time_t span = 0;
+    try {
+    span = stoi(date_span.c_str(), nullptr) * (24 * 60 * 60) - 1; //change from atoi to stoi
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/datevalue.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
 	if (end.is_set()) {
 	    // If START, END and SPAN are all set, we (somewhat arbitrarily)
 	    // ignore START.

--- a/xapian-applications/omega/omega.cc
+++ b/xapian-applications/omega/omega.cc
@@ -173,7 +173,13 @@ try {
 
     hits_per_page = 0;
     val = cgi_params.find("HITSPERPAGE");
-    if (val != cgi_params.end()) hits_per_page = atol(val->second.c_str());
+    try {
+    if (val != cgi_params.end()) hits_per_page = stol(val->second.c_str()); //change from atol to stol
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/omega.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
     if (hits_per_page == 0) {
 	hits_per_page = 10;
     } else if (hits_per_page > 1000) {
@@ -198,7 +204,14 @@ try {
     val = cgi_params.find("MORELIKE");
     if (enquire && val != cgi_params.end()) {
 	const string & v = val->second;
-	Xapian::docid docid = atol(v.c_str());
+	Xapian::docid docid = 0;
+    try {
+    docid = stol(v.c_str()); //change from atol to stol
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/omega.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
 	if (docid == 0) {
 	    // Assume it's MORELIKE=Quid1138 and that Quid1138 is a UID
 	    // from an external source - we just find the correspond docid
@@ -390,7 +403,13 @@ try {
     // Percentage relevance cut-off
     val = cgi_params.find("THRESHOLD");
     if (val != cgi_params.end()) {
-	threshold = atoi(val->second.c_str());
+    try {
+	threshold = stoi(val->second.c_str(), nullptr); //change from atoi to stoi
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/omega.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
 	if (threshold < 0) threshold = 0;
 	if (threshold > 100) threshold = 100;
     }
@@ -400,7 +419,13 @@ try {
     if (val != cgi_params.end()) {
 	const string & v = val->second;
 	if (!v.empty()) {
-	    collapse_key = atoi(v.c_str());
+        try {
+	    collapse_key = stoi(v.c_str()); //change from atoi to stoi
+        } catch(invalid_argument &e)
+        {
+        cerr << "error in file /xapian-application/omega/omega.cc exception by stoi" << endl;
+        exit(EXIT_FAILURE);
+        }
 	    collapse = true;
 	    filters += filter_sep;
 	    filters += str(collapse_key);
@@ -495,14 +520,27 @@ try {
 	} while (*p);
 
 	val = cgi_params.find("SORTREVERSE");
-	if (val != cgi_params.end() && atoi(val->second.c_str()) != 0) {
+    try {
+	if (val != cgi_params.end() && stoi(val->second.c_str()) != 0) { //change from atoi to stoi
 	    reverse_sort = !reverse_sort;
 	}
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/omega.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
+
 
 	val = cgi_params.find("SORTAFTER");
+    try {
 	if (val != cgi_params.end()) {
-	    sort_after = (atoi(val->second.c_str()) != 0);
+	    sort_after = (stoi(val->second.c_str()) != 0); //change from atoi to stoi
 	}
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/omega.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
 
 	// Add the sorting related options to filters too.
 	//
@@ -536,7 +574,13 @@ try {
     // topdoc+max(hits_per_page+1,min_hits)
     val = cgi_params.find("MINHITS");
     if (val != cgi_params.end()) {
-	min_hits = atol(val->second.c_str());
+    try {
+	min_hits = stol(val->second.c_str()); //change from atol to stol
+    } catch(invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/omega.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
     }
 
     parse_omegascript();

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -404,7 +404,14 @@ main(int argc, char **argv)
 	    delete_removed_documents = false;
 	    break;
 	case 'l': { // Set recursion limit
-	    int arg = atoi(optarg);
+        int arg = 0;
+        try {
+        arg = stoi(optarg, NULL, 10); // changed from atoi to stol
+        } catch(invalid_argument &e) {
+        cerr << "-l: Invalid Argument passed,"
+            << " a pure number was expected" << endl;
+        exit(EXIT_FAILURE);
+        }
 	    if (arg < 0) arg = 0;
 	    depth_limit = size_t(arg);
 	    break;

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1992,7 +1992,14 @@ eval(const string &fmt, const vector<string> &param)
 		string::size_type i = 0, j;
 		while (true) {
 		    j = args[0].find_first_not_of("0123456789", i);
-		    Xapian::docid id = atoi(args[0].substr(i, j - i).c_str());
+		    Xapian::docid id = 0;
+            try{
+            id = stoi(args[0].substr(i, j - i).c_str(), nullptr); //change from atoi to stoi
+            } catch(invalid_argument &e)
+            {
+            cerr << "error in file /xapian-application/omega/query.cc exception by stoi" << endl;
+            exit(EXIT_FAILURE);
+            }
 		    if (id) {
 			rset.add_document(id);
 			ticked[id] = true;
@@ -2455,7 +2462,13 @@ ensure_query_parsed()
 	// to display
 	val = cgi_params.find("TOPDOC");
 	if (val != cgi_params.end()) {
-	    topdoc = atol(val->second.c_str());
+        try {
+	    topdoc = stol(val->second.c_str()); //change from atol to stol
+        } catch(invalid_argument &e)
+        {
+        cerr << "error in file /xapian-application/omega/query.cc exception by stoi" << endl;
+        exit(EXIT_FAILURE);
+        }
 	}
 
 	// Handle next, previous, and page links
@@ -2468,7 +2481,14 @@ ensure_query_parsed()
 		topdoc = 0;
 	} else if ((val = cgi_params.find("[")) != cgi_params.end() ||
 		   (val = cgi_params.find("#")) != cgi_params.end()) {
-	    long page = atol(val->second.c_str());
+        long page = 0;
+        try {
+	    page = stol(val->second.c_str()); //change from atol to stol
+        } catch(invalid_argument &e)
+        {
+        cerr << "error in file /xapian-application/omega/query.cc exception by stoi" << endl;
+        exit(EXIT_FAILURE);
+        }
 	    // Do something sensible for page 0 (we count pages from 1).
 	    if (page == 0) page = 1;
 	    topdoc = (page - 1) * hits_per_page;
@@ -2482,7 +2502,13 @@ ensure_query_parsed()
 	bool raw_search = false;
 	val = cgi_params.find("RAWSEARCH");
 	if (val != cgi_params.end()) {
-	    raw_search = bool(atol(val->second.c_str()));
+        try {
+	    raw_search = bool(stol(val->second.c_str())); //change from atol to stol
+        } catch(invalid_argument &e)
+        {
+        cerr << "error in file /xapian-application/omega/query.cc exception by stoi" << endl;
+        exit(EXIT_FAILURE);
+        }
 	}
 
 	if (!raw_search) topdoc = (topdoc / hits_per_page) * hits_per_page;
@@ -2495,7 +2521,13 @@ ensure_query_parsed()
 	    const string & value = i->second;
 	    for (size_t j = 0; j < value.size(); j = value.find('.', j)) {
 		while (value[j] == '.') ++j;
-		Xapian::docid d = atoi(value.c_str() + j);
+		Xapian::docid d;
+        try {
+        d = stoi(value.c_str() + j, nullptr); //change from atoi to stoi
+        } catch(invalid_argument &e) {
+        cerr << "error in file /xapian-application/omega/query.cc exception by stoi" << endl;
+        exit(EXIT_FAILURE);
+        }
 		if (d) {
 		    rset.add_document(d);
 		    ticked[d] = true;

--- a/xapian-applications/omega/scriptindex.cc
+++ b/xapian-applications/omega/scriptindex.cc
@@ -117,7 +117,12 @@ public:
     Action(type action_) : action(action_), num_arg(0) { }
     Action(type action_, const string & arg)
 	: action(action_), string_arg(arg) {
-	num_arg = atoi(string_arg.c_str());
+    try {
+	num_arg = stoi(string_arg.c_str(), nullptr); //change from atoi to stoi
+    } catch(invalid_argument &e) {
+    cerr << "error in file /xapian-application/omega/scriptindex.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
     }
     Action(type action_, const string & arg, int num)
 	: action(action_), num_arg(num), string_arg(arg) { }
@@ -311,7 +316,13 @@ parse_index_script(const string &filename)
 			// We don't push an Action for WEIGHT - instead we
 			// store it ready to use in the INDEX and INDEXNOPOS
 			// Actions.
-			weight = atoi(val.c_str());
+            try {
+			weight = stoi(val.c_str(), nullptr); //change from atoi to stoi
+            } catch(invalid_argument)
+            {
+            cerr << "error in file /xapian-application/omega/scriptindex.cc exception by stoi" << endl;
+            exit(EXIT_FAILURE);
+            }
 			if (useless_weight_pos != string::npos) {
 			    report_useless_action(filename, line_no,
 						  useless_weight_pos, action);
@@ -619,7 +630,14 @@ again:
 			const string & type = i->get_string_arg();
 			string yyyymmdd;
 			if (type == "unix") {
-			    time_t t = atoi(value.c_str());
+                time_t t = 0;
+                try {
+			    t = stoi(value.c_str(), nullptr); //change from atoi to stoi
+                } catch(invalid_argument &e)
+                {
+                cerr << "error in file /xapian-application/omega/scriptindex.cc exception by stoi" << endl; 
+                exit(EXIT_FAILURE);
+                }
 			    struct tm *tm = localtime(&t);
 			    int y = tm->tm_year + 1900;
 			    int m = tm->tm_mon + 1;

--- a/xapian-applications/omega/utils.cc
+++ b/xapian-applications/omega/utils.cc
@@ -20,6 +20,7 @@
  */
 
 #include <config.h>
+#include <iostream> // for cerr
 
 #include "utils.h"
 
@@ -52,7 +53,15 @@ using namespace std;
 int
 string_to_int(const string &s)
 {
-    return atoi(s.c_str());
+    int tmp = 0;
+    try {
+    tmp = std::stoi(s.c_str(), nullptr); //changed to stoi from atoi
+    } catch(std::invalid_argument &e)
+    {
+    cerr << "error in file /xapian-application/omega/utils.cc exception by stoi" << endl;
+    exit(EXIT_FAILURE);
+    }
+    return tmp;
 }
 
 string


### PR DESCRIPTION
Referred from https://trac.xapian.org/wiki/ProjectIdeas#BiteSize Replace atoi() and atol() 

But instead of strtol or strtoul I used stoi and stol (part of stl string), as they raise exceptions on the wrong inputs but strtol/strtoul(the part of the stdlib.h) don't raise the exceptions

This is the change in the xapian-application/omega/ applications, all the required occurences of the atoi/atol are changed, and a try catch mechanism is added to extra so that if suppose in future there is error in converting from string to number, the invalid_exception is raised so that the proper position of the error is known, stoi and stol functions (the part of stl string) are similar to atoi/atol except that they throw error/exception whern we send string something like "ab123" and atoi gives value of 0, but on sending the string like "123ab" they both will give the valid output, in this case 123 http://www.cplusplus.com/reference/string/stoi/ , so according to me we should also change the occurrences of the atoi and atol in the cgiparam.cc file as if we get the valid output in the strings like "2[=" then both atoi and stoi can handle them, my next step is to remove the call of the member function c_str() at the places where I replaced atoi to stoi, but before I need verification, that I did this work correct, 