### PR TITLE
Using std::unordered_set with SimpleStopper

### DIFF
--- a/xapian-core/include/xapian/queryparser.h
+++ b/xapian-core/include/xapian/queryparser.h
@@ -33,8 +33,8 @@
 #include <xapian/termiterator.h>
 #include <xapian/visibility.h>
 
-#include <set>
 #include <string>
+#include <unordered_set>
 
 namespace Xapian {
 
@@ -79,7 +79,7 @@ class XAPIAN_VISIBILITY_DEFAULT Stopper
 
 /// Simple implementation of Stopper class - this will suit most users.
 class XAPIAN_VISIBILITY_DEFAULT SimpleStopper : public Stopper {
-    std::set<std::string> stop_words;
+    std::unordered_set<std::string> stop_words;
 
   public:
     /// Default constructor.

--- a/xapian-core/queryparser/queryparser.cc
+++ b/xapian-core/queryparser/queryparser.cc
@@ -47,7 +47,7 @@ string
 SimpleStopper::get_description() const
 {
     string desc("Xapian::SimpleStopper(");
-    set<string>::const_iterator i;
+    unordered_set<string>::const_iterator i;
     for (i = stop_words.begin(); i != stop_words.end(); ++i) {
 	if (i != stop_words.begin()) desc += ' ';
 	desc += *i;


### PR DESCRIPTION
Since Xapian now uses c++11, we can use std::unordered_set instead of std::set for faster identification of stopwords