### PR TITLE
Fix dangling reference to stopper in letor

### DIFF
--- a/xapian-letor/ranker/ranker.cc
+++ b/xapian-letor/ranker/ranker.cc
@@ -225,7 +225,8 @@ parse_query_string(const string & query_line, int line_number)
 static Xapian::QueryParser
 initialise_queryparser(const Xapian::Database & db)
 {
-    Xapian::SimpleStopper mystopper(sw, sw + sizeof(sw) / sizeof(sw[0]));
+    Xapian::SimpleStopper* mystopper;
+    mystopper = new Xapian::SimpleStopper(sw, sw + sizeof(sw) / sizeof(sw[0]));
     Xapian::Stem stemmer("english");
     Xapian::QueryParser parser;
     parser.add_prefix("title", "S");
@@ -234,7 +235,7 @@ initialise_queryparser(const Xapian::Database & db)
     parser.set_default_op(Xapian::Query::OP_OR);
     parser.set_stemmer(stemmer);
     parser.set_stemming_strategy(Xapian::QueryParser::STEM_SOME);
-    parser.set_stopper(&mystopper);
+    parser.set_stopper(mystopper->release());
     return parser;
 }
 


### PR DESCRIPTION
Since stopper was created locally in Xapian::QueryParser::initialise_queryparser, on calling the function we would get an invalid reference to the stopper. This has been fixed by allocating the stopper using new() and releasing it after it has been set in parser.