### PR TITLE
Update Letor harness to match Core harness

### DIFF
--- a/xapian-letor/configure.ac
+++ b/xapian-letor/configure.ac
@@ -459,12 +459,10 @@ if true ; then
     *-yes )
       dnl For mingw and msvc we have an alternative implementation which
       dnl doesn't need fork() or socketpair().
-      dnl
       ;;
     *djgpp* | *msdos* )
       dnl DJGPP has a dummy implementation of fork which always fails.
       dnl
-      dnl For disk-based backend, use flock() for locking, which doesn't need
       dnl fork() or socketpair().
       enable_backend_remote=no
       ;;

--- a/xapian-letor/configure.ac
+++ b/xapian-letor/configure.ac
@@ -463,7 +463,9 @@ if true ; then
     *djgpp* | *msdos* )
       dnl DJGPP has a dummy implementation of fork which always fails.
       dnl
-      dnl fork() or socketpair().
+      dnl If someone actually wanted remote backend support, then DJGPP has a
+      dnl pthreads port, so using threads like we do on Windows would make more
+      dnl sense.
       enable_backend_remote=no
       ;;
     *)

--- a/xapian-letor/configure.ac
+++ b/xapian-letor/configure.ac
@@ -460,26 +460,6 @@ if true ; then
       dnl For mingw and msvc we have an alternative implementation which
       dnl doesn't need fork() or socketpair().
       dnl
-      dnl We need -lws2_32 for getaddrinfo(), etc.
-      REMOTE_LIBS=-lws2_32
-      dnl Vista is needed for the AI_ADDRCONFIG flag to getaddrinfo().
-      AC_DEFINE([WINVER], [0x600],
-		[Version of Windows to assume (0x600 => Vista).])
-      AC_DEFINE([_WIN32_WINNT], [WINVER],
-		[Version of Windows to assume.])
-      ;;
-    *djgpp* | *msdos* )
-      dnl DJGPP has a dummy implementation of fork which always fails.
-      dnl
-      dnl For disk-based backend, use flock() for locking, which doesn't need
-      dnl fork() or socketpair().
-      AC_DEFINE([FLINTLOCK_USE_FLOCK], 1, [Define to use flock() for flint-compatible locking])
-      dnl If someone actually wanted remote backend support, then DJGPP has a
-      dnl pthreads port, so using threads like we do on Windows would make more
-      dnl sense.
-      enable_backend_remote=no
-      ;;
-    *)
       dnl On Unix, we need fork and socketpair for the remotebackend.
       SAVE_LIBS=$LIBS
       AC_CHECK_FUNCS([fork], [], [
@@ -492,28 +472,11 @@ if true ; then
       ])
       AC_DEFINE([HAVE_SOCKETPAIR], [1],
 		[Define to 1 if you have the 'socketpair' function.])
-      dnl Check if extra libraries are needed for getaddrinfo or inet_ntop()
-      dnl (e.g. on Solaris).
-      dnl
-      dnl We're currently assuming that any system that is worth trying to
-      dnl support has getaddrinfo() and inet_ntop(), since these are the
-      dnl standard route for supporting IPv6, and that's pretty much essential
-      dnl for platforms to support now.
-      AC_SEARCH_LIBS([getaddrinfo], [nsl socket], [], [
-	AC_MSG_ERROR([getaddrinfo() required for the remote backend - if an extra library is needed, pass LIBS=-lfoo to configure.  Or --disable-backend-remote to disable it.)])
-      ])
-      AC_SEARCH_LIBS([inet_ntop], [nsl socket], [], [
-	AC_MSG_ERROR([inet_ntop() required for the remote backend - if an extra library is needed, pass LIBS=-lfoo to configure.  Or --disable-backend-remote to disable it.)])
-      ])
       REMOTE_LIBS=$LIBS
       LIBS=$SAVE_LIBS
       ;;
   esac
 
-  if test "$enable_backend_remote" = yes ; then
-    TYPE_SOCKLEN_T
-    XAPIAN_LIBS="$XAPIAN_LIBS $REMOTE_LIBS"
-  fi
 fi
 
 dnl If eatmydata is installed, we run the testsuite under it to speed it up.

--- a/xapian-letor/configure.ac
+++ b/xapian-letor/configure.ac
@@ -447,6 +447,75 @@ if test -n "$VALGRIND" ; then
   AC_DEFINE([HAVE_VALGRIND], [1], [Define if a suitable valgrind is installed])
 fi
 
+REMOTE_LIBS=
+if true ; then
+  AC_PREPROC_IFELSE([AC_LANG_SOURCE([[
+#ifdef __WIN32__
+#error WIN32
+#endif
+  ]])], [win32=no], [win32=yes])
+
+  case $host_os-$win32 in
+    *-yes )
+      dnl For mingw and msvc we have an alternative implementation which
+      dnl doesn't need fork() or socketpair().
+      dnl
+      dnl We need -lws2_32 for getaddrinfo(), etc.
+      REMOTE_LIBS=-lws2_32
+      dnl Vista is needed for the AI_ADDRCONFIG flag to getaddrinfo().
+      AC_DEFINE([WINVER], [0x600],
+		[Version of Windows to assume (0x600 => Vista).])
+      AC_DEFINE([_WIN32_WINNT], [WINVER],
+		[Version of Windows to assume.])
+      ;;
+    *djgpp* | *msdos* )
+      dnl DJGPP has a dummy implementation of fork which always fails.
+      dnl
+      dnl For disk-based backend, use flock() for locking, which doesn't need
+      dnl fork() or socketpair().
+      AC_DEFINE([FLINTLOCK_USE_FLOCK], 1, [Define to use flock() for flint-compatible locking])
+      dnl If someone actually wanted remote backend support, then DJGPP has a
+      dnl pthreads port, so using threads like we do on Windows would make more
+      dnl sense.
+      enable_backend_remote=no
+      ;;
+    *)
+      dnl On Unix, we need fork and socketpair for the remotebackend.
+      SAVE_LIBS=$LIBS
+      AC_CHECK_FUNCS([fork], [], [
+	AC_MSG_ERROR([fork() required for the remote backend - if an extra library is needed, pass LIBS=-lfoo to configure.  Or --disable-backend-remote to disable it.)])
+      ])
+      dnl Check if -lsocket is required for socketpair (Solaris needs it).
+      dnl And on Haiku it's in -lnetwork.
+      AC_SEARCH_LIBS([socketpair], [socket network], [], [
+	AC_MSG_ERROR([socketpair() required for the remote backend - if an extra library is needed, pass LIBS=-lfoo to configure.  Or --disable-backend-remote to disable it.)])
+      ])
+      AC_DEFINE([HAVE_SOCKETPAIR], [1],
+		[Define to 1 if you have the 'socketpair' function.])
+      dnl Check if extra libraries are needed for getaddrinfo or inet_ntop()
+      dnl (e.g. on Solaris).
+      dnl
+      dnl We're currently assuming that any system that is worth trying to
+      dnl support has getaddrinfo() and inet_ntop(), since these are the
+      dnl standard route for supporting IPv6, and that's pretty much essential
+      dnl for platforms to support now.
+      AC_SEARCH_LIBS([getaddrinfo], [nsl socket], [], [
+	AC_MSG_ERROR([getaddrinfo() required for the remote backend - if an extra library is needed, pass LIBS=-lfoo to configure.  Or --disable-backend-remote to disable it.)])
+      ])
+      AC_SEARCH_LIBS([inet_ntop], [nsl socket], [], [
+	AC_MSG_ERROR([inet_ntop() required for the remote backend - if an extra library is needed, pass LIBS=-lfoo to configure.  Or --disable-backend-remote to disable it.)])
+      ])
+      REMOTE_LIBS=$LIBS
+      LIBS=$SAVE_LIBS
+      ;;
+  esac
+
+  if test "$enable_backend_remote" = yes ; then
+    TYPE_SOCKLEN_T
+    XAPIAN_LIBS="$XAPIAN_LIBS $REMOTE_LIBS"
+  fi
+fi
+
 dnl If eatmydata is installed, we run the testsuite under it to speed it up.
 dnl If EATMYDATA is set to an empty value, then skip this check and don't use
 dnl eatmydata.

--- a/xapian-letor/configure.ac
+++ b/xapian-letor/configure.ac
@@ -466,10 +466,6 @@ if true ; then
       dnl
       dnl For disk-based backend, use flock() for locking, which doesn't need
       dnl fork() or socketpair().
-      AC_DEFINE([FLINTLOCK_USE_FLOCK], 1, [Define to use flock() for flint-compatible locking])
-      dnl If someone actually wanted remote backend support, then DJGPP has a
-      dnl pthreads port, so using threads like we do on Windows would make more
-      dnl sense.
       enable_backend_remote=no
       ;;
     *)

--- a/xapian-letor/configure.ac
+++ b/xapian-letor/configure.ac
@@ -460,6 +460,19 @@ if true ; then
       dnl For mingw and msvc we have an alternative implementation which
       dnl doesn't need fork() or socketpair().
       dnl
+      ;;
+    *djgpp* | *msdos* )
+      dnl DJGPP has a dummy implementation of fork which always fails.
+      dnl
+      dnl For disk-based backend, use flock() for locking, which doesn't need
+      dnl fork() or socketpair().
+      AC_DEFINE([FLINTLOCK_USE_FLOCK], 1, [Define to use flock() for flint-compatible locking])
+      dnl If someone actually wanted remote backend support, then DJGPP has a
+      dnl pthreads port, so using threads like we do on Windows would make more
+      dnl sense.
+      enable_backend_remote=no
+      ;;
+    *)
       dnl On Unix, we need fork and socketpair for the remotebackend.
       SAVE_LIBS=$LIBS
       AC_CHECK_FUNCS([fork], [], [

--- a/xapian-letor/tests/Makefile.am
+++ b/xapian-letor/tests/Makefile.am
@@ -85,7 +85,7 @@ EXTRA_DIST +=\
 	testdata/apitest_allterms4.txt
 
 remove-cached-databases:
-	rm -rf .letor-db
+	rm -rf .glass .multiglass .replicatmp .singlefileglass .stub
 
 clean-local: remove-cached-databases
 

--- a/xapian-letor/tests/apitest.cc
+++ b/xapian-letor/tests/apitest.cc
@@ -59,6 +59,24 @@ get_database_path(const string &dbname)
     return backendmanager->get_database_path(dbname);
 }
 
+string
+get_database_path(const std::string &dbname,
+		  void (*gen)(Xapian::WritableDatabase&,
+			      const std::string &),
+		  const std::string &arg)
+{
+    return backendmanager->get_database_path(dbname, gen, arg);
+}
+
+Xapian::Database
+get_database(const std::string &dbname,
+	     void (*gen)(Xapian::WritableDatabase&,
+			 const std::string &),
+	     const std::string &arg)
+{
+    return backendmanager->get_database(dbname, gen, arg);
+}
+
 class ApiTestRunner : public TestRunner
 {
   public:

--- a/xapian-letor/tests/apitest.h
+++ b/xapian-letor/tests/apitest.h
@@ -31,4 +31,14 @@ Xapian::Database get_database(const std::string &db1, const std::string &db2);
 
 std::string get_database_path(const std::string &db);
 
+Xapian::Database get_database(const std::string &db,
+			      void (*gen)(Xapian::WritableDatabase&,
+					  const std::string &),
+			      const std::string &arg = std::string());
+
+std::string get_database_path(const std::string &db,
+			      void (*gen)(Xapian::WritableDatabase&,
+					  const std::string &),
+			      const std::string &arg = std::string());
+
 #endif // XAPIAN_INCLUDED_APITEST_H

--- a/xapian-letor/tests/harness/Makefile.mk
+++ b/xapian-letor/tests/harness/Makefile.mk
@@ -3,6 +3,14 @@ EXTRA_DIST +=\
 
 noinst_HEADERS +=\
 	harness/backendmanager.h\
+	harness/backendmanager_glass.h\
+	harness/backendmanager_inmemory.h\
+	harness/backendmanager_local.h\
+	harness/backendmanager_multi.h\
+	harness/backendmanager_remote.h\
+	harness/backendmanager_remoteprog.h\
+	harness/backendmanager_remotetcp.h\
+	harness/backendmanager_singlefile.h\
 	harness/cputimer.h\
 	harness/fdtracker.h\
 	harness/index_utils.h\
@@ -15,6 +23,7 @@ noinst_HEADERS +=\
 
 testharness_sources =\
 	harness/backendmanager.cc\
+	harness/backendmanager_multi.cc\
 	harness/cputimer.cc\
 	harness/fdtracker.cc\
 	harness/index_utils.cc\
@@ -31,3 +40,14 @@ testharness_sources += ../common/str.cc
 utestharness_sources =\
 	harness/fdtracker.cc\
 	harness/utestsuite.cc
+
+testharness_sources +=\
+	harness/backendmanager_glass.cc\
+	harness/backendmanager_singlefile.cc
+
+testharness_sources += harness/backendmanager_inmemory.cc
+
+testharness_sources +=\
+	harness/backendmanager_remote.cc\
+	harness/backendmanager_remoteprog.cc\
+	harness/backendmanager_remotetcp.cc

--- a/xapian-letor/tests/harness/backendmanager_glass.cc
+++ b/xapian-letor/tests/harness/backendmanager_glass.cc
@@ -65,4 +65,5 @@ BackendManagerGlass::get_writable_database_again()
     return Xapian::WritableDatabase(".glass/" + last_wdb_name,
 				    Xapian::DB_OPEN|Xapian::DB_BACKEND_GLASS);
 }
-#endif
+
+#endif // XAPIAN_HAS_GLASS_BACKEND

--- a/xapian-letor/tests/harness/backendmanager_glass.cc
+++ b/xapian-letor/tests/harness/backendmanager_glass.cc
@@ -1,0 +1,68 @@
+/** @file backendmanager_glass.cc
+ * @brief BackendManager subclass for glass databases.
+ */
+/* Copyright (C) 2007,2008,2009,2013 Olly Betts
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "backendmanager_glass.h"
+
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+
+using namespace std;
+
+std::string
+BackendManagerGlass::get_dbtype() const
+{
+    return "glass";
+}
+
+string
+BackendManagerGlass::do_get_database_path(const vector<string> & files)
+{
+    return createdb_glass(files);
+}
+
+Xapian::WritableDatabase
+BackendManagerGlass::get_writable_database(const string & name,
+					   const string & file)
+{
+    last_wdb_name = name;
+    return getwritedb_glass(name, vector<string>(1, file));
+}
+
+string
+BackendManagerGlass::get_writable_database_path(const string & name)
+{
+    return getwritedb_glass_path(name);
+}
+
+Xapian::Database
+BackendManagerGlass::get_writable_database_as_database()
+{
+    return Xapian::Database(".glass/" + last_wdb_name,
+			    Xapian::DB_BACKEND_GLASS);
+}
+
+Xapian::WritableDatabase
+BackendManagerGlass::get_writable_database_again()
+{
+    return Xapian::WritableDatabase(".glass/" + last_wdb_name,
+				    Xapian::DB_OPEN|Xapian::DB_BACKEND_GLASS);
+}
+#endif

--- a/xapian-letor/tests/harness/backendmanager_glass.h
+++ b/xapian-letor/tests/harness/backendmanager_glass.h
@@ -1,0 +1,65 @@
+/** @file backendmanager_glass.h
+ * @brief BackendManager subclass for glass databases.
+ */
+/* Copyright (C) 2007,2008,2009 Olly Betts
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_BACKENDMANAGER_GLASS_H
+#define XAPIAN_INCLUDED_BACKENDMANAGER_GLASS_H
+
+#include "backendmanager.h"
+
+#include <string>
+
+#include <xapian/types.h>
+#include <xapian/postingiterator.h>
+
+/// BackendManager subclass for glass databases.
+class BackendManagerGlass : public BackendManager {
+    /// Don't allow assignment.
+    void operator=(const BackendManagerGlass &);
+
+    /// Don't allow copying.
+    BackendManagerGlass(const BackendManagerGlass &);
+
+    /// The path of the last writable database used.
+    std::string last_wdb_name;
+
+    /// Get the path of Glass Xapian::Database instance.
+    std::string do_get_database_path(const std::vector<std::string> & files);
+
+  public:
+    BackendManagerGlass() { }
+
+    /// Return a string representing the current database type.
+    std::string get_dbtype() const;
+
+    /// Create a Glass Xapian::WritableDatabase object indexing a single file.
+    Xapian::WritableDatabase get_writable_database(const std::string & name,
+						   const std::string & file);
+
+    /// Get the path of Glass Xapian::WritableDatabase instance.
+    std::string get_writable_database_path(const std::string & name);
+
+    /// Create a Database object for the last opened WritableDatabase.
+    Xapian::Database get_writable_database_as_database();
+
+    /// Create a WritableDatabase object for the last opened WritableDatabase.
+    Xapian::WritableDatabase get_writable_database_again();
+};
+
+#endif // XAPIAN_INCLUDED_BACKENDMANAGER_GLASS_H

--- a/xapian-letor/tests/harness/backendmanager_inmemory.cc
+++ b/xapian-letor/tests/harness/backendmanager_inmemory.cc
@@ -1,0 +1,47 @@
+/** @file backendmanager_inmemory.cc
+ * @brief BackendManager subclass for inmemory databases.
+ */
+/* Copyright (C) 2007,2009 Olly Betts
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "backendmanager_inmemory.h"
+
+#ifdef XAPIAN_HAS_INMEMORY_BACKEND
+
+using namespace std;
+
+std::string
+BackendManagerInMemory::get_dbtype() const
+{
+    return "inmemory";
+}
+
+Xapian::Database
+BackendManagerInMemory::do_get_database(const vector<string> & files)
+{
+    return getwritedb_inmemory(files);
+}
+
+Xapian::WritableDatabase
+BackendManagerInMemory::get_writable_database(const string &,
+					      const string & file)
+{
+    return getwritedb_inmemory(vector<string>(1, file));
+}
+#endif

--- a/xapian-letor/tests/harness/backendmanager_inmemory.cc
+++ b/xapian-letor/tests/harness/backendmanager_inmemory.cc
@@ -44,4 +44,5 @@ BackendManagerInMemory::get_writable_database(const string &,
 {
     return getwritedb_inmemory(vector<string>(1, file));
 }
-#endif
+
+#endif // XAPIAN_HAS_INMEMORY_BACKEND

--- a/xapian-letor/tests/harness/backendmanager_inmemory.h
+++ b/xapian-letor/tests/harness/backendmanager_inmemory.h
@@ -1,0 +1,53 @@
+/** @file backendmanager_inmemory.h
+ * @brief BackendManager subclass for inmemory databases.
+ */
+/* Copyright (C) 2007,2009 Olly Betts
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_BACKENDMANAGER_INMEMORY_H
+#define XAPIAN_INCLUDED_BACKENDMANAGER_INMEMORY_H
+
+#include "backendmanager.h"
+
+#include <string>
+
+#include <xapian/types.h>
+#include <xapian/postingiterator.h>
+
+/// BackendManager subclass for inmemory databases.
+class BackendManagerInMemory : public BackendManager {
+    /// Don't allow assignment.
+    void operator=(const BackendManagerInMemory &);
+
+    /// Don't allow copying.
+    BackendManagerInMemory(const BackendManagerInMemory &);
+
+  protected:
+    /// Create a InMemory Xapian::Database object indexing multiple files.
+    Xapian::Database do_get_database(const std::vector<std::string> & files);
+
+  public:
+    BackendManagerInMemory() { }
+
+    /// Return a string representing the current database type.
+    std::string get_dbtype() const;
+
+    /// Create a InMemory Xapian::WritableDatabase object indexing a single file.
+    Xapian::WritableDatabase get_writable_database(const std::string & name, const std::string & file);
+};
+
+#endif // XAPIAN_INCLUDED_BACKENDMANAGER_INMEMORY_H

--- a/xapian-letor/tests/harness/backendmanager_local.h
+++ b/xapian-letor/tests/harness/backendmanager_local.h
@@ -1,0 +1,40 @@
+/** @file backendmanager_local.h
+ * @brief BackendManager subclass for local databases.
+ */
+/* Copyright (C) 2007,2008,2009,2011,2016 Olly Betts
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_BACKENDMANAGER_LOCAL_H
+#define XAPIAN_INCLUDED_BACKENDMANAGER_LOCAL_H
+
+#include <xapian.h>
+
+#if defined XAPIAN_HAS_GLASS_BACKEND
+# include "backendmanager_glass.h"
+# define BackendManagerLocal BackendManagerGlass
+#else
+# include "backendmanager.h"
+# include "testsuite.h"
+class BackendManagerLocal : public BackendManager {
+  public:
+    BackendManagerLocal() {
+	SKIP_TEST("No local database backend enabled");
+    }
+};
+#endif
+
+#endif // XAPIAN_INCLUDED_BACKENDMANAGER_LOCAL_H

--- a/xapian-letor/tests/harness/backendmanager_multi.cc
+++ b/xapian-letor/tests/harness/backendmanager_multi.cc
@@ -1,0 +1,126 @@
+/** @file backendmanager_multi.cc
+ * @brief BackendManager subclass for multi databases.
+ */
+/* Copyright (C) 2007,2008,2009,2011,2012,2013,2015 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "backendmanager_multi.h"
+
+#include "filetests.h"
+#include "index_utils.h"
+#include "str.h"
+
+#include <cstdio> // For rename().
+#include <cstring>
+#include "safeerrno.h"
+
+using namespace std;
+
+BackendManagerMulti::BackendManagerMulti(const std::string & subtype_)
+	: subtype(subtype_)
+{
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+    if (subtype == "glass") return;
+#endif
+    throw ("Unknown backend type \"" + subtype + "\" specified for multi database subdatabases");
+}
+
+std::string
+BackendManagerMulti::get_dbtype() const
+{
+    return "multi_" + subtype;
+}
+
+#define NUMBER_OF_SUB_DBS 2
+
+string
+BackendManagerMulti::createdb_multi(const vector<string> & files)
+{
+    string dbdir = ".multi" + subtype;
+    create_dir_if_needed(dbdir);
+
+    string dbname = "db";
+    vector<string>::const_iterator i;
+    for (i = files.begin(); i != files.end(); ++i) {
+	dbname += "__";
+	dbname += *i;
+    }
+    string dbpath = dbdir + "/" + dbname;
+
+    if (file_exists(dbpath)) return dbpath;
+
+    string tmpfile = dbpath;
+    tmpfile += ".tmp";
+    ofstream out(tmpfile.c_str());
+    if (!out.is_open()) {
+	string msg = "Couldn't create file '";
+	msg += tmpfile;
+	msg += "' (";
+	msg += strerror(errno);
+	msg += ')';
+	throw msg;
+    }
+
+    // Open NUMBER_OF_SUB_DBS databases and index files to them alternately so
+    // a multi-db combining them contains the documents in the expected order.
+    Xapian::WritableDatabase dbs;
+    int flags = Xapian::DB_CREATE_OR_OVERWRITE;
+    if (subtype == "glass") {
+	flags |= Xapian::DB_BACKEND_GLASS;
+    } else {
+	string msg = "Unknown multidb subtype: ";
+	msg += subtype;
+	throw msg;
+    }
+    string dbbase = dbdir;
+    dbbase += '/';
+    dbbase += dbname;
+    dbbase += "___";
+    size_t dbbase_len = dbbase.size();
+    string line = subtype;
+    line += ' ';
+    line += dbname;
+    line += "___";
+    for (size_t n = 0; n < NUMBER_OF_SUB_DBS; ++n) {
+	dbbase += str(n);
+	dbs.add_database(Xapian::WritableDatabase(dbbase, flags));
+	dbbase.resize(dbbase_len);
+	out << line << n << '\n';
+    }
+    out.close();
+
+    FileIndexer(get_datadir(), files).index_to(dbs);
+
+    rename(tmpfile.c_str(), dbpath.c_str());
+
+    return dbpath;
+}
+
+string
+BackendManagerMulti::do_get_database_path(const vector<string> & files)
+{
+    return createdb_multi(files);
+}
+
+Xapian::WritableDatabase
+BackendManagerMulti::get_writable_database(const string &, const string &)
+{
+    throw Xapian::UnimplementedError("Multi-databases don't support writing");
+}

--- a/xapian-letor/tests/harness/backendmanager_multi.h
+++ b/xapian-letor/tests/harness/backendmanager_multi.h
@@ -1,0 +1,59 @@
+/** @file backendmanager_multi.h
+ * @brief BackendManager subclass for multi databases.
+ */
+/* Copyright (C) 2007,2009 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_BACKENDMANAGER_MULTI_H
+#define XAPIAN_INCLUDED_BACKENDMANAGER_MULTI_H
+
+#include "backendmanager.h"
+
+#include <string>
+
+#include <xapian/types.h>
+#include <xapian/postingiterator.h>
+
+/// BackendManager subclass for multi databases.
+class BackendManagerMulti : public BackendManager {
+    /// The type to use for the sub-databases.
+    std::string subtype;
+
+    /// Don't allow assignment.
+    void operator=(const BackendManagerMulti &);
+
+    /// Don't allow copying.
+    BackendManagerMulti(const BackendManagerMulti &);
+
+    std::string createdb_multi(const std::vector<std::string> & files);
+
+  protected:
+    /// Get the path of the Xapian::Database instance.
+    std::string do_get_database_path(const std::vector<std::string> & files);
+
+  public:
+    BackendManagerMulti(const std::string & subtype_);
+
+    /// Return a string representing the current database type.
+    std::string get_dbtype() const;
+
+    /// Create a Multi Xapian::WritableDatabase object indexing a single file.
+    Xapian::WritableDatabase get_writable_database(const std::string & name, const std::string & file);
+};
+
+#endif // XAPIAN_INCLUDED_BACKENDMANAGER_MULTI_H

--- a/xapian-letor/tests/harness/backendmanager_remote.cc
+++ b/xapian-letor/tests/harness/backendmanager_remote.cc
@@ -1,0 +1,103 @@
+/** @file backendmanager_remote.cc
+ * @brief BackendManager subclass for remote databases.
+ */
+/* Copyright (C) 2006,2007,2008,2009,2011,2015 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <config.h>
+#include "backendmanager_remote.h"
+#include <cstdlib>
+#include <string>
+#include "str.h"
+
+#ifdef XAPIAN_HAS_REMOTE_BACKEND
+
+BackendManagerRemote::BackendManagerRemote(const std::string & remote_type_)
+	: remote_type(remote_type_)
+{
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+    if (remote_type == "glass") return;
+#endif
+    throw ("Unknown backend type \"" + remote_type + "\" specified for remote database");
+}
+
+std::string
+BackendManagerRemote::get_writable_database_args(const std::string & name,
+						 const std::string & file)
+{
+    last_wdb_name = name;
+
+    // Default to a long (5 minute) timeout so that tests won't fail just
+    // because the host is slow or busy.
+    std::string args = "-t300000 --writable ";
+
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+    if (remote_type == "glass") {
+	(void)getwritedb_glass(name, std::vector<std::string>(1, file));
+	args += ".glass/";
+    }
+#endif
+    args += name;
+
+    return args;
+}
+
+std::string
+BackendManagerRemote::get_remote_database_args(const std::vector<std::string> & files,
+					       unsigned int timeout)
+{
+    std::string args = "-t";
+    args += str(timeout);
+    args += ' ';
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+	if (remote_type == "glass") {
+	    args += createdb_glass(files);
+	}
+#endif
+
+    return args;
+}
+
+std::string
+BackendManagerRemote::get_writable_database_as_database_args()
+{
+    std::string args = "-t300000 ";
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+    if (remote_type == "glass") {
+	args += ".glass/";
+    }
+#endif
+    args += last_wdb_name;
+
+    return args;
+}
+
+std::string
+BackendManagerRemote::get_writable_database_again_args()
+{
+    std::string args = "-t300000 --writable ";
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+    if (remote_type == "glass") {
+	args += ".glass/";
+    }
+#endif
+    args += last_wdb_name;
+
+    return args;
+}
+#endif

--- a/xapian-letor/tests/harness/backendmanager_remote.cc
+++ b/xapian-letor/tests/harness/backendmanager_remote.cc
@@ -100,4 +100,5 @@ BackendManagerRemote::get_writable_database_again_args()
 
     return args;
 }
-#endif
+
+#endif // XAPIAN_HAS_REMOTE_BACKEND

--- a/xapian-letor/tests/harness/backendmanager_remote.h
+++ b/xapian-letor/tests/harness/backendmanager_remote.h
@@ -1,0 +1,62 @@
+/** @file backendmanager_remote.h
+ * @brief BackendManager subclass for remote databases.
+ */
+/* Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_BACKENDMANAGER_REMOTE_H
+#define XAPIAN_INCLUDED_BACKENDMANAGER_REMOTE_H
+
+#include "backendmanager.h"
+
+#include <string>
+#include <vector>
+
+/// BackendManager subclass for remote databases.
+class BackendManagerRemote : public BackendManager {
+    /// Don't allow assignment.
+    void operator=(const BackendManagerRemote &);
+
+    /// Don't allow copying.
+    BackendManagerRemote(const BackendManagerRemote &);
+
+    /// The path of the last writable database used.
+    std::string last_wdb_name;
+
+  protected:
+    /// The type of the remote database to use.
+    std::string remote_type;
+
+  public:
+    BackendManagerRemote(const std::string & remote_type_);
+
+    /// Get the args for opening a remote database indexing a single file.
+    std::string get_writable_database_args(const std::string & name,
+					   const std::string & file);
+
+    /// Get the args for opening a remote database with the specified timeout.
+    std::string get_remote_database_args(const std::vector<std::string> & files,
+					 unsigned int timeout);
+
+    /// Get the args for opening the last opened WritableDatabase.
+    std::string get_writable_database_as_database_args();
+
+    /// Get the args for opening the last opened WritableDatabase again.
+    std::string get_writable_database_again_args();
+};
+
+#endif // XAPIAN_INCLUDED_BACKENDMANAGER_REMOTE_H

--- a/xapian-letor/tests/harness/backendmanager_remoteprog.cc
+++ b/xapian-letor/tests/harness/backendmanager_remoteprog.cc
@@ -1,0 +1,107 @@
+/** @file backendmanager_remoteprog.cc
+ * @brief BackendManager subclass for remoteprog databases.
+ */
+/* Copyright (C) 2007,2008,2009 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "backendmanager_remoteprog.h"
+
+#include <xapian.h>
+
+#ifdef HAVE_VALGRIND
+# include <valgrind/memcheck.h>
+#endif
+
+#ifdef XAPIAN_HAS_REMOTE_BACKEND
+
+using namespace std;
+
+std::string
+BackendManagerRemoteProg::get_dbtype() const
+{
+    return "remoteprog_" + remote_type;
+}
+
+Xapian::Database
+BackendManagerRemoteProg::do_get_database(const vector<string> & files)
+{
+    // Default to a long (5 minute) timeout so that tests won't fail just
+    // because the host is slow or busy.
+    return BackendManagerRemoteProg::get_remote_database(files, 300000);
+}
+
+Xapian::WritableDatabase
+BackendManagerRemoteProg::get_writable_database(const string & name,
+						const string & file)
+{
+    string args = get_writable_database_args(name, file);
+
+#ifdef HAVE_VALGRIND
+    if (RUNNING_ON_VALGRIND) {
+	args.insert(0, XAPIAN_PROGSRV" ");
+	return Xapian::Remote::open_writable("./runsrv", args);
+    }
+#endif
+    return Xapian::Remote::open_writable(XAPIAN_PROGSRV, args);
+}
+
+Xapian::Database
+BackendManagerRemoteProg::get_remote_database(const vector<string> & files,
+					      unsigned int timeout)
+{
+    string args = get_remote_database_args(files, timeout);
+
+#ifdef HAVE_VALGRIND
+    if (RUNNING_ON_VALGRIND) {
+	args.insert(0, XAPIAN_PROGSRV" ");
+	return Xapian::Remote::open("./runsrv", args);
+    }
+#endif
+    return Xapian::Remote::open(XAPIAN_PROGSRV, args);
+}
+
+Xapian::Database
+BackendManagerRemoteProg::get_writable_database_as_database()
+{
+    string args = get_writable_database_as_database_args();
+
+#ifdef HAVE_VALGRIND
+    if (RUNNING_ON_VALGRIND) {
+	args.insert(0, XAPIAN_PROGSRV" ");
+	return Xapian::Remote::open("./runsrv", args);
+    }
+#endif
+    return Xapian::Remote::open(XAPIAN_PROGSRV, args);
+}
+
+Xapian::WritableDatabase
+BackendManagerRemoteProg::get_writable_database_again()
+{
+    string args = get_writable_database_again_args();
+
+#ifdef HAVE_VALGRIND
+    if (RUNNING_ON_VALGRIND) {
+	args.insert(0, XAPIAN_PROGSRV" ");
+	return Xapian::Remote::open_writable("./runsrv", args);
+    }
+#endif
+    return Xapian::Remote::open_writable(XAPIAN_PROGSRV, args);
+}
+#endif

--- a/xapian-letor/tests/harness/backendmanager_remoteprog.cc
+++ b/xapian-letor/tests/harness/backendmanager_remoteprog.cc
@@ -104,4 +104,5 @@ BackendManagerRemoteProg::get_writable_database_again()
 #endif
     return Xapian::Remote::open_writable(XAPIAN_PROGSRV, args);
 }
-#endif
+
+#endif // XAPIAN_HAS_REMOTE_BACKEND

--- a/xapian-letor/tests/harness/backendmanager_remoteprog.h
+++ b/xapian-letor/tests/harness/backendmanager_remoteprog.h
@@ -1,0 +1,69 @@
+/** @file backendmanager_remoteprog.h
+ * @brief BackendManager subclass for remoteprog databases.
+ */
+/* Copyright (C) 2007,2009,2011 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_BACKENDMANAGER_REMOTEPROG_H
+#define XAPIAN_INCLUDED_BACKENDMANAGER_REMOTEPROG_H
+
+#include "backendmanager.h"
+#include "backendmanager_remote.h"
+
+#include <string>
+
+#include <xapian/types.h>
+#include <xapian/postingiterator.h>
+
+/// BackendManager subclass for remoteprog databases.
+class BackendManagerRemoteProg : public BackendManagerRemote {
+    /// Don't allow assignment.
+    void operator=(const BackendManagerRemoteProg &);
+
+    /// Don't allow copying.
+    BackendManagerRemoteProg(const BackendManagerRemoteProg &);
+
+    /// The path of the last writable database used.
+    std::string last_wdb_name;
+
+    /// Create a Xapian::Database object indexing multiple files.
+    Xapian::Database do_get_database(const std::vector<std::string> & files);
+
+  public:
+    BackendManagerRemoteProg(const std::string & remote_type_)
+	: BackendManagerRemote(remote_type_) { }
+
+    /// Return a string representing the current database type.
+    std::string get_dbtype() const;
+
+    /// Create a RemoteProg Xapian::WritableDatabase object indexing a single file.
+    Xapian::WritableDatabase get_writable_database(const std::string & name,
+						   const std::string & file);
+
+    /// Create a RemoteProg Xapian::Database with the specified timeout.
+    Xapian::Database get_remote_database(const std::vector<std::string> & files,
+					 unsigned int timeout);
+
+    /// Create a Database object for the last opened WritableDatabase.
+    Xapian::Database get_writable_database_as_database();
+
+    /// Create a WritableDatabase object for the last opened WritableDatabase.
+    Xapian::WritableDatabase get_writable_database_again();
+};
+
+#endif // XAPIAN_INCLUDED_BACKENDMANAGER_REMOTEPROG_H

--- a/xapian-letor/tests/harness/backendmanager_remotetcp.cc
+++ b/xapian-letor/tests/harness/backendmanager_remotetcp.cc
@@ -1,0 +1,410 @@
+/** @file backendmanager_remotetcp.cc
+ * @brief BackendManager subclass for remotetcp databases.
+ */
+/* Copyright (C) 2006,2007,2008,2009,2013,2015 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "backendmanager_remotetcp.h"
+
+#include <xapian.h>
+
+#include "safeerrno.h"
+#include <stdio.h> // For fdopen().
+#include <cstring>
+
+#ifdef HAVE_FORK
+# include <signal.h>
+# include <sys/types.h>
+# include "safesyssocket.h"
+# include <sys/wait.h>
+# include <unistd.h>
+// Some older systems had SIGCLD rather than SIGCHLD.
+# if !defined SIGCHLD && defined SIGCLD
+#  define SIGCHLD SIGCLD
+# endif
+#endif
+
+#ifdef __WIN32__
+# include <io.h> // For _open_osfhandle().
+# include "safefcntl.h"
+# include "safewindows.h"
+# include <cstdlib> // For free().
+#endif
+
+#include "noreturn.h"
+#include "str.h"
+
+#include <string>
+#include <vector>
+
+#ifdef HAVE_VALGRIND
+# include <valgrind/memcheck.h>
+#endif
+
+#ifdef XAPIAN_HAS_REMOTE_BACKEND
+
+using namespace std;
+
+// We've had problems on some hosts which run tinderbox tests with "localhost"
+// not being set in /etc/hosts - using the IP address equivalent seems more
+// reliable.
+#define LOCALHOST "127.0.0.1"
+
+// Start at DEFAULT port and try higher ports until one isn't already in use.
+#define DEFAULT_PORT 1239
+
+#ifdef HAVE_FORK
+
+// We can't dynamically allocate memory for this because it confuses the leak
+// detector.  We only have 1-3 child fds open at once anyway, so a fixed size
+// array isn't a problem, and linear scanning isn't a problem either.
+struct pid_fd {
+    pid_t pid;
+    int fd;
+};
+
+static pid_fd pid_to_fd[16];
+
+extern "C" {
+
+static void
+on_SIGCHLD(int /*sig*/)
+{
+    int status;
+    pid_t child;
+    while ((child = waitpid(-1, &status, WNOHANG)) > 0) {
+	for (unsigned i = 0; i < sizeof(pid_to_fd) / sizeof(pid_fd); ++i) {
+	    if (pid_to_fd[i].pid == child) {
+		int fd = pid_to_fd[i].fd;
+		pid_to_fd[i].fd = 0;
+		pid_to_fd[i].pid = 0;
+		// NB close() *is* safe to use in a signal handler.
+		close(fd);
+		break;
+	    }
+	}
+    }
+}
+
+}
+
+static int
+launch_xapian_tcpsrv(const string & args)
+{
+    int port = DEFAULT_PORT;
+
+    // We want to be able to get the exit status of the child process we fork
+    // if xapian-tcpsrv doesn't start listening successfully.
+    signal(SIGCHLD, SIG_DFL);
+try_next_port:
+    string cmd = XAPIAN_TCPSRV " --one-shot --interface " LOCALHOST " --port ";
+    cmd += str(port);
+    cmd += " ";
+    cmd += args;
+#ifdef HAVE_VALGRIND
+    if (RUNNING_ON_VALGRIND) cmd = "./runsrv " + cmd;
+#endif
+    int fds[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, PF_UNSPEC, fds) < 0) {
+	string msg("Couldn't create socketpair: ");
+	msg += strerror(errno);
+	throw msg;
+    }
+
+    pid_t child = fork();
+    if (child == 0) {
+	// Child process.
+	close(fds[0]);
+	// Connect stdout and stderr to the socket.
+	//
+	// Make sure the socket isn't fd 1 or 2.  We need to ensure that
+	// FD_CLOEXEC isn't set for stdout or stderr (which creating them with
+	// dup2() achieves), and that we close fds[1].  The cleanest way to
+	// address this seems to be to turn the unusual situation into the
+	// usual one.
+	if (fds[1] == 1 || fds[1] == 2) {
+	    dup2(fds[1], 3);
+	    fds[1] = 3;
+	}
+	dup2(fds[1], 1);
+	dup2(fds[1], 2);
+	close(fds[1]);
+	execl("/bin/sh", "/bin/sh", "-c", cmd.c_str(), static_cast<void*>(0));
+	_exit(-1);
+    }
+
+    close(fds[1]);
+    if (child == -1) {
+	// Couldn't fork.
+	int fork_errno = errno;
+	close(fds[0]);
+	string msg("Couldn't fork: ");
+	msg += strerror(fork_errno);
+	throw msg;
+    }
+
+    // Parent process.
+
+    // Wrap the file descriptor in a FILE * so we can read lines using fgets().
+    FILE * fh = fdopen(fds[0], "r");
+    if (fh == NULL) {
+	string msg("Failed to run command '");
+	msg += cmd;
+	msg += "': ";
+	msg += strerror(errno);
+	throw msg;
+    }
+
+    string output;
+    while (true) {
+	char buf[256];
+	if (fgets(buf, sizeof(buf), fh) == NULL) {
+	    fclose(fh);
+	    // Wait for the child to exit.
+	    int status;
+	    if (waitpid(child, &status, 0) == -1) {
+		string msg("waitpid failed: ");
+		msg += strerror(errno);
+		throw msg;
+	    }
+	    if (++port < 65536 && status != 0) {
+		if (WIFEXITED(status) && WEXITSTATUS(status) == 69) {
+		    // 69 is EX_UNAVAILABLE which xapian-tcpsrv exits
+		    // with if (and only if) the port specified was
+		    // in use.
+		    goto try_next_port;
+		}
+	    }
+	    string msg("Failed to get 'Listening...' from command '");
+	    msg += cmd;
+	    msg += "' (output: ";
+	    msg += output;
+	    msg += ")";
+	    throw msg;
+	}
+	if (strcmp(buf, "Listening...\n") == 0) break;
+	output += buf;
+    }
+
+    // dup() the fd we wrapped with fdopen() so we can keep it open so the
+    // xapian-tcpsrv keeps running.
+    int tracked_fd = dup(fds[0]);
+
+    // We must fclose() the FILE* to avoid valgrind detecting memory leaks from
+    // its buffers.
+    fclose(fh);
+
+    // Find a slot to track the pid->fd mapping in.  If we can't find a slot
+    // it just means we'll leak the fd, so don't worry about that too much.
+    for (unsigned i = 0; i < sizeof(pid_to_fd) / sizeof(pid_fd); ++i) {
+	if (pid_to_fd[i].pid == 0) {
+	    pid_to_fd[i].fd = tracked_fd;
+	    pid_to_fd[i].pid = child;
+	    break;
+	}
+    }
+
+    // Set a signal handler to clean up the xapian-tcpsrv child process when it
+    // finally exits.
+    signal(SIGCHLD, on_SIGCHLD);
+
+    return port;
+}
+
+#elif defined __WIN32__
+
+XAPIAN_NORETURN(static void win32_throw_error_string(const char * str));
+static void win32_throw_error_string(const char * str)
+{
+    string msg(str);
+    char * error = 0;
+    DWORD len;
+    len = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_ALLOCATE_BUFFER,
+			0, GetLastError(), 0, (CHAR*)&error, 0, 0);
+    if (error) {
+	// Remove any trailing \r\n from output of FormatMessage.
+	if (len >= 2 && error[len - 2] == '\r' && error[len - 1] == '\n')
+	    len -= 2;
+	if (len) {
+	    msg += ": ";
+	    msg.append(error, len);
+	}
+	LocalFree(error);
+    }
+    throw msg;
+}
+
+// This implementation uses the WIN32 API to start xapian-tcpsrv as a child
+// process and read its output using a pipe.
+static int
+launch_xapian_tcpsrv(const string & args)
+{
+    int port = DEFAULT_PORT;
+
+try_next_port:
+    string cmd = XAPIAN_TCPSRV " --one-shot --interface " LOCALHOST " --port ";
+    cmd += str(port);
+    cmd += " ";
+    cmd += args;
+
+    // Create a pipe so we can read stdout/stderr from the child process.
+    HANDLE hRead, hWrite;
+    if (!CreatePipe(&hRead, &hWrite, 0, 0))
+	win32_throw_error_string("Couldn't create pipe");
+
+    // Set the write handle to be inherited by the child process.
+    SetHandleInformation(hWrite, HANDLE_FLAG_INHERIT, 1);
+
+    // Create the child process.
+    PROCESS_INFORMATION procinfo;
+    memset(&procinfo, 0, sizeof(PROCESS_INFORMATION));
+
+    STARTUPINFO startupinfo;
+    memset(&startupinfo, 0, sizeof(STARTUPINFO));
+    startupinfo.cb = sizeof(STARTUPINFO);
+    startupinfo.hStdError = hWrite;
+    startupinfo.hStdOutput = hWrite;
+    startupinfo.hStdInput = INVALID_HANDLE_VALUE;
+    startupinfo.dwFlags |= STARTF_USESTDHANDLES;
+
+    // For some reason Windows wants a modifiable copy!
+    BOOL ok;
+    char * cmdline = strdup(cmd.c_str());
+    ok = CreateProcess(0, cmdline, 0, 0, TRUE, 0, 0, 0, &startupinfo, &procinfo);
+    free(cmdline);
+    if (!ok)
+	win32_throw_error_string("Couldn't create child process");
+
+    CloseHandle(hWrite);
+    CloseHandle(procinfo.hThread);
+
+    string output;
+    FILE *fh = fdopen(_open_osfhandle(intptr_t(hRead), O_RDONLY), "r");
+    while (true) {
+	char buf[256];
+	if (fgets(buf, sizeof(buf), fh) == NULL) {
+	    fclose(fh);
+	    DWORD rc;
+	    // This doesn't seem to be necessary on the machine I tested on,
+	    // but I guess it could be on a slow machine...
+	    while (GetExitCodeProcess(procinfo.hProcess, &rc) && rc == STILL_ACTIVE) {
+		Sleep(100);
+	    }
+	    CloseHandle(procinfo.hProcess);
+	    if (++port < 65536 && rc == 69) {
+		// 69 is EX_UNAVAILABLE which xapian-tcpsrv exits
+		// with if (and only if) the port specified was
+		// in use.
+		goto try_next_port;
+	    }
+	    string msg("Failed to get 'Listening...' from command '");
+	    msg += cmd;
+	    msg += "' (output: ";
+	    msg += output;
+	    msg += ")";
+	    throw msg;
+	}
+	if (strcmp(buf, "Listening...\r\n") == 0) break;
+	output += buf;
+    }
+    fclose(fh);
+
+    return port;
+}
+
+#else
+# error Neither HAVE_FORK nor __WIN32__ is defined
+#endif
+
+BackendManagerRemoteTcp::~BackendManagerRemoteTcp() {
+    BackendManagerRemoteTcp::clean_up();
+}
+
+std::string
+BackendManagerRemoteTcp::get_dbtype() const
+{
+    return "remotetcp_" + remote_type;
+}
+
+Xapian::Database
+BackendManagerRemoteTcp::do_get_database(const vector<string> & files)
+{
+    // Default to a long (5 minute) timeout so that tests won't fail just
+    // because the host is slow or busy.
+    return BackendManagerRemoteTcp::get_remote_database(files, 300000);
+}
+
+Xapian::WritableDatabase
+BackendManagerRemoteTcp::get_writable_database(const string & name,
+					       const string & file)
+{
+    string args = get_writable_database_args(name, file);
+    int port = launch_xapian_tcpsrv(args);
+    return Xapian::Remote::open_writable(LOCALHOST, port);
+}
+
+Xapian::Database
+BackendManagerRemoteTcp::get_remote_database(const vector<string> & files,
+					     unsigned int timeout)
+{
+    string args = get_remote_database_args(files, timeout);
+    int port = launch_xapian_tcpsrv(args);
+    return Xapian::Remote::open(LOCALHOST, port);
+}
+
+Xapian::Database
+BackendManagerRemoteTcp::get_writable_database_as_database()
+{
+    string args = get_writable_database_as_database_args();
+    int port = launch_xapian_tcpsrv(args);
+    return Xapian::Remote::open(LOCALHOST, port);
+}
+
+Xapian::WritableDatabase
+BackendManagerRemoteTcp::get_writable_database_again()
+{
+    string args = get_writable_database_again_args();
+    int port = launch_xapian_tcpsrv(args);
+    return Xapian::Remote::open_writable(LOCALHOST, port);
+}
+
+void
+BackendManagerRemoteTcp::clean_up()
+{
+#ifdef HAVE_FORK
+    signal(SIGCHLD, SIG_DFL);
+    for (unsigned i = 0; i < sizeof(pid_to_fd) / sizeof(pid_fd); ++i) {
+	pid_t child = pid_to_fd[i].pid;
+	if (child) {
+	    int status;
+	    while (waitpid(child, &status, 0) == -1 && errno == EINTR) { }
+	    // Other possible error from waitpid is ECHILD, which it seems can
+	    // only mean that the child has already exited and SIGCHLD was set
+	    // to SIG_IGN.  If we did somehow see that, the sanest response
+	    // seems to be to close the fd and move on.
+	    int fd = pid_to_fd[i].fd;
+	    pid_to_fd[i].fd = 0;
+	    pid_to_fd[i].pid = 0;
+	    close(fd);
+	}
+    }
+#endif
+}
+#endif

--- a/xapian-letor/tests/harness/backendmanager_remotetcp.cc
+++ b/xapian-letor/tests/harness/backendmanager_remotetcp.cc
@@ -407,4 +407,5 @@ BackendManagerRemoteTcp::clean_up()
     }
 #endif
 }
-#endif
+
+#endif // XAPIAN_HAS_REMOTE_BACKEND

--- a/xapian-letor/tests/harness/backendmanager_remotetcp.h
+++ b/xapian-letor/tests/harness/backendmanager_remotetcp.h
@@ -1,0 +1,71 @@
+/** @file backendmanager_remotetcp.h
+ * @brief BackendManager subclass for remotetcp databases.
+ */
+/* Copyright (C) 2007,2009,2011 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_BACKENDMANAGER_REMOTETCP_H
+#define XAPIAN_INCLUDED_BACKENDMANAGER_REMOTETCP_H
+
+#include "backendmanager.h"
+#include "backendmanager_remote.h"
+
+#include <string>
+
+/// BackendManager subclass for remotetcp databases.
+class BackendManagerRemoteTcp : public BackendManagerRemote {
+    /// Don't allow assignment.
+    void operator=(const BackendManagerRemoteTcp &);
+
+    /// Don't allow copying.
+    BackendManagerRemoteTcp(const BackendManagerRemoteTcp &);
+
+    /// The path of the last writable database used.
+    std::string last_wdb_name;
+
+    /// Create a Xapian::Database object indexing multiple files.
+    Xapian::Database do_get_database(const std::vector<std::string> & files);
+
+  public:
+    BackendManagerRemoteTcp(const std::string & remote_type_)
+	: BackendManagerRemote(remote_type_) { }
+
+    ~BackendManagerRemoteTcp();
+
+    /// Return a string representing the current database type.
+    std::string get_dbtype() const;
+
+    /// Create a RemoteTcp Xapian::WritableDatabase object indexing a single file.
+    Xapian::WritableDatabase get_writable_database(const std::string & name,
+						   const std::string & file);
+
+    /// Create a RemoteTcp Xapian::Database with the specified timeout.
+    Xapian::Database get_remote_database(const std::vector<std::string> & files,
+					 unsigned int timeout);
+
+    /// Create a Database object for the last opened WritableDatabase.
+    Xapian::Database get_writable_database_as_database();
+
+    /// Create a WritableDatabase object for the last opened WritableDatabase.
+    Xapian::WritableDatabase get_writable_database_again();
+
+    /// Called after each test, to perform any necessary cleanup.
+    void clean_up();
+};
+
+#endif // XAPIAN_INCLUDED_BACKENDMANAGER_REMOTETCP_H

--- a/xapian-letor/tests/harness/backendmanager_singlefile.cc
+++ b/xapian-letor/tests/harness/backendmanager_singlefile.cc
@@ -105,4 +105,5 @@ BackendManagerSingleFile::get_writable_database(const string &, const string &)
 {
     throw Xapian::UnimplementedError("Single-file databases don't support writing");
 }
-#endif
+
+#endif // XAPIAN_HAS_GLASS_BACKEND

--- a/xapian-letor/tests/harness/backendmanager_singlefile.cc
+++ b/xapian-letor/tests/harness/backendmanager_singlefile.cc
@@ -1,0 +1,108 @@
+/** @file backendmanager_singlefile.cc
+ * @brief BackendManager subclass for singlefile databases.
+ */
+/* Copyright (C) 2007,2008,2009,2011,2012,2013,2015 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <config.h>
+
+#include "backendmanager_singlefile.h"
+
+#include "filetests.h"
+#include "index_utils.h"
+#include "unixcmds.h"
+
+#include <cstdio> // For rename().
+#include <cstring>
+#include "safeerrno.h"
+
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+
+using namespace std;
+
+BackendManagerSingleFile::BackendManagerSingleFile(const std::string & subtype_)
+	: subtype(subtype_)
+{
+#ifdef XAPIAN_HAS_GLASS_BACKEND
+    if (subtype == "glass") return;
+#endif
+    throw ("Unknown backend type \"" + subtype + "\" specified for singlefile database subdatabases");
+}
+
+std::string
+BackendManagerSingleFile::get_dbtype() const
+{
+    return "singlefile_" + subtype;
+}
+
+#define NUMBER_OF_SUB_DBS 2
+
+string
+BackendManagerSingleFile::createdb_singlefile(const vector<string> & files)
+{
+    string dbdir = ".singlefile" + subtype;
+    create_dir_if_needed(dbdir);
+
+    string dbname = "db";
+    vector<string>::const_iterator i;
+    for (i = files.begin(); i != files.end(); ++i) {
+	dbname += "__";
+	dbname += *i;
+    }
+    string dbpath = dbdir + "/" + dbname;
+
+    if (file_exists(dbpath)) return dbpath;
+
+    string db_source = dbpath + ".src";
+    int flags = Xapian::DB_CREATE_OR_OVERWRITE;
+    if (subtype == "glass") {
+	flags |= Xapian::DB_BACKEND_GLASS;
+    } else {
+	string msg = "Unknown singlefiledb subtype: ";
+	msg += subtype;
+	throw msg;
+    }
+
+    string tmpfile = dbpath;
+    tmpfile += ".tmp";
+
+    Xapian::WritableDatabase db(db_source, flags);
+    FileIndexer(get_datadir(), files).index_to(db);
+    db.commit();
+    db.compact(tmpfile, Xapian::DBCOMPACT_SINGLE_FILE);
+    db.close();
+
+    rm_rf(db_source);
+
+    rename(tmpfile.c_str(), dbpath.c_str());
+
+    return dbpath;
+}
+
+string
+BackendManagerSingleFile::do_get_database_path(const vector<string> & files)
+{
+    return createdb_singlefile(files);
+}
+
+Xapian::WritableDatabase
+BackendManagerSingleFile::get_writable_database(const string &, const string &)
+{
+    throw Xapian::UnimplementedError("Single-file databases don't support writing");
+}
+#endif

--- a/xapian-letor/tests/harness/backendmanager_singlefile.h
+++ b/xapian-letor/tests/harness/backendmanager_singlefile.h
@@ -1,0 +1,58 @@
+/** @file backendmanager_singlefile.h
+ * @brief BackendManager subclass for singlefile databases.
+ */
+/* Copyright (C) 2007,2009,2015 Olly Betts
+ * Copyright (C) 2008 Lemur Consulting Ltd
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_BACKENDMANAGER_SINGLEFILE_H
+#define XAPIAN_INCLUDED_BACKENDMANAGER_SINGLEFILE_H
+
+#include "backendmanager.h"
+
+#include <string>
+
+#include <xapian/database.h>
+
+/// BackendManager subclass for singlefile databases.
+class BackendManagerSingleFile : public BackendManager {
+    /// The type to use for the sub-databases.
+    std::string subtype;
+
+    /// Don't allow assignment.
+    void operator=(const BackendManagerSingleFile &);
+
+    /// Don't allow copying.
+    BackendManagerSingleFile(const BackendManagerSingleFile &);
+
+    std::string createdb_singlefile(const std::vector<std::string> & files);
+
+  protected:
+    /// Get the path of the Xapian::Database instance.
+    std::string do_get_database_path(const std::vector<std::string> & files);
+
+  public:
+    BackendManagerSingleFile(const std::string & subtype_);
+
+    /// Return a string representing the current database type.
+    std::string get_dbtype() const;
+
+    /// Create a Xapian::WritableDatabase object.
+    Xapian::WritableDatabase get_writable_database(const std::string & name, const std::string & file);
+};
+
+#endif // XAPIAN_INCLUDED_BACKENDMANAGER_SINGLEFILE_H

--- a/xapian-letor/tests/harness/testrunner.cc
+++ b/xapian-letor/tests/harness/testrunner.cc
@@ -32,6 +32,7 @@
 #include "backendmanager_remoteprog.h"
 #include "backendmanager_remotetcp.h"
 #include "backendmanager_singlefile.h"
+
 #include "stringutils.h"
 #include <iostream>
 

--- a/xapian-letor/tests/harness/testrunner.h
+++ b/xapian-letor/tests/harness/testrunner.h
@@ -52,6 +52,10 @@ class TestRunner {
      */
     bool use_backend(const std::string & backend_name);
 
+    /** Set the property flags to those for the named backend.
+     */
+    void set_properties_for_backend(const std::string & backend_name);
+
     /** Run the tests with the specified backend.
      */
     void do_tests_for_backend(BackendManager * manager);
@@ -59,6 +63,20 @@ class TestRunner {
   protected:
     enum {
 	BACKEND		= 0x00000001,
+	REMOTE		= 0x00000002,
+	TRANSACTIONS	= 0x00000004,
+	POSITIONAL	= 0x00000008,
+	WRITABLE	= 0x00000010,
+	SPELLING	= 0x00000020,
+	METADATA	= 0x00000040,
+	SYNONYMS	= 0x00000080,
+	REPLICAS	= 0x00000100,
+	VALUESTATS	= 0x00000200,
+	GENERATED	= 0x00000400,
+	MULTI		= 0x00000800,
+	SINGLEFILE	= 0x00001000,
+	INMEMORY	= 0x00002000,
+	GLASS		= 0x00004000,
     };
 
   public:

--- a/xapian-letor/tests/harness/testsuite.cc
+++ b/xapian-letor/tests/harness/testsuite.cc
@@ -2,7 +2,7 @@
  *
  * Copyright 1999,2000,2001 BrightStation PLC
  * Copyright 2002 Ananova Ltd
- * Copyright 2002,2003,2004,2005,2006,2007,2008,2009,2010,2012,2013,2015 Olly Betts
+ * Copyright 2002,2003,2004,2005,2006,2007,2008,2009,2010,2012,2013,2015,2016,2017 Olly Betts
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -29,10 +29,10 @@
 #endif
 #include "fdtracker.h"
 #include "testrunner.h"
+#include "safeerrno.h"
 #include "safeunistd.h"
 
 #ifdef HAVE_VALGRIND
-# include "safeerrno.h"
 # include <valgrind/memcheck.h>
 # include <sys/types.h>
 # include "safefcntl.h"
@@ -56,8 +56,8 @@
 #include <exception>
 #ifdef USE_RTTI
 # include <typeinfo>
-# ifdef __GNUC__
-#  include <cxxabi.h> // Added in GCC 3.1 which is now required.
+# ifdef HAVE_CXXABI_H
+#  include <cxxabi.h>
 # endif
 #endif
 
@@ -510,6 +510,16 @@ test_driver::runtest(const test_desc *test)
 		    out << col_yellow << " C++ FAILED TO CATCH " << errclass << col_reset;
 		    return SKIP;
 		}
+		if (errclass == "NetworkError" &&
+		    strcmp(err.get_error_string(), strerror(ECHILD)) == 0) {
+		    // ECHILD suggests we've run out of processes, and that's
+		    // much more likely to be a system issue than a Xapian bug.
+		    //
+		    // We also see apparently spurious ECHILD on Debian
+		    // buildds sometimes: https://bugs.debian.org/681941
+		    out << col_yellow << " ECHILD in network code" << col_reset;
+		    return SKIP;
+		}
 		out << " " << col_red << err.get_description() << col_reset;
 		write_and_clear_tout();
 		return FAIL;
@@ -524,7 +534,7 @@ test_driver::runtest(const test_desc *test)
 		out << "std::exception";
 #else
 		const char * name = typeid(e).name();
-# ifdef __GNUC__
+# ifdef HAVE_CXXABI_H__
 		// __cxa_demangle() apparently requires GCC >= 3.1.
 		// Demangle the name which GCC returns for type_info::name().
 		int status;


### PR DESCRIPTION
This will allow the tests written in letor to run against all the backends. Although the changes in xapian-letor/configure.ac and xapian-letor/build/tests/Makefile.mk are not permanent, for the time being this will help. 