### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/xapian-core/net/tcpclient.cc
+++ b/xapian-core/net/tcpclient.cc
@@ -25,7 +25,6 @@
 #include "tcpclient.h"
 
 #include "remoteconnection.h"
-#include "resolver.h"
 #include "str.h"
 #include <xapian/error.h>
 
@@ -36,6 +35,7 @@
 #include "safesysselect.h"
 #include "safesyssocket.h"
 #include "socket_utils.h"
+#include "resolver.h"
 
 #include <cmath>
 #include <cstring>


### PR DESCRIPTION
In net/tcpclient.cc, include resolver.h after safesyssocket.h to solve the following build failure.

```
--- net/tcpclient.lo ---
In file included from net/tcpclient.cc:28:
net/resolver.h:102:20: error: use of undeclared identifier 'AF_INET'
        hints.ai_family = AF_INET;
                          ^
net/resolver.h:103:22: error: use of undeclared identifier 'SOCK_STREAM'
        hints.ai_socktype = SOCK_STREAM;
                            ^
```