### PR TITLE
Fix broken snippetmisc1 test

### DIFF
--- a/xapian-core/tests/api_snippets.cc
+++ b/xapian-core/tests/api_snippets.cc
@@ -178,7 +178,7 @@ DEFINE_TESTCASE(snippetmisc1, generated) {
     Xapian::MSet mset = enquire.get_mset(0, 6);
     TEST_EQUAL(mset.size(), 3);
     TEST_STRINGS_EQUAL(mset.snippet(mset[0].get_document().get_data(), 40, stem),
-		       "How much o'brien <b>do we have</b>?  Miles...");
+		       "...<b>do we have</b>?  Miles O'Brien, that's how...");
     TEST_STRINGS_EQUAL(mset.snippet(mset[1].get_document().get_data(), 40, stem),
 		       "...Unicode: How much o’brien <b>do we have</b>?");
     TEST_STRINGS_EQUAL(mset.snippet(mset[2].get_document().get_data(), 32, stem),


### PR DESCRIPTION
The snippetmisc1 unit test currently breaks on master when ran on backend 'glass'. This seems to have slipped through when the snippet test patch was initially merged.