### PR TITLE
omindex: delay libmagic checks(ticket#743)

### DIFF
--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -93,14 +93,7 @@ index_file(const string &file, const string &url, DirectoryIterator & d,
 	urlterm = hash_long_term(urlterm, MAX_SAFE_TERM_LENGTH);
 
     string mimetype = mimetype_from_ext(mime_map, ext);
-    if (mimetype.empty()) {
-	mimetype = d.get_magic_mimetype();
-	if (mimetype.empty()) {
-	    skip(urlterm, file.substr(root.size()), "Unknown extension and unrecognised format",
-		 d.get_size(), d.get_mtime(), SKIP_SHOW_FILENAME);
-	    return;
-	}
-    } else if (mimetype == "ignore") {
+    if (mimetype == "ignore") {
 	return;
     } else if (mimetype == "skip") {
 	// Ignore mimetype, skipped mimetype should not be quietly ignored.
@@ -111,13 +104,7 @@ index_file(const string &file, const string &url, DirectoryIterator & d,
 	return;
     }
 
-    if (verbose)
-	cout << "Indexing \"" << file.substr(root.size()) << "\" as "
-	     << mimetype << " ... ";
-
-    // Only check the file size if we recognise the extension to avoid a call
-    // to stat()/lstat() for files we definitely can't handle when readdir()
-    // tells us the file type.
+    // check the file size
     off_t size = d.get_size();
     if (size == 0) {
 	skip(urlterm, file.substr(root.size()), "Zero-sized file",
@@ -132,6 +119,20 @@ index_file(const string &file, const string &url, DirectoryIterator & d,
 	     SKIP_VERBOSE_ONLY);
 	return;
     }
+
+    // if can't get the mime type from extension,call libmagic to get it
+    if (mimetype.empty()) {
+	mimetype = d.get_magic_mimetype();
+	if (mimetype.empty()) {
+	    skip(urlterm, file.substr(root.size()), "Unknown extension and unrecognised format",
+		 d.get_size(), d.get_mtime(), SKIP_SHOW_FILENAME);
+	    return;
+	}
+    }
+
+    if (verbose)
+	cout << "Indexing \"" << file.substr(root.size()) << "\" as "
+	     << mimetype << " ... ";
 
     Xapian::Document new_doc;
 


### PR DESCRIPTION
Link to the Ticket: https://trac.xapian.org/ticket/743

the libmagic call to get mime type is expensive, so we should check it later, for example, we can check the size by call the stat, check the timestamps and the DB for an existing entry before call libmagic.

This PR now achieves to check the filesize before call the libmagic.

To solved next:

since check the timestamps of a file need to check through the database in some situation: when the timestamps of the file return from stat call (says T1 for  convenience) is older than the last time we run omindex, we need to  look through the database to determine if the file is indexed and get the modify time when it is indexed (says T2 for  convenience), if T2 is older than T1, we should re-index the file.

it is expensive to iterate through the DB, so we should figure out the order between libmagic check and timestamps in next step.