### PR TITLE
Fixing letor bugs and improving ranker api

### DIFF
--- a/xapian-letor/api/featurelist.cc
+++ b/xapian-letor/api/featurelist.cc
@@ -98,6 +98,8 @@ FeatureList::create_feature_vectors(const Xapian::MSet & mset,
 				    const Xapian::Database & letor_db) const
 {
     LOGCALL(API, std::vector<FeatureVector>, "FeatureList::create_feature_vectors", mset | letor_query | letor_db);
+    if (mset.empty())
+	return vector<FeatureVector>();
     std::vector<FeatureVector> fvec;
 
     for (Xapian::MSetIterator i = mset.begin(); i != mset.end(); ++i) {

--- a/xapian-letor/feature/feature.cc
+++ b/xapian-letor/feature/feature.cc
@@ -26,7 +26,7 @@
 
 namespace Xapian {
 
-Feature::Feature()
+Feature::Feature() : stats_needed()
 {
     LOGCALL_CTOR(API, "Feature", NO_ARGS);
 }

--- a/xapian-letor/include/xapian-letor/ranker.h
+++ b/xapian-letor/include/xapian-letor/ranker.h
@@ -193,7 +193,7 @@ class XAPIAN_VISIBILITY_DEFAULT Ranker : public Xapian::Internal::intrusive_base
   protected:
     /// Method to train the model. Overridden in ranker subclass.
     virtual void
-    train_model(const std::vector<Xapian::FeatureVector> & training_data) = 0;
+    train(const std::vector<Xapian::FeatureVector> & training_data) = 0;
 
     /** Method to save model as db metadata. Overridden in ranker subclass.
      *
@@ -257,7 +257,7 @@ class XAPIAN_VISIBILITY_DEFAULT ListNETRanker: public Ranker {
      *
      * @exception LetorInternalError will be thrown if training data is null.
      */
-    void train_model(const std::vector<Xapian::FeatureVector> & training_data);
+    void train(const std::vector<Xapian::FeatureVector> & training_data);
 
     /** Method to save ListNET model as db metadata.
      *
@@ -317,7 +317,7 @@ class XAPIAN_VISIBILITY_DEFAULT SVMRanker: public Ranker {
      *
      *  @exception LetorInternalError will be thrown if training data is null.
      */
-    void train_model(const std::vector<Xapian::FeatureVector> & training_data);
+    void train(const std::vector<Xapian::FeatureVector> & training_data);
 
     /** Method to save SVMRanker model as db metadata.
      *

--- a/xapian-letor/ranker/listnet_ranker.cc
+++ b/xapian-letor/ranker/listnet_ranker.cc
@@ -119,8 +119,8 @@ updateParameters(vector<double> &new_parameters, const vector<double> &gradient,
 }
 
 void
-ListNETRanker::train_model(const std::vector<Xapian::FeatureVector> & training_data) {
-    LOGCALL_VOID(API, "ListNETRanker::train_model", training_data);
+ListNETRanker::train(const std::vector<Xapian::FeatureVector> & training_data) {
+    LOGCALL_VOID(API, "ListNETRanker::train", training_data);
     size_t fvv_len = training_data.size();
     int feature_cnt = -1;
     if (fvv_len != 0) {

--- a/xapian-letor/ranker/ranker.cc
+++ b/xapian-letor/ranker/ranker.cc
@@ -387,7 +387,7 @@ Ranker::train_model(const std::string & input_filename, const std::string & mode
 {
     LOGCALL_VOID(API, "Ranker::train_model", input_filename | model_key);
     vector<FeatureVector> list_fvecs = load_list_fvecs(input_filename);
-    train_model(list_fvecs);
+    train(list_fvecs);
     save_model_to_metadata(model_key);
 }
 

--- a/xapian-letor/ranker/svmranker.cc
+++ b/xapian-letor/ranker/svmranker.cc
@@ -66,9 +66,9 @@ get_non_zero_num(const Xapian::FeatureVector & fv_non_zero)
 }
 
 void
-SVMRanker::train_model(const std::vector<Xapian::FeatureVector> & training_data)
+SVMRanker::train(const std::vector<Xapian::FeatureVector> & training_data)
 {
-    LOGCALL_VOID(API, "SVMRanker::train_model", training_data);
+    LOGCALL_VOID(API, "SVMRanker::train", training_data);
     struct svm_parameter param;
     param.svm_type = 4;         //nu-SVR
     param.kernel_type = 0;      //linear Kernel


### PR DESCRIPTION
Following Changes have been made as discussed on irc:
1. Renamed pure virtual function "virtual void Ranker::train_model" and all its instances to train.
2. FeatureList::create_feature_vector now returns an empty vector<FeatureVector> if the input MSet is empty.
3. Initialized the stats_needed variable in Feature constructor.

These were the few issues I found while testing. I will continue to discuss and resolve issues as they keep coming up.