### PR TITLE
Add seterror command in omega

### DIFF
--- a/xapian-applications/omega/docs/omegascript.rst
+++ b/xapian-applications/omega/docs/omegascript.rst
@@ -542,14 +542,14 @@ $set{OPT,VALUE}
 	Similarly, ``XFOO:stemmer`` specifies the stemmer to use for field
 	``XFOO``, with ``stemmer`` providing a default.
 
-$seterror{error_msg}
+$seterror{ERROR_MESSAGE}
 	set error message for the current execution, which can also be looked
 	up using ``$error``.
 
-	Using ``$seterror`` error early in template prevent running query.
-	Saves us from executing query unnecessarily.
+	Using ``$seterror`` error early in template prevents running the query.
 
-	You can use ``$seterror`` when the user enters a wrong parameter in the search.
+	For example, ``$seterror`` can be used when the user enters a wrong
+	parameter in the search.
 
 $setrelevant{docids}
 	add documents into the RSet

--- a/xapian-applications/omega/docs/omegascript.rst
+++ b/xapian-applications/omega/docs/omegascript.rst
@@ -542,6 +542,15 @@ $set{OPT,VALUE}
 	Similarly, ``XFOO:stemmer`` specifies the stemmer to use for field
 	``XFOO``, with ``stemmer`` providing a default.
 
+$seterror{error_msg}
+	set error message for the current execution, which can also be looked
+	up using ``$error``.
+
+	Using ``$seterror`` error early in template prevent running query.
+	Saves us from executing query unnecessarily.
+
+	You can use ``$seterror`` when the user enters a wrong parameter in the search.
+
 $setrelevant{docids}
 	add documents into the RSet
 

--- a/xapian-applications/omega/omegatest
+++ b/xapian-applications/omega/omegatest
@@ -414,16 +414,20 @@ printf '$highlight{$cgi{text},$cgi{list},$cgi{open},$cgi{close}}' > "$TEST_TEMPL
 testcase 'A list of <b>words</b>' list="words" text="A list of words" open="<b>" close="</b>"
 testcase 'A *list* of *words*' list="words${tab}list" text="A list of words" open="*" close="*"
 
-#Test setting seterror and mset size, should not run the query after setting error.
+# Test setting seterror and mset size, should not run the query after setting error.
 printf '$if{$cgi{ERR},$seterror{$cgi{ERR}}}$msize$if{$error,!$error!}' > "$TEST_TEMPLATE"
 testcase '1' P=text
 testcase '0!boo!' P=text ERR=boo
 
-#Test arguments inside seterror are evaluated
+# Test arguments inside seterror are evaluated
 printf '$set{error,sample error}$seterror{$opt{error}}$msize$if{$error,!$error!}' > "$TEST_TEMPLATE"
 testcase '0!sample error!' P=text
 
-#Test msize when error set after running query, should not affect running of query.
+# Test error message doesn't get sent through HTML entity encoding.
+printf '$seterror{{ "error": true, "error_message": "Parameter cannot be > 9" }}$if{$error,$error}' > "$TEST_TEMPLATE"
+testcase '{ "error": true, "error_message": "Parameter cannot be > 9" }' P=text
+
+# Test msize when error set after running query, should not affect running of query.
 printf '$last$if{$cgi{ERR},$seterror{$cgi{ERR}}}$msize$if{$error,!$error!}' > "$TEST_TEMPLATE"
 testcase '11' P=text
 testcase '11!boo!' P=text ERR=boo

--- a/xapian-applications/omega/omegatest
+++ b/xapian-applications/omega/omegatest
@@ -414,6 +414,20 @@ printf '$highlight{$cgi{text},$cgi{list},$cgi{open},$cgi{close}}' > "$TEST_TEMPL
 testcase 'A list of <b>words</b>' list="words" text="A list of words" open="<b>" close="</b>"
 testcase 'A *list* of *words*' list="words${tab}list" text="A list of words" open="*" close="*"
 
+#Test setting seterror and mset size, should not run the query after setting error.
+printf '$if{$cgi{ERR},$seterror{$cgi{ERR}}}$msize$if{$error,!$error!}' > "$TEST_TEMPLATE"
+testcase '1' P=text
+testcase '0!boo!' P=text ERR=boo
+
+#Test arguments inside seterror are evaluated
+printf '$set{error,sample error}$seterror{$opt{error}}$msize$if{$error,!$error!}' > "$TEST_TEMPLATE"
+testcase '0!sample error!' P=text
+
+#Test msize when error set after running query, should not affect running of query.
+printf '$last$if{$cgi{ERR},$seterror{$cgi{ERR}}}$msize$if{$error,!$error!}' > "$TEST_TEMPLATE"
+testcase '11' P=text
+testcase '11!boo!' P=text ERR=boo
+
 rm "$OMEGA_CONFIG_FILE" "$TEST_INDEXSCRIPT" "$TEST_TEMPLATE"
 rm -rf "$TEST_DB"
 if [ "$failed" = 0 ] ; then

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -985,6 +985,7 @@ CMD_relevant,
 CMD_relevants,
 CMD_score,
 CMD_set,
+CMD_seterror,
 CMD_setmap,
 CMD_setrelevant,
 CMD_slice,
@@ -1116,6 +1117,7 @@ T(relevant,	   0, 1, N, Q), // is document relevant?
 T(relevants,	   0, 0, N, Q), // return list of relevant documents
 T(score,	   0, 0, N, 0), // score (0-10) of current hit
 T(set,		   2, 2, N, 0), // set option value
+T(seterror,	   1, 1, 1, 0), // set error_msg, setting it early stops query execution
 T(setmap,	   1, N, N, 0), // set map of option values
 T(setrelevant,	   0, 1, N, Q), // set rset
 T(slice,	   2, 2, N, 0), // slice a list using a second list
@@ -2007,6 +2009,9 @@ eval(const string &fmt, const vector<string> &param)
 		break;
 	    case CMD_set:
 		option[args[0]] = args[1];
+		break;
+	    case CMD_seterror:
+		error_msg = args[0];
 		break;
 	    case CMD_setmap: {
 		string base = args[0] + ',';

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1117,7 +1117,7 @@ T(relevant,	   0, 1, N, Q), // is document relevant?
 T(relevants,	   0, 0, N, Q), // return list of relevant documents
 T(score,	   0, 0, N, 0), // score (0-10) of current hit
 T(set,		   2, 2, N, 0), // set option value
-T(seterror,	   1, 1, 1, 0), // set error_msg, setting it early stops query execution
+T(seterror,	   1, 1, N, 0), // set error_msg, setting it early stops query execution
 T(setmap,	   1, N, N, 0), // set map of option values
 T(setrelevant,	   0, 1, N, Q), // set rset
 T(slice,	   2, 2, N, 0), // slice a list using a second list


### PR DESCRIPTION
Currently, it's not possible to stop the execution of a query and return an error message from the template. 

Let's say we want to check if the user passed a very high hitsperpage, which will hang the browser. We can check the CGI parameter in the template and use the seterror command to set error and prevent the query from being executed.

