### PR TITLE
Returning MSet instead of sorted Docids after re-ranking (Ticket #734)

### DIFF
--- a/xapian-core/api/omenquireinternal.h
+++ b/xapian-core/api/omenquireinternal.h
@@ -313,6 +313,24 @@ class MSet::Internal : public Xapian::Internal::intrusive_base {
 	/** Fetch items specified into the document cache.
 	 */
 	void fetch_items(Xapian::doccount first, Xapian::doccount last) const;
+
+	/** Updates the weight corresponding to the document indexed at
+	 *  position i with wt_.
+	 *
+	 *  Updates the max_possible and max_attained for the MSet.
+	 *
+	 *  set_item_weight must be called to update the weight of every
+	 *  document in MSet in the same order as that of the documents present
+	 *  in MSet to avoid miscalculation of max_attained and max_possible.
+	 *
+	 *  @param i	position of the document in MSet whose weight is being
+	 *		updated.
+	 *  @param wt_  new weight assigned to the document.
+	 */
+	void set_item_weight(Xapian::doccount i, double wt_);
+
+	/// Sorts the MSet::Internal::items by their corresponding weights.
+	void sort_by_relevance();
 };
 
 class RSet::Internal : public Xapian::Internal::intrusive_base {

--- a/xapian-letor/bin/xapian-rank.cc
+++ b/xapian-letor/bin/xapian-rank.cc
@@ -192,12 +192,10 @@ try {
     }
 
     cout << "Docids before re-ranking by LTR model:" << endl;
-    int rank = 0;
     for (Xapian::MSetIterator i = mset.begin(); i != mset.end(); ++i) {
-
 	Xapian::Document doc = i.get_document();
-	Xapian::docid did = doc.get_docid();
-	cout << "Rank " << ++rank << ": " << did << endl;
+	string data = doc.get_data();
+	cout << *i << ": [" << i.get_weight() << "]\n" << data << "\n";
     }
 
     // Initialise Ranker object with ListNETRanker instance, db path and query.
@@ -207,13 +205,15 @@ try {
     ranker->set_query(query);
 
     // Get vector of re-ranked docids
-    std::vector<Xapian::docid> ranked_docids = ranker->rank(mset, model_metadata_key);
+    ranker->rank(mset, model_metadata_key);
 
-    cout << "Docids after re-ranking by LTR model:" << endl;
-    rank = 0;
-    for (auto&& did : ranked_docids)
-	cout << "Rank " << ++rank << ": " << did << endl;
+    cout << "Docids after re-ranking by LTR model:\n" << endl;
 
+    for (Xapian::MSetIterator i = mset.begin(); i != mset.end(); ++i) {
+	Xapian::Document doc = i.get_document();
+	string data = doc.get_data();
+	cout << *i << ": [" << i.get_weight() << "]\n" << data << "\n";
+    }
     delete ranker;
 
     cout << flush;

--- a/xapian-letor/include/xapian-letor/ranker.h
+++ b/xapian-letor/include/xapian-letor/ranker.h
@@ -37,36 +37,58 @@
 
 namespace Xapian {
 
-    /** Utility function that prepares the 'training-data.txt' file in the current working directory. This file is used to train a model which in turn will be used to
-     *  assign scores to the documents based of Learning-to-Rank model. The file is created in the standard format of Letor training file
+    /** Utility function that prepares the training data.
+     *
+     *  The training data file is used to train a model which in turn will be used to
+     *  assign scores to the documents based of Learning-to-Rank model.
+     *
+     *  The file is created in the standard format of Letor training file
      *  as below:
      *
-     *  0 qid:102 1:0.130742 2:0.000000 3:0.333333 4:0.000000 ... 18:0.750000 19:1.000000 #docid = 13566007
-     *  1 qid:102 1:0.593640 2:1.000000 3:0.000000 4:0.000000 ... 18:0.500000 19:0.000000 #docid = 0740276
+     *  0 qid:102 1:0.130742 2:0.000000 3:0.333333 4:0.000000 ... 18:0.750000
+     *            19:1.000000 #docid = 13566007
+     *  1 qid:102 1:0.593640 2:1.000000 3:0.000000 4:0.000000 ... 18:0.500000
+     *            19:0.000000 #docid = 0740276
      *
-     *  where first column is relevance judgement of the document with docid as shown in the last column. The second column is query id and in between
+     *  where first column is relevance judgement of the document with docid as
+     *  shown in the last column. The second column is query id and in between
      *  there are 19 feature values.
      *
-     *  @param  db_path		Path to Xapian::Database to be used.
-     *  @param  query_file      Here you have to give a path to the file (in free text form)  containing training queries in specified format.
-     *  @param  qrel_file       Here supply the path to the qrel file (in free text form) containing the relevance judgements for the
-     *          queries in the training file. This file should be in standard format specified.
-     *  @param  msetsize   This is the mset size used for the first retrieval for training queries. It should be selected depending on the qrel file
-     *          and database size.
-     *  @param  filename   Filename path where the training file has to be stored. Default is "./training-data.txt".
-     *  @param  flist      Xapian::FeatureList object definining what set of features to use for preparing the training file.
-     *          It is initialised by DEFAULT set of Features by default.
-     *          To use a custom set of features, pass a customised Xapian::FeatureList object.
-     *  @exception FileNotFoundError will be thrown if file not found at supplied path
-     *  @exception LetorParseError will be thrown if query file or qrel file could not be parsed
+     *  @param  db_path	Path to Xapian::Database to be used.
+     *  @param  query_file      Here you have to give a path to the file
+     *				(in free text form) containing training queries
+     *				in specified format.
+     *  @param  qrel_file       Here supply the path to the qrel file
+     *				(in free text form) containing the relevance
+     *				judgements for the queries in the training
+     *				file. This file should be in standard format
+     *				specified.
+     *  @param  msetsize	This is the mset size used for the first
+     *				retrieval for training queries.
+     *				It should be selected depending on the qrel
+     *				file and database size.
+     *  @param  filename	Filename path where the training file has to
+     *				be stored. Default is "./training-data.txt".
+     *  @param  flist		Xapian::FeatureList object defining what set
+     *				of features to use for preparing the training
+     *				file. It is initialised by DEFAULT set of
+     *				Features by default. To use a custom set of
+     *				features, pass a customised Xapian::FeatureList
+     *				object.
+     *
+     *  @exception FileNotFoundError will be thrown if file not found at
+     *		   supplied path
+     *  @exception LetorParseError will be thrown if query file or qrel file
+     *		   could not be parsed
      */
     XAPIAN_VISIBILITY_DEFAULT
-    void prepare_training_file(const std::string & db_path,
-			       const std::string & query_file,
-			       const std::string & qrel_file,
-			       Xapian::doccount msetsize,
-			       const std::string & filename = "training-data.txt",
-			       const Xapian::FeatureList & flist = Xapian::FeatureList());
+    void
+    prepare_training_file(const std::string & db_path,
+			  const std::string & query_file,
+			  const std::string & qrel_file,
+			  Xapian::doccount msetsize,
+			  const std::string & filename = "training-data.txt",
+			  const Xapian::FeatureList & flist = FeatureList());
 
 class XAPIAN_VISIBILITY_DEFAULT Ranker : public Xapian::Internal::intrusive_base {
     /// Path to Xapian::Database instance to be used.
@@ -82,58 +104,83 @@ class XAPIAN_VISIBILITY_DEFAULT Ranker : public Xapian::Internal::intrusive_base
     virtual ~Ranker();
 
     /** Specify path to Xapian::Database to be used for Ranker methods.
+     *
      *  @param  dbpath      Path to Xapian::Database to be used.
      */
     void set_database_path(const std::string & dbpath);
 
     /** Get path to Xapian::Database that has been set for ranking.
+     *
      *  @return	  Path to Xapian::Database that has been set for ranking.
      */
     std::string get_database_path();
 
     /** Specify Xapian::Query that is to be used for ranking.
+     *
      *  @param  query      Xapian::Query to be ranked using ranking model.
      */
     void set_query(const Xapian::Query & query);
 
     /** Learns the model using the training file.
-     *  Model file is saved as DB metadata.
-     *  @param  input_filename   Path to training file. Default is "./train.txt".
-     *  @param  model_key  Metadata key using which the model is to be loaded. If no model_key is supplied, ranker subclass
-     *          uses its default key. e.g. ListNET_default_key
-     *  @exception FileNotFoundError will be thrown if file not found at supplied path
-     */
-    void train_model(const std::string & input_filename = "training-data.txt", const std::string & model_key = std::string());
-
-    /** Ranking function. Re-ranks the initial mset using trained model.
      *
-     *  @param  mset       Xapian::MSet corresponding to Xapian::Query that is to be re-ranked
-     *  @param  model_key  DB metadata key from which the ranking model is to be loaded. If no model_key is provided,
-     *                     ranker subclass uses its default model_key e.g. ListNET_default_key
-     *  @param flist       Xapian::FeatureList object definining what set of features to use for ranking.
-     *                     It is initialised by DEFAULT set of Features by default.
-     *                     Note: Make sure that this FeatureList object is the same as what was used during
-     *                     preparation of the training file.
-     *  @exception FileNotFoundError will be thrown if file not found at supplied path
-     *  @return A vector of docids after ranking.
+     *  Model file is saved as DB metadata.
+     *
+     *  @param  input_filename   Path to training file.
+     *				 Default is "./training-data.txt".
+     *  @param  model_key	 Metadata key using which the model is to be
+     *				 loaded. If no model_key is supplied, ranker
+     *				 subclass uses its default key
+     *				 e.g. ListNET_default_key.
+     *
+     *  @exception FileNotFoundError will be thrown if file not found at
+     *		   supplied path
      */
-    std::vector<Xapian::docid> rank(const Xapian::MSet & mset,
-				    const std::string & model_key = std::string(),
-				    const Xapian::FeatureList & flist = Xapian::FeatureList());
+    void train_model(const std::string & input_filename = "training-data.txt",
+		     const std::string & model_key = std::string());
+
+    /** Ranking function.
+     *
+     *  Re-ranks the initial mset using trained model.
+     *
+     *  @param  mset       Xapian::MSet corresponding to Xapian::Query that
+     *			   is to be re-ranked.
+     *  @param  model_key  DB metadata key from which the ranking model is to
+     *			   be loaded. If no model_key is provided,
+     *			   ranker subclass uses its default model_key
+     *			   e.g. ListNET_default_key.
+     *  @param flist       Xapian::FeatureList object defining what set of
+     *			   features to use for ranking. It is initialised by
+     *			   DEFAULT set of Features by default.
+     *                     Note: Make sure that this FeatureList object is the
+     *			   same as what was used during preparation of the
+     *			   training file.
+     */
+    void rank(Xapian::MSet & mset,
+	      const std::string & model_key = std::string(),
+	      const Xapian::FeatureList & flist = Xapian::FeatureList());
 
     /** Method to score the ranking.
-     * @param query_file    Query file containing test queries in letor specified format
-     * @param qrel_file     Qrel file containing relevance judgements for the queries in letor specified format
-     * @param model_key     Model to check for ranking quality
-     * @param output_file   Output file noting scoring results
-     * @param msetsize      MSet size of retrieved documents
-     * @param scorer_type   Scorer algorithm to use. By default, NDCGScore is used.
-     *                      Available algorithms:
-     *                      1. NDCGScore
-     * @param flist         Xapian::FeatureList object definining what set of features to use. Note: Make
-     *                       sure that it is same as what was used while training the model being used.
-     *  @exception FileNotFoundError will be thrown if file not found at supplied path
-     *  @exception LetorParseError will be thrown if query file or qrel file could not be parsed
+     *
+     *  @param query_file    Query file containing test queries in letor
+     *			     specified format.
+     *  @param qrel_file     Qrel file containing relevance judgements for the
+     *			     queries in letor specified format.
+     *  @param model_key     Model to check for ranking quality.
+     *  @param output_file   Output file noting scoring results.
+     *  @param msetsize      MSet size of retrieved documents.
+     *  @param scorer_type   Scorer algorithm to use. By default, NDCGScore is
+     *			     used.
+     *                       Available algorithms:
+     *                       1. NDCGScore
+     *  @param flist         Xapian::FeatureList object defining what set of
+     *			     features to use.
+     *			     Note: Make sure that it is same as what was used
+     *			     while training the model being used.
+     *
+     *  @exception FileNotFoundError will be thrown if file not found at
+     *		   supplied path
+     *  @exception LetorParseError will be thrown if query file or qrel file
+     *		   could not be parsed
      */
     void score(const std::string & query_file,
 	       const std::string & qrel_file,
@@ -144,31 +191,49 @@ class XAPIAN_VISIBILITY_DEFAULT Ranker : public Xapian::Internal::intrusive_base
 	       const Xapian::FeatureList & flist = Xapian::FeatureList());
 
   protected:
-    /// Method to train the model. Overrided in ranker subclass.
-    virtual void train_model(const std::vector<Xapian::FeatureVector> & training_data) = 0;
+    /// Method to train the model. Overridden in ranker subclass.
+    virtual void
+    train_model(const std::vector<Xapian::FeatureVector> & training_data) = 0;
 
-    /** Method to save model as db metadata. Overrided in ranker subclass.
+    /** Method to save model as db metadata. Overridden in ranker subclass.
+     *
      *  Note: Make sure that there is no active writer on the database.
-     *        Since this method writes to database, it may cause database exceptions.
-     *  @param model_key      Key by which model is to be stored. If empty, default key is used by the respective subclass.
+     *        Since this method writes to database, it may cause database
+     *	      exceptions.
+     *
+     *  @param model_key     Key by which model is to be stored.
+     *			     If empty, default key is used by the respective
+     *			     subclass.
      */
     virtual void save_model_to_metadata(const std::string & model_key) = 0;
 
-    /** Method to load model from db metadata. Overrided in ranker subclass.
-     *  @param model_key      Key by which model is to be loaded. If empty, default key is used by the respective subclass.
+    /** Method to load model from db metadata. Overridden in ranker subclass.
+     *
+     *  @param model_key     Key by which model is to be loaded.
+     *			     If empty, default key is used by the respective
+     *			     subclass.
      */
     virtual void load_model_from_metadata(const std::string & model_key) = 0;
 
-    /** Method to re-rank a list of FeatureVectors (each representing a Xapian::Document) by using the model.
-     *  Overrided in ranker subclass.
+    /** Method to re-rank a list of FeatureVectors
+     *	(each representing a Xapian::Document) by using the model.
+     *
+     *  Overridden in ranker subclass.
      */
-    virtual std::vector<Xapian::FeatureVector> rank_fvv(const std::vector<Xapian::FeatureVector> & fvv) const = 0;
+    virtual std::vector<Xapian::FeatureVector>
+    rank_fvv(const std::vector<Xapian::FeatureVector> & fvv) const = 0;
 
-    /// Compare function used to sort std::vector<Xapian::FeatureVector> by score values.
-    static bool scorecomparer(const FeatureVector & firstfv, const FeatureVector & secondfv);
+    /** Compare function used to sort std::vector<Xapian::FeatureVector>
+     *  by score values.
+     */
+    static bool scorecomparer(const FeatureVector & firstfv,
+			      const FeatureVector & secondfv);
 
-    /// Compare function used to sort std::vector<Xapian::FeatureVector> by label values.
-    static bool labelcomparer(const FeatureVector & firstfv, const FeatureVector & secondfv);
+    /** Compare function used to sort std::vector<Xapian::FeatureVector>
+     *  by label values.
+     */
+    static bool labelcomparer(const FeatureVector & firstfv,
+			      const FeatureVector & secondfv);
 
   private:
     /// Don't allow assignment.
@@ -189,40 +254,53 @@ class XAPIAN_VISIBILITY_DEFAULT ListNETRanker: public Ranker {
     int iterations;
 
     /** Method to train the model.
+     *
      * @exception LetorInternalError will be thrown if training data is null.
      */
     void train_model(const std::vector<Xapian::FeatureVector> & training_data);
 
     /** Method to save ListNET model as db metadata.
-     *  ListNET model file gets stored with each parameter value in a new line. e.g.
+     *
+     *  ListNET model file gets stored with each parameter value in a new line.
+     *	 e.g.
      *
      *  0.000920817564536697
      *  0.000920817564536697
      *  0
      *  -1.66533453693773e-19
      *
-     *  @param model_key      Metadata key using which model is to be stored.
+     *  @param model_key	Metadata key using which model is to be stored.
      */
     void save_model_to_metadata(const std::string & model_key);
 
     /** Method to load model from an external file.
-     * @param model_key         Metadata key using which model is to be loaded.
-     * @exception LetorInternalError will be thrown if no model exists corresponding to the supplied key
+     *
+     *  @param model_key         Metadata key using which model is to be
+     *				 loaded.
+     *
+     *  @exception LetorInternalError will be thrown if no model exists
+     *  	   corresponding to the supplied key
      */
     void load_model_from_metadata(const std::string & model_key);
 
-    /** Method to re-rank a std::vector<Xapian::FeatureVector> by using the model.
-     * @param fvv vector<FeatureVector> that will be re-ranked
-     * @exception LetorInternalError will be thrown if model file is not compatible.
+    /** Method to re-rank a std::vector<Xapian::FeatureVector> by using the
+     *  model.
+     *
+     *  @param fvv	vector<FeatureVector> that will be re-ranked.
+     *
+     *  @exception	LetorInternalError will be thrown if model file
+     *			is not compatible.
      */
-    std::vector<Xapian::FeatureVector> rank_fvv(const std::vector<Xapian::FeatureVector> & fvv) const;
+    std::vector<Xapian::FeatureVector>
+    rank_fvv(const std::vector<Xapian::FeatureVector> & fvv) const;
 
   public:
     /* Construct ListNet instance
      * @param learn_rate       Learning rate
      * @param num_interations  Number of iterations
      */
-    explicit ListNETRanker(double learn_rate = 0.001, int num_interations = 15):
+    explicit ListNETRanker(double learn_rate = 0.001,
+			    int num_interations = 15):
 	 learning_rate(learn_rate), iterations(num_interations) { }
 
     /// Destructor
@@ -236,28 +314,39 @@ class XAPIAN_VISIBILITY_DEFAULT SVMRanker: public Ranker {
     std::string model_data;
 
     /** Method to train the model.
-     * @exception LetorInternalError will be thrown if training data is null.
+     *
+     *  @exception LetorInternalError will be thrown if training data is null.
      */
     void train_model(const std::vector<Xapian::FeatureVector> & training_data);
 
     /** Method to save SVMRanker model as db metadata.
+     *
      *  @param model_key      Metadata key using which model is to be stored.
      */
     void save_model_to_metadata(const std::string & model_key);
 
     /** Method to load model from an external file.
-     * @param model_key         Metadata key using which model is to be loaded.
-     * @exception LetorInternalError will be thrown if no model exists corresponding to the supplied key
+     *
+     *  @param model_key        Metadata key using which model is to be
+     *				loaded.
+     *
+     *  @exception LetorInternalError will be thrown if no model exists
+     *		   corresponding to the supplied key
      */
     void load_model_from_metadata(const std::string & model_key);
 
-    /** Method to re-rank a std::vector<Xapian::FeatureVector> by using the model.
-     * @param fvv vector<FeatureVector> that will be re-ranked
+    /** Method to re-rank a std::vector<Xapian::FeatureVector> by using the
+     *  model.
+     *
+     *  @param fvv vector<FeatureVector> that will be re-ranked
      */
-    std::vector<Xapian::FeatureVector> rank_fvv(const std::vector<Xapian::FeatureVector> & fvv) const;
+    std::vector<Xapian::FeatureVector>
+    rank_fvv(const std::vector<Xapian::FeatureVector> & fvv) const;
 
   public:
-    // TODO: Pass struct svm_parameter* to constructor to be able to configure libsvm params at run time.
+    /* TODO: Pass struct svm_parameter* to constructor to be able to configure
+     * libsvm params at run time.
+     */
     /// Constructor
     SVMRanker();
     /// Destructor

--- a/xapian-letor/ranker/listnet_ranker.cc
+++ b/xapian-letor/ranker/listnet_ranker.cc
@@ -193,6 +193,5 @@ ListNETRanker::rank_fvv(const std::vector<FeatureVector> & fvv) const {
 	    listnet_score += fvals[j] * parameters[j];
 	testfvv[i].set_score(listnet_score);
     }
-    std::sort(testfvv.begin(), testfvv.end(), &Ranker::scorecomparer);
     return testfvv;
 }

--- a/xapian-letor/ranker/svmranker.cc
+++ b/xapian-letor/ranker/svmranker.cc
@@ -225,6 +225,5 @@ SVMRanker::rank_fvv(const std::vector<FeatureVector> & fvv) const
 	test[non_zero_flag].value = -1;
 	testfvv[i].set_score(svm_predict(model, test));
     }
-    std::sort(testfvv.begin(), testfvv.end(), &Ranker::scorecomparer);
     return testfvv;
 }


### PR DESCRIPTION
Changes made to MSet: Added two functions to the public API set_new_weights and re_rank to MSet along with a helper function set_new_weights_helper.
1. set_new_weights: assigns new weights to items
2. re_rank sorts the MSet by sorting items on the basis of their weights.

Changes made to Letor: 
1. Keeping the vector<FeatureVector> in the original order. Ranker only updates weights.
2. New weights are obtained from vector<FeatureVector> and assigned to items and it is sorted according to the wieghts subsequently.
3. Printing the docids from MSet to show the updated order after ranker re-ranks MSet