### PR TITLE
Fix TermGenerator do not stop stemmed term.

### DIFF
--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -181,7 +181,7 @@ index_add_default_filters()
     // pod2text's output character set doesn't seem to be documented, but from
     // inspecting the source it looks like it's probably iso-8859-1.
     index_command("text/x-perl",
-		  Filter("pod2text --errors=none", "text/plain", "iso-8859-1", false));
+		  Filter("perl -MPod::Text -e '$p = Pod::Text->new(); $p->no_errata_section(1); $p->parse_file($ARGV[0])'", "text/plain", "iso-8859-1", false));
     // FIXME: -e0 means "UTF-8", but that results in "fi", "ff", "ffi", etc
     // appearing as single ligatures.  For European languages, it's actually
     // better to use -e2 (ISO-8859-1) and then convert, so let's do that for

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -181,7 +181,7 @@ index_add_default_filters()
     // pod2text's output character set doesn't seem to be documented, but from
     // inspecting the source it looks like it's probably iso-8859-1.
     index_command("text/x-perl",
-		  Filter("pod2text", "text/plain", "iso-8859-1", false));
+		  Filter("pod2text --errors=none", "text/plain", "iso-8859-1", false));
     // FIXME: -e0 means "UTF-8", but that results in "fi", "ff", "ffi", etc
     // appearing as single ligatures.  For European languages, it's actually
     // better to use -e2 (ISO-8859-1) and then convert, so let's do that for

--- a/xapian-core/queryparser/termgenerator_internal.cc
+++ b/xapian-core/queryparser/termgenerator_internal.cc
@@ -267,18 +267,22 @@ TermGenerator::Internal::index_text(Utf8Iterator itor, termcount wdf_inc,
 	    if (strategy == TermGenerator::STEM_NONE ||
 		!stemmer.internal.get()) return true;
 
-	    if (strategy == TermGenerator::STEM_SOME) {
-		if (current_stop_mode == TermGenerator::STOP_STEMMED &&
-		    (*stopper)(term))
-		    return true;
-
-		// Note, this uses the lowercased term, but that's OK as we
-		// only want to avoid stemming terms starting with a digit.
-		if (!should_stem(term)) return true;
+	    // Note, this uses the lowercased term, but that's OK as we
+	    // only want to avoid stemming terms starting with a digit.
+	    if (strategy == TermGenerator::STEM_SOME && !should_stem(term)) {
+		return true;
 	    }
 
 	    // Add stemmed form without positional information.
 	    const string& stem = stemmer(term);
+
+	    // Stop stemmed term which belongs to stopword list.
+	    if (strategy == TermGenerator::STEM_SOME) {
+		if (current_stop_mode == TermGenerator::STOP_STEMMED &&
+		    (*stopper)(stem))
+		    return true;
+	    }
+
 	    if (rare(stem.empty())) return true;
 	    string stemmed_term;
 	    if (strategy != TermGenerator::STEM_ALL) {

--- a/xapian-core/tests/api_termgen.cc
+++ b/xapian-core/tests/api_termgen.cc
@@ -878,3 +878,26 @@ DEFINE_TESTCASE(tg_max_word_length1, !backend) {
 
     return true;
 }
+
+DEFINE_TESTCASE(stop_stemmed_terms, !backend) {
+    Xapian::TermGenerator termgen;
+    termgen.set_stemmer(Xapian::Stem("en"));
+
+    Xapian::Document doc;
+    termgen.set_document(doc);
+
+    array<const char *, 3> x = {{"bowl", "a", "an"}};
+    Xapian::SimpleStopper *stopper = new Xapian::SimpleStopper(x.begin(), x.end());
+    termgen.set_stopper(stopper->release());
+
+    termgen.set_stopper_strategy(termgen.STOP_STEMMED);
+    termgen.set_stemming_strategy(termgen.STEM_SOME);
+
+    termgen.index_text("cups bowls mugs");
+
+    TEST_STRINGS_EQUAL(format_doc_termlist(doc),
+		       "Zcup:1 Zmug:1 bowls[2] cups[1] mugs[3]");
+
+    return true;
+
+}


### PR DESCRIPTION
It seems that the TermGenerator? (with STOP_ALL and STEM_ALL strategy) do not stop stemmed term.

For example, with french stemmer and "le" in the stopwords, le term "lea" will be stemmed to "le" and "le" term will be added to the document.

Looking into termgenerator_internal.cc (method index_text), it seems that the stopper in never called on the stem, whatever the flags are.

We are using version 1.4.2 but the stopper is never called on the stem even on git master.

Fixed the issue by changing code and added a test case to fix this issue.

