### PR TITLE
Add ListMLE ranker to letor

### DIFF
--- a/xapian-letor/include/xapian-letor/ranker.h
+++ b/xapian-letor/include/xapian-letor/ranker.h
@@ -354,7 +354,7 @@ class XAPIAN_VISIBILITY_DEFAULT SVMRanker: public Ranker {
 
 };
 
-class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
+class XAPIAN_VISIBILITY_DEFAULT ListMLERanker : public Ranker {
     /// Ranker parameters
     std::vector<double> parameters;
     /// Learning rate (Default is 0.001)
@@ -367,11 +367,11 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
      * @exception InvalidArgumentError will be thrown if training_data is
      *            empty.
      */
-    void train(const std::vector<Xapian::FeatureVector> & training_data);
+    void train(const std::vector<Xapian::FeatureVector>& training_data);
 
     /** Save ListMLE model as db metadata.
      *
-     *  ListMLE model file gets stored with each parameter value in a new line.
+     *  ListMLE model gets stored with each parameter value in a new line.
      *	e.g.
      *
      *  0.000920817564536697
@@ -381,28 +381,28 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
      *
      *  @param model_key	Metadata key using which model is to be stored.
      */
-    void save_model_to_metadata(const std::string & model_key);
+    void save_model_to_metadata(const std::string& model_key);
 
-    /** Load model from an external file.
+    /** Load model from db metadata.
      *
      *  @param model_key         Metadata key using which model is to be
      *				 loaded.
      *
-     *  @exception LetorInternalError will be thrown if no model exists
+     *  @exception InvalidArgumentError will be thrown if no model exists
      *  	   corresponding to the supplied key
      */
-    void load_model_from_metadata(const std::string & model_key);
+    void load_model_from_metadata(const std::string& model_key);
 
     /** Re-rank a std::vector<Xapian::FeatureVector> by using the
      *  model.
      *
      *  @param fvv	vector<FeatureVector> that will be re-ranked.
      *
-     *  @exception	LetorInternalError will be thrown if model file
+     *  @exception	InvalidArgumentError will be thrown if model file
      *			is not compatible.
      */
     std::vector<Xapian::FeatureVector>
-    rank_fvv(const std::vector<Xapian::FeatureVector> & fvv) const;
+    rank_fvv(const std::vector<Xapian::FeatureVector>& fvv) const;
 
   public:
     /* Construct ListMLE instance
@@ -410,8 +410,8 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
      * @param num_interations  Number of iterations (Default is 10)
      */
     explicit ListMLERanker(double learn_rate = 0.001,
-			    int num_interations = 10):
-	 learning_rate(learn_rate), iterations(num_interations) { }
+			    int num_interations = 10)
+	: learning_rate(learn_rate), iterations(num_interations) { }
 
     /// Destructor
     ~ListMLERanker();

--- a/xapian-letor/include/xapian-letor/ranker.h
+++ b/xapian-letor/include/xapian-letor/ranker.h
@@ -371,7 +371,8 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker : public Ranker {
 
     /** Save ListMLE model as db metadata.
      *
-     *  ListMLE model gets stored with each parameter value in a new line.
+     *  ListMLE model gets stored with serialised value of each parameter in
+     *  a new line.
      *	e.g.
      *
      *  0.000920817564536697

--- a/xapian-letor/include/xapian-letor/ranker.h
+++ b/xapian-letor/include/xapian-letor/ranker.h
@@ -354,6 +354,67 @@ class XAPIAN_VISIBILITY_DEFAULT SVMRanker: public Ranker {
 
 };
 
+class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
+    /// Ranker parameters
+    std::vector<double> parameters;
+    /// Learning rate (Default is 0.001)
+    double learning_rate;
+    /// Number of iterations (Default is 10)
+    int iterations;
+
+    /** Method to train the model.
+     *
+     * @exception LetorInternalError will be thrown if training data is null.
+     */
+    void train(const std::vector<Xapian::FeatureVector> & training_data);
+
+    /** Method to save ListMLE model as db metadata.
+     *
+     *  ListMLE model file gets stored with each parameter value in a new line.
+     *	 e.g.
+     *
+     *  0.000920817564536697
+     *  0.000920817564536697
+     *  0
+     *  -1.66533453693773e-19
+     *
+     *  @param model_key	Metadata key using which model is to be stored.
+     */
+    void save_model_to_metadata(const std::string & model_key);
+
+    /** Method to load model from an external file.
+     *
+     *  @param model_key         Metadata key using which model is to be
+     *				 loaded.
+     *
+     *  @exception LetorInternalError will be thrown if no model exists
+     *  	   corresponding to the supplied key
+     */
+    void load_model_from_metadata(const std::string & model_key);
+
+    /** Method to re-rank a std::vector<Xapian::FeatureVector> by using the
+     *  model.
+     *
+     *  @param fvv	vector<FeatureVector> that will be re-ranked.
+     *
+     *  @exception	LetorInternalError will be thrown if model file
+     *			is not compatible.
+     */
+    std::vector<Xapian::FeatureVector>
+    rank_fvv(const std::vector<Xapian::FeatureVector> & fvv) const;
+
+  public:
+    /* Construct ListMLE instance
+     * @param learn_rate       Learning rate
+     * @param num_interations  Number of iterations
+     */
+    explicit ListMLERanker(double learn_rate = 0.001,
+			    int num_interations = 10):
+	 learning_rate(learn_rate), iterations(num_interations) { }
+
+    /// Destructor
+    ~ListMLERanker();
+};
 }
 
 #endif /* RANKER_H */

--- a/xapian-letor/include/xapian-letor/ranker.h
+++ b/xapian-letor/include/xapian-letor/ranker.h
@@ -362,16 +362,17 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
     /// Number of iterations (Default is 10)
     int iterations;
 
-    /** Method to train the model.
+    /** Train the model.
      *
-     * @exception LetorInternalError will be thrown if training data is null.
+     * @exception InvalidArgumentError will be thrown if training_data is
+     *            empty.
      */
     void train(const std::vector<Xapian::FeatureVector> & training_data);
 
-    /** Method to save ListMLE model as db metadata.
+    /** Save ListMLE model as db metadata.
      *
      *  ListMLE model file gets stored with each parameter value in a new line.
-     *	 e.g.
+     *	e.g.
      *
      *  0.000920817564536697
      *  0.000920817564536697
@@ -382,7 +383,7 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
      */
     void save_model_to_metadata(const std::string & model_key);
 
-    /** Method to load model from an external file.
+    /** Load model from an external file.
      *
      *  @param model_key         Metadata key using which model is to be
      *				 loaded.
@@ -392,7 +393,7 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
      */
     void load_model_from_metadata(const std::string & model_key);
 
-    /** Method to re-rank a std::vector<Xapian::FeatureVector> by using the
+    /** Re-rank a std::vector<Xapian::FeatureVector> by using the
      *  model.
      *
      *  @param fvv	vector<FeatureVector> that will be re-ranked.
@@ -405,8 +406,8 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker: public Ranker {
 
   public:
     /* Construct ListMLE instance
-     * @param learn_rate       Learning rate
-     * @param num_interations  Number of iterations
+     * @param learn_rate       Learning rate (Default is 0.001)
+     * @param num_interations  Number of iterations (Default is 10)
      */
     explicit ListMLERanker(double learn_rate = 0.001,
 			    int num_interations = 10):

--- a/xapian-letor/include/xapian-letor/ranker.h
+++ b/xapian-letor/include/xapian-letor/ranker.h
@@ -371,14 +371,7 @@ class XAPIAN_VISIBILITY_DEFAULT ListMLERanker : public Ranker {
 
     /** Save ListMLE model as db metadata.
      *
-     *  ListMLE model gets stored with serialised value of each parameter in
-     *  a new line.
-     *	e.g.
-     *
-     *  0.000920817564536697
-     *  0.000920817564536697
-     *  0
-     *  -1.66533453693773e-19
+     *  The model is serialised as a binary blob.
      *
      *  @param model_key	Metadata key using which model is to be stored.
      */

--- a/xapian-letor/ranker/Makefile.mk
+++ b/xapian-letor/ranker/Makefile.mk
@@ -5,6 +5,7 @@ EXTRA_DIST +=\
 	ranker/Makefile
 
 lib_src +=\
+	ranker/listmle_ranker.cc\
 	ranker/listnet_ranker.cc\
 	ranker/ranker.cc\
 	common/serialise-double.cc\

--- a/xapian-letor/ranker/listmle_ranker.cc
+++ b/xapian-letor/ranker/listmle_ranker.cc
@@ -78,8 +78,8 @@ calculateGradient(vector<FeatureVector> & sorted_feature_vectors,
 
     for (size_t i = 0; i < list_length; ++i) {
 	double temp = exp(calculateInnerProduct(
-			  new_parameters,
-			  sorted_feature_vectors[i].get_fvals()));
+			      new_parameters,
+			      sorted_feature_vectors[i].get_fvals()));
 	exponents.push_back(temp);
 	expsum += temp;
     }
@@ -108,7 +108,7 @@ updateParameters(vector<double> & new_parameters, vector<double> & gradient,
 		 double & learning_rate) {
     size_t num = new_parameters.size();
     for (size_t i = 0; i < num; ++i) {
-	    new_parameters[i] -= gradient[i] * learning_rate;
+	new_parameters[i] -= gradient[i] * learning_rate;
     }
 }
 
@@ -180,32 +180,18 @@ ListMLERanker::load_model_from_metadata(const string & model_key) {
     swap(parameters, loaded_parameters);
 }
 
-vector<FeatureVector>
-ListMLERanker::rank_fvv(const vector<FeatureVector> & fvv) const {
-
-    vector<FeatureVector> testfvv = fvv;
-    size_t testfvvsize = testfvv.size();
-
-    vector<double> new_parameters = this->parameters;
-    size_t parameters_size = new_parameters.size();
-
-    for (size_t i = 0; i < testfvvsize; ++i) {
-
-	double listnet_score = 0.0;
-
-	vector<double> fvals = testfvv[i].get_fvals();
-	size_t fvalsize = fvals.size();
-
-	if (fvalsize != parameters_size) {
-	    throw Xapian::InvalidArgumentError(
-			"Number of fvals don't match the number of ListNet "
-			"parameters\n");
-	}
-
-	for (size_t j = 0; j < fvalsize; ++j) {
-	    listnet_score += fvals[j] * new_parameters[j];
-	}
-
+std::vector<FeatureVector>
+ListNETRanker::rank_fvv(const std::vector<FeatureVector> & fvv) const {
+    LOGCALL(API, std::vector<FeatureVector>, "ListNETRanker::rank_fvv", fvv);
+    std::vector<FeatureVector> testfvv = fvv;
+    for (size_t i = 0; i < testfvv.size(); ++i) {
+	double listnet_score = 0;
+	std::vector<double> fvals = testfvv[i].get_fvals();
+	if (fvals.size() != parameters.size())
+	    throw LetorInternalError("Model incompatible. Make sure that you are using "
+				     "the same set of Features using which the model was created.");
+	for (size_t j = 0; j < fvals.size(); ++j)
+	    listnet_score += fvals[j] * parameters[j];
 	testfvv[i].set_score(listnet_score);
     }
     return testfvv;

--- a/xapian-letor/ranker/listmle_ranker.cc
+++ b/xapian-letor/ranker/listmle_ranker.cc
@@ -1,0 +1,265 @@
+/** @file listmle_ranker.cc
+ *  @brief Implementation of ListMLERanker
+ */
+/* Copyright (C) 2014 Hanxiao Sun
+ * Copyright (C) 2016 Ayush Tomar
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+/*
+ListNET is adapted from the paper:
+Fen Xia, Tie-Yan Liu, Jue Wang, Wensheng Zhang, Hang Li
+et al. "Listwise Approach to Learning to Rank - Theory and Algorithm."
+*/
+#include <config.h>
+
+#include "xapian-letor/ranker.h"
+
+#include "debuglog.h"
+#include "serialise-double.h"
+
+#include <xapian.h>
+#include <xapian/intrusive_ptr.h>
+#include <xapian/types.h>
+#include <xapian/visibility.h>
+
+#include <algorithm>
+#include <cmath>
+#include <stdlib.h>
+
+using namespace std;
+using namespace Xapian;
+
+ListMLERanker::~ListMLERanker() {
+    LOGCALL_DTOR(API, "ListMLERanker");
+}
+
+struct labelComparer {
+    bool operator()(const FeatureVector & firstfv,
+		    const FeatureVector& secondfv) const {
+	return firstfv.get_label() > secondfv.get_label();
+    }
+};
+
+static double
+calculateInnerProduct(vector<double> & parameters,
+		      vector<double> feature_sets) {
+
+    double inner_product = 0.0;
+    for (size_t i = 0; i < parameters.size(); ++i) {
+	//the feature start from 1, while the parameters strat from 0
+	inner_product += parameters[i] * feature_sets[i];
+    }
+    return inner_product;
+}
+
+/*
+loss function: negative log Likelihood
+the equation (9) in the paper
+
+static double
+negativeLogLikelihood(vector<FeatureVector> sorted_feature_vectors,
+		      vector<double> new_parameters) {
+
+    size_t list_length = sorted_feature_vectors.size();
+    //top 1 probability
+    double first_place_in_ground_truth;
+    double expsum = 0.0;
+    if (list_length != 0) {
+	//Also use top 1 probability, so we need the first one in the ground
+	//truth.
+	//Should be put into init?
+	first_place_in_ground_truth =
+		exp(calculateInnerProduct(new_parameters,
+					  sorted_feature_vectors[0].get_fvals()
+					  ));
+    }
+    else{
+	printf("the feature_vectors is null in ListMLERanker:logLikelihood\n");
+	exit(1);
+    }
+
+    for (size_t i = 0; i < list_length; ++i) {
+	expsum += exp(calculateInnerProduct(new_parameters,
+		      sorted_feature_vectors[i].get_fvals()));
+    }
+    return log(expsum) - log(first_place_in_ground_truth);
+}
+*/
+
+static vector<double>
+calculateGradient(vector<FeatureVector> & sorted_feature_vectors,
+		  vector<double> & new_parameters) {
+
+    //need to be optimized,how to get the length of the features
+    vector<double> gradient(sorted_feature_vectors[0].get_fcount(), 0);
+
+    size_t list_length = sorted_feature_vectors.size();
+
+    vector<double> exponents;
+    double expsum = 0.0;
+
+    for (size_t i = 0; i < list_length; ++i) {
+	double temp = exp(calculateInnerProduct(
+			  new_parameters,
+			  sorted_feature_vectors[i].get_fvals()));
+	exponents.push_back(temp);
+	expsum += temp;
+    }
+
+    for (size_t i = 0; i < list_length; ++i) {
+	//Not convenient, but in order to get the feature,
+	//I have to run the ranklist loop first.
+	//Need to see whether the fvals could be a vector
+	vector<double> feature_sets = sorted_feature_vectors[i].get_fvals();
+
+	//for each feature in special feature vector
+	for (size_t j = 0; j < feature_sets.size() - 1; ++j) {
+	    gradient[j] += feature_sets[j] * exponents[i] / expsum;
+	}
+    }
+
+    vector<double> first_place_in_ground_truth_feature_sets =
+	    sorted_feature_vectors[0].get_fvals();
+
+    for (size_t i = 0; i < first_place_in_ground_truth_feature_sets.size() - 1;
+	 ++i) {
+	gradient[i] -= first_place_in_ground_truth_feature_sets[i];
+
+    }
+
+    return gradient;
+}
+
+static void
+updateParameters(vector<double> & new_parameters, vector<double> & gradient,
+		 double & learning_rate) {
+    size_t num = new_parameters.size();
+    if (num != gradient.size()) {
+	printf("the size between base new_parameters and gradient is not "
+	       "match in listnet::updateParameters\n");
+	printf("the size of new_parameters: %zu\n", num);
+	printf("the size of gradient: %zu\n", gradient.size());
+    }
+    else {
+	for (size_t i = 0; i < num; ++i) {
+	    new_parameters[i] -= gradient[i] * learning_rate;
+	}
+    }
+}
+
+static void
+batchLearning(vector<FeatureVector> feature_vectors,
+	      vector<double> & new_parameters, double learning_rate) {
+
+    //ListMLE need to use the ground truth, so sort before train
+    sort(feature_vectors.begin(), feature_vectors.end(), labelComparer());
+
+    //compute gradient
+    vector<double> gradient = calculateGradient(feature_vectors,
+						new_parameters);
+
+    //update parameters: w = w - gradient * learningRate
+    updateParameters(new_parameters, gradient, learning_rate);
+
+}
+
+void
+ListMLERanker::train(const vector<FeatureVector> & training_data) {
+
+    int feature_cnt = training_data[0].get_fcount();
+
+    //initialize the parameters for neural network
+    vector<double> new_parameters;
+    for (int feature_num = 0; feature_num < feature_cnt; ++feature_num) {
+	new_parameters.push_back(0.0);
+    }
+
+    //iterations
+    for (int iter_num = 1; iter_num < iterations; ++iter_num) {
+	batchLearning(training_data, new_parameters, learning_rate);
+    }
+
+    swap(parameters, new_parameters);
+}
+
+void
+ListMLERanker::save_model_to_metadata(const string & model_key) {
+    LOGCALL_VOID(API, "ListMLERanker::save_model_to_metadata", model_key);
+    WritableDatabase letor_db(get_database_path());
+    string key = model_key;
+    if (key.empty()) {
+	key = "ListMLE.model.default";
+    }
+    string model_data;
+    for (size_t i = 0; i < parameters.size(); ++i)
+	model_data += serialise_double(parameters[i]);
+    letor_db.set_metadata(key, model_data);
+}
+
+void
+ListMLERanker::load_model_from_metadata(const string & model_key) {
+    LOGCALL_VOID(API, "ListMLERanker::load_model_from_metadata", model_key);
+    Database letor_db(get_database_path());
+    string key = model_key;
+    if (key.empty()) {
+	key = "ListMLE.model.default";
+    }
+    string model_data = letor_db.get_metadata(key);
+    // Throw exception if no model data associated with key
+    if (model_data.empty()) {
+	throw LetorInternalError("No model found. Check key.");
+    }
+    vector<double> loaded_parameters;
+    const char *ptr = model_data.data();
+    const char *end = ptr + model_data.size();
+    while (ptr != end) {
+	loaded_parameters.push_back(unserialise_double(&ptr, end));
+    }
+    swap(parameters, loaded_parameters);
+}
+
+vector<FeatureVector>
+ListMLERanker::rank_fvv(const vector<FeatureVector> & fvv) const {
+
+    vector<FeatureVector> testfvv = fvv;
+    size_t testfvvsize = testfvv.size();
+
+    vector<double> new_parameters = this->parameters;
+    size_t parameters_size = new_parameters.size();
+
+    for (size_t i = 0; i < testfvvsize; ++i) {
+
+	double listnet_score = 0.0;
+
+	vector<double> fvals = testfvv[i].get_fvals();
+	size_t fvalsize = fvals.size();
+
+	if (fvalsize != parameters_size) {
+	    throw Xapian::InvalidArgumentError(
+			"Number of fvals don't match the number of ListNet "
+			"parameters\n");
+	}
+
+	for (size_t j = 0; j < fvalsize; ++j) {
+	    listnet_score += fvals[j] * new_parameters[j];
+	}
+
+	testfvv[i].set_score(listnet_score);
+    }
+    return testfvv;
+}

--- a/xapian-letor/ranker/listmle_ranker.cc
+++ b/xapian-letor/ranker/listmle_ranker.cc
@@ -21,7 +21,7 @@
  */
 
 /*
-ListNET is adapted from the paper:
+ListMLE is adapted from the paper:
 Fen Xia, Tie-Yan Liu, Jue Wang, Wensheng Zhang, Hang Li
 et al. "Listwise Approach to Learning to Rank - Theory and Algorithm."
 */
@@ -185,14 +185,14 @@ ListMLERanker::rank_fvv(const std::vector<FeatureVector> & fvv) const {
     LOGCALL(API, std::vector<FeatureVector>, "ListMLERanker::rank_fvv", fvv);
     std::vector<FeatureVector> testfvv = fvv;
     for (size_t i = 0; i < testfvv.size(); ++i) {
-	double listnet_score = 0;
+	double listmle_score = 0;
 	std::vector<double> fvals = testfvv[i].get_fvals();
 	if (fvals.size() != parameters.size())
 	    throw LetorInternalError("Model incompatible. Make sure that you are using "
 				     "the same set of Features using which the model was created.");
 	for (size_t j = 0; j < fvals.size(); ++j)
-	    listnet_score += fvals[j] * parameters[j];
-	testfvv[i].set_score(listnet_score);
+	    listmle_score += fvals[j] * parameters[j];
+	testfvv[i].set_score(listmle_score);
     }
     return testfvv;
 }

--- a/xapian-letor/ranker/listmle_ranker.cc
+++ b/xapian-letor/ranker/listmle_ranker.cc
@@ -188,8 +188,9 @@ ListMLERanker::rank_fvv(const std::vector<FeatureVector> & fvv) const {
 	double listmle_score = 0;
 	std::vector<double> fvals = testfvv[i].get_fvals();
 	if (fvals.size() != parameters.size())
-	    throw LetorInternalError("Model incompatible. Make sure that you are using "
-				     "the same set of Features using which the model was created.");
+	    throw LetorInternalError("Model incompatible. Make sure that you "
+				     "are using the same set of Features using "
+				     "which the model was created.");
 	for (size_t j = 0; j < fvals.size(); ++j)
 	    listmle_score += fvals[j] * parameters[j];
 	testfvv[i].set_score(listmle_score);

--- a/xapian-letor/ranker/listmle_ranker.cc
+++ b/xapian-letor/ranker/listmle_ranker.cc
@@ -1,10 +1,10 @@
 /** @file listmle_ranker.cc
  *  @brief Implementation of ListMLERanker
- */
-
-/* ListMLE is adapted from the paper:
- * Fen Xia, Tie-Yan Liu, Jue Wang, Wensheng Zhang, Hang Li
- * et al. "Listwise Approach to Learning to Rank - Theory and Algorithm."
+ *
+ *  ListMLE is adapted from the paper:
+ *  Fen Xia, Tie-Yan Liu, Jue Wang, Wensheng Zhang, Hang Li
+ *  et al. "Listwise Approach to Learning to Rank - Theory and Algorithm."
+ *  http://icml2008.cs.helsinki.fi/papers/167.pdf
  */
 
 /* Copyright (C) 2014 Hanxiao Sun
@@ -72,7 +72,6 @@ static vector<double>
 calculate_gradient(const vector<FeatureVector>& sorted_feature_vectors,
 		   const vector<double>& new_parameters)
 {
-    // Need to be optimized,how to get the length of the features
     vector<double> gradient(sorted_feature_vectors[0].get_fcount(), 0);
 
     size_t list_length = sorted_feature_vectors.size();
@@ -175,11 +174,8 @@ ListMLERanker::load_model_from_metadata(const string& model_key)
 	key = "ListMLE.model.default";
     }
     string model_data = letor_db.get_metadata(key);
-    // Throw exception if no model data associated with key
     if (model_data.empty()) {
-	throw InvalidArgumentError("No model found. Either model has not been "
-				   "stored as db metadata or wrong model_key "
-				   "has been provided.");
+	throw InvalidArgumentError("No model found. Check key.");
     }
     vector<double> loaded_parameters;
     const char *ptr = model_data.data();

--- a/xapian-letor/ranker/listmle_ranker.cc
+++ b/xapian-letor/ranker/listmle_ranker.cc
@@ -34,9 +34,6 @@
 #include "serialise-double.h"
 
 #include <xapian.h>
-#include <xapian/intrusive_ptr.h>
-#include <xapian/types.h>
-#include <xapian/visibility.h>
 
 #include <algorithm>
 #include <cmath>

--- a/xapian-letor/ranker/listmle_ranker.cc
+++ b/xapian-letor/ranker/listmle_ranker.cc
@@ -181,8 +181,8 @@ ListMLERanker::load_model_from_metadata(const string & model_key) {
 }
 
 std::vector<FeatureVector>
-ListNETRanker::rank_fvv(const std::vector<FeatureVector> & fvv) const {
-    LOGCALL(API, std::vector<FeatureVector>, "ListNETRanker::rank_fvv", fvv);
+ListMLERanker::rank_fvv(const std::vector<FeatureVector> & fvv) const {
+    LOGCALL(API, std::vector<FeatureVector>, "ListMLERanker::rank_fvv", fvv);
     std::vector<FeatureVector> testfvv = fvv;
     for (size_t i = 0; i < testfvv.size(); ++i) {
 	double listnet_score = 0;

--- a/xapian-letor/ranker/listmle_ranker.cc
+++ b/xapian-letor/ranker/listmle_ranker.cc
@@ -67,40 +67,6 @@ calculateInnerProduct(vector<double> & parameters,
     return inner_product;
 }
 
-/*
-loss function: negative log Likelihood
-the equation (9) in the paper
-
-static double
-negativeLogLikelihood(vector<FeatureVector> sorted_feature_vectors,
-		      vector<double> new_parameters) {
-
-    size_t list_length = sorted_feature_vectors.size();
-    //top 1 probability
-    double first_place_in_ground_truth;
-    double expsum = 0.0;
-    if (list_length != 0) {
-	//Also use top 1 probability, so we need the first one in the ground
-	//truth.
-	//Should be put into init?
-	first_place_in_ground_truth =
-		exp(calculateInnerProduct(new_parameters,
-					  sorted_feature_vectors[0].get_fvals()
-					  ));
-    }
-    else{
-	printf("the feature_vectors is null in ListMLERanker:logLikelihood\n");
-	exit(1);
-    }
-
-    for (size_t i = 0; i < list_length; ++i) {
-	expsum += exp(calculateInnerProduct(new_parameters,
-		      sorted_feature_vectors[i].get_fvals()));
-    }
-    return log(expsum) - log(first_place_in_ground_truth);
-}
-*/
-
 static vector<double>
 calculateGradient(vector<FeatureVector> & sorted_feature_vectors,
 		  vector<double> & new_parameters) {

--- a/xapian-letor/tests/.gitignore
+++ b/xapian-letor/tests/.gitignore
@@ -23,7 +23,7 @@
 /perflog.xml
 /submitperftest
 /zlib-vg.so
-/.listmle_ranker_training.txt
+/listmle_ranker_training.txt
 /listnet_ranker_training.txt
 /scorer_output.txt
 /svm_ranker_training.txt

--- a/xapian-letor/tests/.gitignore
+++ b/xapian-letor/tests/.gitignore
@@ -23,7 +23,7 @@
 /perflog.xml
 /submitperftest
 /zlib-vg.so
-/listmle_ranker_training.txt
+/.listmle_ranker_training.txt
 /listnet_ranker_training.txt
 /scorer_output.txt
 /svm_ranker_training.txt

--- a/xapian-letor/tests/.gitignore
+++ b/xapian-letor/tests/.gitignore
@@ -23,6 +23,7 @@
 /perflog.xml
 /submitperftest
 /zlib-vg.so
+/listmle_ranker_training.txt
 /listnet_ranker_training.txt
 /scorer_output.txt
 /svm_ranker_training.txt

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -194,7 +194,7 @@ DEFINE_TESTCASE(listmle_ranker, generated)
     string data_directory = test_driver::get_srcdir() + "/testdata/";
     string query = data_directory + "query.txt";
     string qrel = data_directory + "qrel.txt";
-    string training = test_driver::get_srcdir() +
+    string training = test_driver::get_srcdir() + "/" +
 	    "listmle_ranker_training.txt";
     Xapian::prepare_training_file(db_path, query, qrel, 10, training);
     ranker.set_database_path(db_path);

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -182,6 +182,48 @@ DEFINE_TESTCASE(svm_ranker, generated)
     return true;
 }
 
+DEFINE_TESTCASE(listmle_ranker, generated)
+{
+    Xapian::ListMLERanker ranker;
+    TEST_EXCEPTION(Xapian::FileNotFoundError, ranker.train_model(""));
+    string db_path = get_database_path("apitest_listmle_ranker",
+				       db_index_two_documents);
+    Xapian::Enquire enquire((Xapian::Database(db_path)));
+    enquire.set_query(Xapian::Query("lions"));
+    Xapian::MSet mymset = enquire.get_mset(0, 10);
+    string data_directory = test_driver::get_srcdir() + "/testdata/";
+    string query = data_directory + "query.txt";
+    string qrel = data_directory + "qrel.txt";
+    Xapian::prepare_training_file(db_path, query, qrel, 10,
+				  "listmle_ranker_training.txt");
+    ranker.set_database_path(db_path);
+    TEST_EQUAL(ranker.get_database_path(), db_path);
+    ranker.set_query(Xapian::Query("lions"));
+    ranker.train_model("listmle_ranker_training.txt");
+    Xapian::docid doc1 = *mymset[0];
+    Xapian::docid doc2 = *mymset[1];
+    ranker.rank(mymset);
+    TEST_EQUAL(doc2, *mymset[0]);
+    TEST_EQUAL(doc1, *mymset[1]);
+    mymset = enquire.get_mset(0, 10);
+    ranker.train_model("listmle_ranker_training.txt", "ListMLE_Ranker");
+    ranker.rank(mymset, "ListMLE_Ranker");
+    TEST_EQUAL(doc2, *mymset[0]);
+    TEST_EQUAL(doc1, *mymset[1]);
+    TEST_EXCEPTION(Xapian::LetorInternalError,
+		   ranker.score(query, qrel, "ListMLE_Ranker",
+				"scorer_output.txt", 10, ""));
+    TEST_EXCEPTION(Xapian::FileNotFoundError,
+		   ranker.score("", qrel, "ListMLE_Ranker",
+				"scorer_output.txt", 10));
+    TEST_EXCEPTION(Xapian::FileNotFoundError,
+		   ranker.score(qrel, "", "ListMLE_Ranker",
+				"scorer_output.txt", 10));
+    ranker.score(query, qrel, "ListMLE_Ranker", "scorer_output.txt", 10);
+
+    return true;
+}
+
 DEFINE_TESTCASE(featurename, !backend)
 {
     Xapian::TfDoclenCollTfCollLenFeature feature1;

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -194,8 +194,7 @@ DEFINE_TESTCASE(listmle_ranker, generated)
     string data_directory = test_driver::get_srcdir() + "/testdata/";
     string query = data_directory + "query.txt";
     string qrel = data_directory + "qrel.txt";
-    string training = test_driver::get_srcdir() + "/" +
-	    "listmle_ranker_training.txt";
+    string training = "listmle_ranker_training.txt";
     Xapian::prepare_training_file(db_path, query, qrel, 10, training);
     ranker.set_database_path(db_path);
     TEST_EQUAL(ranker.get_database_path(), db_path);

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -194,8 +194,8 @@ DEFINE_TESTCASE(listmle_ranker, generated)
     string data_directory = test_driver::get_srcdir() + "/testdata/";
     string query = data_directory + "query.txt";
     string qrel = data_directory + "qrel.txt";
-    string training = test_driver::get_srcdir()
-	    + "listmle_ranker_training.txt";
+    string training = test_driver::get_srcdir() +
+	    "listmle_ranker_training.txt";
     Xapian::prepare_training_file(db_path, query, qrel, 10, training);
     ranker.set_database_path(db_path);
     TEST_EQUAL(ranker.get_database_path(), db_path);

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -194,19 +194,20 @@ DEFINE_TESTCASE(listmle_ranker, generated)
     string data_directory = test_driver::get_srcdir() + "/testdata/";
     string query = data_directory + "query.txt";
     string qrel = data_directory + "qrel.txt";
-    Xapian::prepare_training_file(db_path, query, qrel, 10,
-				  "listmle_ranker_training.txt");
+    string training = test_driver::get_srcdir()
+	    + "listmle_ranker_training.txt";
+    Xapian::prepare_training_file(db_path, query, qrel, 10, training);
     ranker.set_database_path(db_path);
     TEST_EQUAL(ranker.get_database_path(), db_path);
     ranker.set_query(Xapian::Query("lions"));
-    ranker.train_model("listmle_ranker_training.txt");
+    ranker.train_model(training);
     Xapian::docid doc1 = *mymset[0];
     Xapian::docid doc2 = *mymset[1];
     ranker.rank(mymset);
     TEST_EQUAL(doc2, *mymset[0]);
     TEST_EQUAL(doc1, *mymset[1]);
     mymset = enquire.get_mset(0, 10);
-    ranker.train_model("listmle_ranker_training.txt", "ListMLE_Ranker");
+    ranker.train_model(training, "ListMLE_Ranker");
     ranker.rank(mymset, "ListMLE_Ranker");
     TEST_EQUAL(doc2, *mymset[0]);
     TEST_EQUAL(doc1, *mymset[1]);


### PR DESCRIPTION
Added listmle_ranker.cc along with a test for listmle_ranker to letor.

Have added listmle_ranker.cc from vhasu's 2014 GSoC repository ->
https://github.com/v-hasu/xapian/tree/gsoc2014/xapian-letor
 after making suitable changes to account for the elimination of
Xapian::Ranklist and changes made to Xapian::FeatureVector. Have also
added a standard test to test all the features of ListMLERanker.