### PR TITLE
Fix macOS build on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,10 @@ matrix:
         # already installed and up-to-date, but travis change what's installed
         # by default from time to time so it's brittle to just filter out those
         # installed by default from the list we need.  Instead we ignore the
-        # exit status from "brew install", then check that "brew outdated" says
-        # all the packages requested are installed.
+        # exit status from "brew install", then check that
+        # "brew list --versions" says all the packages requested are installed.
         - brew install $HOMEBREW_PACKAGES || true
-        - brew outdated $HOMEBREW_PACKAGES
+        - brew list --versions $HOMEBREW_PACKAGES
         - pip install sphinx docutils
         - pip3 install sphinx
         - mkdir -p /tmp/xapian-libsvm-fixed-include


### PR DESCRIPTION
homebrew is fiddly to work with; brew outdated doesn't give us
a reliable (and crucially exit-code driven) way of checking
whether packages are actually installed. Instead, we now use
brew install --versions, which apparently will exit 0 if and only
if all listed formulae are installed. (We use --versions because
it just lists the formulae and installed versions, rather than all
the files that make up each formula.)