### PR TITLE
Stopword removal

### DIFF
--- a/xapian-core/cluster/cluster.cc
+++ b/xapian-core/cluster/cluster.cc
@@ -57,7 +57,7 @@ TermListGroup::TermListGroup()
     LOGCALL_CTOR(API, "TermListGroup", NO_ARGS);
 }
 
-TermListGroup::TermListGroup(const MSet &docs, const Stopper *stopper = NULL)
+TermListGroup::TermListGroup(const MSet &docs, const Stopper *stopper)
 {
     LOGCALL_CTOR(API, "TermListGroup", docs | stopper);
     for (MSetIterator it = docs.begin(); it != docs.end(); ++it)
@@ -80,7 +80,7 @@ DummyFreqSource::get_doccount() const
 }
 
 void
-TermListGroup::add_document(const Document &document, const Stopper *stopper = NULL)
+TermListGroup::add_document(const Document &document, const Stopper *stopper)
 {
     LOGCALL_VOID(API, "TermListGroup::add_document", document | stopper);
 

--- a/xapian-core/cluster/cluster.cc
+++ b/xapian-core/cluster/cluster.cc
@@ -52,11 +52,6 @@ Clusterer::~Clusterer()
     LOGCALL_DTOR(API, "Clusterer");
 }
 
-TermListGroup::TermListGroup()
-{
-    LOGCALL_CTOR(API, "TermListGroup", NO_ARGS);
-}
-
 TermListGroup::TermListGroup(const MSet &docs, const Stopper *stopper)
 {
     LOGCALL_CTOR(API, "TermListGroup", docs | stopper);

--- a/xapian-core/cluster/kmeans.cc
+++ b/xapian-core/cluster/kmeans.cc
@@ -56,6 +56,13 @@ KMeans::get_description() const
 }
 
 void
+KMeans::set_stopper(const Stopper *stopper_)
+{
+    LOGCALL_VOID(API, "KMeans::set_stopper", stopper_);
+    stopper = stopper_;
+}
+
+void
 KMeans::initialise_clusters(ClusterSet &cset, doccount num_of_points)
 {
     LOGCALL_VOID(API, "KMeans::initialise_clusters", cset | num_of_points);
@@ -72,7 +79,7 @@ void
 KMeans::initialise_points(const MSet &source)
 {
     LOGCALL_VOID(API, "KMeans::initialise_points", source);
-    TermListGroup tlg(source);
+    TermListGroup tlg(source, stopper.get());
     for (MSetIterator it = source.begin(); it != source.end(); ++it)
 	points.push_back(Point(tlg, it.get_document()));
 }

--- a/xapian-core/include/xapian/cluster.h
+++ b/xapian-core/include/xapian/cluster.h
@@ -175,9 +175,6 @@ class XAPIAN_VISIBILITY_DEFAULT TermListGroup : public FreqSource {
      */
     explicit TermListGroup(const MSet &docs, const Stopper *stopper = NULL);
 
-    /// Default constructor
-    TermListGroup();
-
     /** Return the number of documents that the term 'tname' exists in
      *
      *  @param tname	The term for which to return the term frequency

--- a/xapian-core/include/xapian/cluster.h
+++ b/xapian-core/include/xapian/cluster.h
@@ -28,6 +28,7 @@
 #endif
 
 #include <xapian/mset.h>
+#include <xapian/queryparser.h>
 #include <xapian/types.h>
 #include <xapian/visibility.h>
 
@@ -162,15 +163,20 @@ class XAPIAN_VISIBILITY_DEFAULT TermListGroup : public FreqSource {
      *
      *  @param document 	Adds a document and updates the TermListGroup
      *				based on the terms found in the document
+     *  @param stopper		Xapian::Stopper object to identify stopwords
      */
-    void add_document(const Document &document);
+    void add_document(const Document &document, const Stopper *stopper = NULL);
 
   public:
     /** Constructor
      *
      *  @param docs	MSet object used to construct the TermListGroup
+     *  @param stopper	Xapian::Stopper object to identify stopwords
      */
-    explicit TermListGroup(const MSet &docs);
+    explicit TermListGroup(const MSet &docs, const Stopper *stopper = NULL);
+
+    /// Default constructor
+    TermListGroup();
 
     /** Return the number of documents that the term 'tname' exists in
      *
@@ -570,6 +576,9 @@ class XAPIAN_VISIBILITY_DEFAULT KMeans : public Clusterer {
     /// Specifies the maximum number of iterations that KMeans will have
     unsigned int max_iters;
 
+    /// Pointer to stopper object for identifying stopwords
+    Xapian::Internal::opt_intrusive_ptr<const Xapian::Stopper> stopper;
+
     /** Initialise 'k' clusters by selecting 'k' centroids and assigning
      *  them to different clusters
      *
@@ -604,6 +613,14 @@ class XAPIAN_VISIBILITY_DEFAULT KMeans : public Clusterer {
      *                 be clustered
      */
     ClusterSet cluster(const MSet &mset);
+
+    /** Set the Xapian::Stopper object to be used for identifying stopwords.
+     *  Stopwords are discarded while calculating term frequency for terms
+     *
+     *  @param stop	The Stopper object to set (default NULL, which means no
+     *			stopwords)
+     */
+    void set_stopper(const Xapian::Stopper *stop = NULL);
 
     /// Return a string describing this object
     std::string get_description() const;


### PR DESCRIPTION
KMeans has been added with a method named set_stopper. This gives the user full control on the kind of stopwords they would want to use. The provided stopper is given to the TermListGroup which uses it to filter out stopword terms.