### PR TITLE
Add ERR Scorer to xapian-letor

### DIFF
--- a/xapian-letor/include/xapian-letor/scorer.h
+++ b/xapian-letor/include/xapian-letor/scorer.h
@@ -65,22 +65,41 @@ class XAPIAN_VISIBILITY_DEFAULT NDCGScore: public Scorer {
     ~NDCGScore();
 
     double score(const std::vector<FeatureVector> & fvv) const;
+
 };
 
-/** ERRScore class
- *  ERR Score is adapted from the paper: goo.gl/Cs3ydQ
+/** Expected Reciprocal Rank(ERR) Scorer.
+ *  ERR Scorer is adapted from the paper:
+ *  http://olivier.chapelle.cc/pub/err.pdf
  *  Chapelle, Metzler, Zhang, Grinspan (2009)
  *  Expected Reciprocal Rank for Graded Relevance
  */
-class XAPIAN_VISIBILITY_DEFAULT ERRScore: public Scorer {
+class XAPIAN_VISIBILITY_DEFAULT ERRScore : public Scorer {
+    /* max_grade is the maximum grade that a label can be mapped to.
+     * The relevance label that user sets for the documents can be arbitary
+     * and huge. Computing the probability of relevance for the documents,
+     * which involves computing pow(2, label), can be time consuming.
+     * To reduce the time complexity the labels are mapped to a smaller space
+     * i.e. {0, 1, 2,...., max_grade}.
+     * By default max_grade is 4.
+     */
+    int max_grade = 4;
+
   public:
     /// Default constructor
     ERRScore();
+
+    /// Function to set max_grade
+    void set_max_grade(int max_grade_);
+
+    /// Function that returns the value set for max_grade.
+    int get_max_grade();
 
     /// Destructor
     ~ERRScore();
 
     double score(const std::vector<FeatureVector> & fvv) const;
+
 };
 
 }

--- a/xapian-letor/include/xapian-letor/scorer.h
+++ b/xapian-letor/include/xapian-letor/scorer.h
@@ -68,6 +68,19 @@ class XAPIAN_VISIBILITY_DEFAULT NDCGScore: public Scorer {
 
 };
 
+/// ERRScore class
+class XAPIAN_VISIBILITY_DEFAULT ERRScore: public Scorer {
+  public:
+    /// Default constructor
+    ERRScore();
+
+    /// Destructor
+    ~ERRScore();
+
+    double score(const std::vector<FeatureVector> & fvv) const;
+
+};
+
 }
 
 #endif /* SCORER_H */

--- a/xapian-letor/include/xapian-letor/scorer.h
+++ b/xapian-letor/include/xapian-letor/scorer.h
@@ -65,7 +65,6 @@ class XAPIAN_VISIBILITY_DEFAULT NDCGScore: public Scorer {
     ~NDCGScore();
 
     double score(const std::vector<FeatureVector> & fvv) const;
-
 };
 
 /** ERRScore class
@@ -82,7 +81,6 @@ class XAPIAN_VISIBILITY_DEFAULT ERRScore: public Scorer {
     ~ERRScore();
 
     double score(const std::vector<FeatureVector> & fvv) const;
-
 };
 
 }

--- a/xapian-letor/include/xapian-letor/scorer.h
+++ b/xapian-letor/include/xapian-letor/scorer.h
@@ -75,21 +75,9 @@ class XAPIAN_VISIBILITY_DEFAULT NDCGScore: public Scorer {
  *  Expected Reciprocal Rank for Graded Relevance
  */
 class XAPIAN_VISIBILITY_DEFAULT ERRScore : public Scorer {
-    /* max_grade is the maximum grade that a label can be mapped to.
-     * The relevance label that user sets for the documents can be arbitary
-     * and huge. Computing the probability of relevance for the documents,
-     * which involves computing pow(2, label), can be time consuming.
-     * To reduce the time complexity the labels are mapped to a smaller space
-     * i.e. {0, 1, 2,...., max_grade}.
-     */
-    int max_grade;
-
   public:
-    /** Construct an ERRScore.
-     *  @param max_grade_ max_grade value for the ERRScore.
-     *                    By default max_grade is set to 4.
-     */
-    explicit ERRScore(int max_grade_ = 4) : max_grade(max_grade_) { }
+    /// Default constructor
+    ERRScore();
 
     /// Destructor
     ~ERRScore();

--- a/xapian-letor/include/xapian-letor/scorer.h
+++ b/xapian-letor/include/xapian-letor/scorer.h
@@ -81,15 +81,15 @@ class XAPIAN_VISIBILITY_DEFAULT ERRScore : public Scorer {
      * which involves computing pow(2, label), can be time consuming.
      * To reduce the time complexity the labels are mapped to a smaller space
      * i.e. {0, 1, 2,...., max_grade}.
-     * By default max_grade is 4.
      */
-    int max_grade = 4;
+    int max_grade;
 
   public:
-    /// Default constructor
-    ERRScore();
-
-    ERRScore(int max_grade_);
+    /** Construct an ERRScore.
+     *  @param max_grade_ max_grade value for the ERRScore.
+     *                    By default max_grade is set to 4.
+     */
+    explicit ERRScore(int max_grade_ = 4) : max_grade(max_grade_) { }
 
     /// Destructor
     ~ERRScore();

--- a/xapian-letor/include/xapian-letor/scorer.h
+++ b/xapian-letor/include/xapian-letor/scorer.h
@@ -52,7 +52,6 @@ class XAPIAN_VISIBILITY_DEFAULT Scorer : public Xapian::Internal::intrusive_base
 
     /// Don't allow copying.
     Scorer(const Scorer & o);
-
 };
 
 /// NDCGScore class
@@ -65,7 +64,6 @@ class XAPIAN_VISIBILITY_DEFAULT NDCGScore: public Scorer {
     ~NDCGScore();
 
     double score(const std::vector<FeatureVector> & fvv) const;
-
 };
 
 /** Expected Reciprocal Rank(ERR) Scorer.
@@ -83,9 +81,7 @@ class XAPIAN_VISIBILITY_DEFAULT ERRScore : public Scorer {
     ~ERRScore();
 
     double score(const std::vector<FeatureVector> & fvv) const;
-
 };
-
 }
 
 #endif /* SCORER_H */

--- a/xapian-letor/include/xapian-letor/scorer.h
+++ b/xapian-letor/include/xapian-letor/scorer.h
@@ -68,7 +68,11 @@ class XAPIAN_VISIBILITY_DEFAULT NDCGScore: public Scorer {
 
 };
 
-/// ERRScore class
+/** ERRScore class
+ *  ERR Score is adapted from the paper: goo.gl/Cs3ydQ
+ *  Chapelle, Metzler, Zhang, Grinspan (2009)
+ *  Expected Reciprocal Rank for Graded Relevance
+ */
 class XAPIAN_VISIBILITY_DEFAULT ERRScore: public Scorer {
   public:
     /// Default constructor

--- a/xapian-letor/include/xapian-letor/scorer.h
+++ b/xapian-letor/include/xapian-letor/scorer.h
@@ -89,11 +89,7 @@ class XAPIAN_VISIBILITY_DEFAULT ERRScore : public Scorer {
     /// Default constructor
     ERRScore();
 
-    /// Function to set max_grade
-    void set_max_grade(int max_grade_);
-
-    /// Function that returns the value set for max_grade.
-    int get_max_grade();
+    ERRScore(int max_grade_);
 
     /// Destructor
     ~ERRScore();

--- a/xapian-letor/ranker/ranker.cc
+++ b/xapian-letor/ranker/ranker.cc
@@ -404,7 +404,7 @@ Ranker::score(const string & query_file, const string & qrel_file,
     Xapian::Internal::intrusive_ptr<Scorer> scorer;
     if (scorer_type == "NDCGScore") {
 	scorer = new NDCGScore();
-    } else if(scorer_type == "ERRScore") {
+    } else if (scorer_type == "ERRScore") {
 	scorer = new ERRScore();
     } else {
 	throw LetorInternalError("Invalid Scorer type.");

--- a/xapian-letor/ranker/ranker.cc
+++ b/xapian-letor/ranker/ranker.cc
@@ -404,6 +404,8 @@ Ranker::score(const string & query_file, const string & qrel_file,
     Xapian::Internal::intrusive_ptr<Scorer> scorer;
     if (scorer_type == "NDCGScore") {
 	scorer = new NDCGScore();
+    } else if(scorer_type == "ERRScore") {
+	scorer = new ERRScore();
     } else {
 	throw LetorInternalError("Invalid Scorer type.");
     }

--- a/xapian-letor/scorer/Makefile.mk
+++ b/xapian-letor/scorer/Makefile.mk
@@ -2,4 +2,5 @@ EXTRA_DIST +=\
     scorer/Makefile
 
 lib_src +=\
+    scorer/err_score.cc\
     scorer/ndcg_score.cc

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -45,12 +45,6 @@ ERRScore::~ERRScore()
     LOGCALL_DTOR(API, "ERRScore");
 }
 
-static bool
-comp(FeatureVector i, FeatureVector j)
-{
-    return i.get_label() < j.get_label();
-}
-
 double
 ERRScore::score(const std::vector<FeatureVector> & fvv) const
 {
@@ -59,7 +53,12 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
 	return 0;
     }
     size_t length = fvv.size();
-    FeatureVector max_label = *std::max_element(fvv.begin(), fvv.end(), comp);
+    FeatureVector max_label = *max_element(fvv.begin(), fvv.end(),
+					   [](FeatureVector x,
+					   FeatureVector y) {
+					       return x.get_label() <
+						      y.get_label();
+					   });
     double max_value = exp2(max_label.get_label());
 
     // Accumulated probability, which is updated for each document.
@@ -72,9 +71,9 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
 	 * http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.74.9057&rep=rep1&type=pdf
 	 */
 	double relevance_probability = (exp2(fvv[rank - 1].get_label()) -
-					 1) / max_value;
+		1) / max_value;
 
-       /* err_score = summation over all the documents
+	/* err_score = summation over all the documents
 	* ((satisfaction probability * p) / rank).
 	* Expected Reciprocal Rank(err_score) is calculated in accordance with
 	* algorithm 2 in the paper http://olivier.chapelle.cc/pub/err.pdf

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -70,7 +70,7 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
     // Accumulated probability, which is updated for each document.
     double p = 1;
     double err_score = 0;
-    int max_value = exp2((int)max_label);
+    int max_value = exp2(max_label);
     for (int rank = 1; rank <= length; ++rank) {
 
 	/* Compute the probability of relevance for the document.

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -1,5 +1,9 @@
 /** @file err_score.cc
  *  @brief Implementation of ERRScore
+ *
+ *  ERR Score is adapted from the paper: goo.gl/Cs3ydQ
+ *  Chapelle, Metzler, Zhang, Grinspan (2009)
+ *  Expected Reciprocal Rank for Graded Relevance
  */
 /* Copyright (C) 2014 Hanxiao Sun
  *
@@ -41,24 +45,6 @@ ERRScore::~ERRScore()
     LOGCALL_DTOR(API, "ERRScore");
 }
 
-static vector<double>
-get_labels(vector<Xapian::FeatureVector> fvv)
-{
-    LOGCALL_STATIC(API, vector<double>, "get_labels", fvv);
-    size_t fvvsize = fvv.size();
-    vector<double> labels;
-
-    for (size_t i = 0; i < fvvsize; ++i) {
-	labels.push_back(fvv[i].get_label());
-    }
-
-    return labels;
-}
-
-/* test the err_Score() use the data from goo.gl/LxEmPZ
- * input:[3,2,4]
- * output:0.63
- */
 double
 ERRScore::score(const std::vector<FeatureVector> & fvv) const
 {
@@ -67,7 +53,19 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
     // hard code for the a five-point scale, the 16 means 2^(5-1)
     int MAX_LABEL = 16;
 
-    std::vector<double> labels = get_labels(fvv);
+    std::vector<double> labels;
+    double max_label = fvv[0].get_label();
+
+    for (size_t i = 0; i < fvv.size(); ++i) {
+	double label = fvv[i].get_label();
+	labels.push_back(fvv[i].get_label());
+	max_label = max(max_label, label);
+    }
+
+    for (size_t i = 0; i < fvv.size(); ++i) {
+	labels[i] = round((labels[i] * 4) / max_label);
+    }
+
     int length = labels.size();
 
     // compute the satisfaction probability for lable of each doc in the ranking

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -46,7 +46,7 @@ ERRScore::~ERRScore()
 }
 
 static bool
-comp (FeatureVector i, FeatureVector j)
+comp(FeatureVector i, FeatureVector j)
 {
     return i.get_label() < j.get_label();
 }

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -55,10 +55,10 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
     size_t length = fvv.size();
     FeatureVector max_label = *max_element(fvv.begin(), fvv.end(),
 					   [](FeatureVector x,
-					   FeatureVector y) {
-					       return x.get_label() <
-						      y.get_label();
-					   });
+					      FeatureVector y) {
+						  return x.get_label() <
+							 y.get_label();
+					      });
     double max_value = exp2(max_label.get_label());
 
     // Accumulated probability, which is updated for each document.
@@ -70,8 +70,8 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
 	 * function for the Discounted Cumulative Gain in the paper:
 	 * http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.74.9057&rep=rep1&type=pdf
 	 */
-	double relevance_probability = (exp2(fvv[rank - 1].get_label()) -
-		1) / max_value;
+	auto label = fvv[rank - 1].get_label();
+	double relevance_probability = (exp2(label) - 1) / max_value;
 
 	/* err_score = summation over all the documents
 	* ((satisfaction probability * p) / rank).

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -45,6 +45,12 @@ ERRScore::~ERRScore()
     LOGCALL_DTOR(API, "ERRScore");
 }
 
+static bool
+comp (FeatureVector i, FeatureVector j)
+{
+    return i.get_label() < j.get_label();
+}
+
 double
 ERRScore::score(const std::vector<FeatureVector> & fvv) const
 {
@@ -53,18 +59,12 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
 	return 0;
     }
     size_t length = fvv.size();
-    double max_label = fvv[0].get_label();
-
-    // store the labels set	by the user in intermediate_values.
-    for (size_t i = 0; i < length; ++i) {
-	double label = fvv[i].get_label();
-	max_label = max(max_label, label);
-    }
+    FeatureVector max_label = *std::max_element(fvv.begin(), fvv.end(), comp);
+    double max_value = exp2(max_label.get_label());
 
     // Accumulated probability, which is updated for each document.
     double p = 1;
     double err_score = 0;
-    double max_value = exp2(max_label);
     for (size_t rank = 1; rank <= length; ++rank) {
 	/* Compute the probability of relevance for the document.
 	 * Probability of relevance is calculated in accordance with the gain

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -67,18 +67,10 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
 	max_label = max(max_label, label);
     }
 
-    /* All the powers of 2 from 0 to max_grade as calculated and stored to
-     * optimize the calculation of satisfaction probability.
-     */
-    double powers_of_two[(int)max_label + 1];
-    powers_of_two[0] = 1;
-    for (int i = 1; i <= max_label; ++i) {
-	powers_of_two[i] = 2 * powers_of_two[i - 1];
-    }
-
     // Accumulated probability, which is updated for each document.
     double p = 1;
     double err_score = 0;
+    int max_value = exp2((int)max_label);
     for (int rank = 1; rank <= length; ++rank) {
 
 	/* Compute the probability of relevance for the document.
@@ -86,9 +78,8 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
 	 * function for the Discounted Cumulative Gain in the paper:
 	 * http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.74.9057&rep=rep1&type=pdf
 	 */
-	intermediate_values[rank - 1] = (powers_of_two[
-					 (int)intermediate_values[rank - 1]] -
-					 1) / powers_of_two[(int)max_label];
+	intermediate_values[rank - 1] = (exp2(intermediate_values[rank - 1]) -
+					 1) / max_value;
 
        /* err_score = summation over all the documents
 	* ((satisfaction probability * p) / rank).

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -45,10 +45,9 @@ ERRScore::~ERRScore()
     LOGCALL_DTOR(API, "ERRScore");
 }
 
-void
-ERRScore::set_max_grade(int max_grade_)
+ERRScore::ERRScore(int max_grade_)
 {
-    LOGCALL_VOID(API, "ERRScore::set_max_grade", max_grade_);
+    LOGCALL_CTOR(API, "ERRScore", max_grade_);
     max_grade = max_grade_;
 }
 

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -50,35 +50,28 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
 {
     LOGCALL(API, double, "ERRScore::score", fvv);
     if (fvv.empty()) {
-	throw Xapian::InvalidArgumentError("Empty argument supplied");
+	return 0;
     }
-    int length = fvv.size();
-
-    /* used to store values which change from labels to
-     * satisfaction probability
-     */
-    double intermediate_values[length];
+    size_t length = fvv.size();
     double max_label = fvv[0].get_label();
 
     // store the labels set	by the user in intermediate_values.
-    for (int i = 0; i < length; ++i) {
+    for (size_t i = 0; i < length; ++i) {
 	double label = fvv[i].get_label();
-	intermediate_values[i] = label;
 	max_label = max(max_label, label);
     }
 
     // Accumulated probability, which is updated for each document.
     double p = 1;
     double err_score = 0;
-    int max_value = exp2(max_label);
-    for (int rank = 1; rank <= length; ++rank) {
-
+    double max_value = exp2(max_label);
+    for (size_t rank = 1; rank <= length; ++rank) {
 	/* Compute the probability of relevance for the document.
 	 * Probability of relevance is calculated in accordance with the gain
 	 * function for the Discounted Cumulative Gain in the paper:
 	 * http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.74.9057&rep=rep1&type=pdf
 	 */
-	intermediate_values[rank - 1] = (exp2(intermediate_values[rank - 1]) -
+	double relevance_probability = (exp2(fvv[rank - 1].get_label()) -
 					 1) / max_value;
 
        /* err_score = summation over all the documents
@@ -88,8 +81,8 @@ ERRScore::score(const std::vector<FeatureVector> & fvv) const
 	* The paper assumes discrete relevances but continous relevances can
 	* be scored using this scorer.
 	*/
-	err_score = err_score + (p * intermediate_values[rank - 1] / rank);
-	p = p * (1 - intermediate_values[rank - 1]);
+	err_score = err_score + (p * relevance_probability / rank);
+	p = p * (1 - relevance_probability);
     }
 
     return err_score;

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -1,0 +1,94 @@
+/** @file err_score.cc
+ *  @brief Implementation of ERRScore
+ */
+/* Copyright (C) 2014 Hanxiao Sun
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+#include <config.h>
+
+#include "xapian-letor/scorer.h"
+
+#include "debuglog.h"
+
+#include <algorithm>
+
+using namespace std;
+
+using namespace Xapian;
+
+ERRScore::ERRScore()
+{
+    LOGCALL_CTOR(API, "ERRScore", NO_ARGS);
+}
+
+ERRScore::~ERRScore()
+{
+    LOGCALL_DTOR(API, "ERRScore");
+}
+
+static vector<double>
+get_labels(vector<Xapian::FeatureVector> fvv)
+{
+    LOGCALL_STATIC(API, vector<double>, "get_labels", fvv);
+    size_t fvvsize = fvv.size();
+    vector<double> labels;
+
+    for (size_t i = 0; i < fvvsize; ++i) {
+	labels.push_back(fvv[i].get_label());
+    }
+
+    return labels;
+}
+
+/* test the err_Score() use the data from goo.gl/LxEmPZ
+ * input:[3,2,4]
+ * output:0.63
+ */
+double
+ERRScore::score(const std::vector<FeatureVector> & fvv) const
+{
+    LOGCALL(API, double, "ERRScore::score", fvv);
+
+    // hard code for the a five-point scale, the 16 means 2^(5-1)
+    int MAX_LABEL = 16;
+
+    std::vector<double> labels = get_labels(fvv);
+    int length = labels.size();
+
+    // compute the satisfaction probability for lable of each doc in the ranking
+    for (int i = 0; i < length; ++i) {
+	labels[i] = (pow(2, labels[i]) - 1) / MAX_LABEL;
+    }
+
+    double err_score = labels[0];
+
+    // compute the accumulated probability for each doc which user will stop at
+    for (int i = 1; i < length; ++i) {
+
+	// single stop probability
+	double temp_err = (1.0 / (i + 1.0)) * labels[i];
+
+	// for users
+	for (int j = i - 1; j >= 0; --j) {
+	    temp_err *= (1 - labels[j]);
+	}
+	err_score += temp_err;
+    }
+
+    return err_score;
+}

--- a/xapian-letor/scorer/err_score.cc
+++ b/xapian-letor/scorer/err_score.cc
@@ -35,20 +35,9 @@ using namespace std;
 
 using namespace Xapian;
 
-ERRScore::ERRScore()
-{
-    LOGCALL_CTOR(API, "ERRScore", NO_ARGS);
-}
-
 ERRScore::~ERRScore()
 {
     LOGCALL_DTOR(API, "ERRScore");
-}
-
-ERRScore::ERRScore(int max_grade_)
-{
-    LOGCALL_CTOR(API, "ERRScore", max_grade_);
-    max_grade = max_grade_;
 }
 
 double

--- a/xapian-letor/tests/.gitignore
+++ b/xapian-letor/tests/.gitignore
@@ -23,8 +23,9 @@
 /perflog.xml
 /submitperftest
 /zlib-vg.so
+/err_output.txt
 /listmle_ranker_training.txt
 /listnet_ranker_training.txt
-/scorer_output.txt
+/ndcg_output.txt
 /svm_ranker_training.txt
 /training_output.txt

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -289,7 +289,9 @@ DEFINE_TESTCASE(featurename, !backend)
 
 DEFINE_TESTCASE(err_scorer, !backend)
 {
-    // demonstrating the example mentioned in the blogpost goo.gl/Cs3ydQ
+    /* Derived from the example mentioned in the blogpost
+     * https://lingpipe-blog.com/2010/03/09/chapelle-metzler-zhang-grinspan-2009-expected-reciprocal-rank-for-graded-relevance/
+     */
     vector<Xapian::FeatureVector> fvv;
     Xapian::FeatureVector temp1;
     Xapian::FeatureVector temp2;

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -289,7 +289,7 @@ DEFINE_TESTCASE(featurename, !backend)
 
 DEFINE_TESTCASE(err_scorer, !backend)
 {
-    // demonstrating the example mentioned in the paper goo.gl/Cs3ydQ
+    // demonstrating the example mentioned in the blogpost goo.gl/Cs3ydQ
     vector<Xapian::FeatureVector> fvv;
     Xapian::FeatureVector temp1;
     Xapian::FeatureVector temp2;

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -179,7 +179,8 @@ DEFINE_TESTCASE(listnet_ranker, generated)
     TEST_EXCEPTION(Xapian::FileNotFoundError,
 		   ranker.score(qrel, "", "ListNet_Ranker",
 				"scorer_output.txt", 10));
-    ranker.score(query, qrel, "ListNet_Ranker", "scorer_output.txt", 10);
+    ranker.score(query, qrel, "ListNet_Ranker", "ndcg_output.txt", 10);
+    ranker.score(query, qrel, "ListNet_Ranker", "err_output.txt", 10, "ERRScore");
 
     return true;
 }
@@ -220,7 +221,8 @@ DEFINE_TESTCASE(svm_ranker, generated)
     TEST_EXCEPTION(Xapian::FileNotFoundError,
 		   ranker.score(qrel, "", "SVM_Ranker",
 				"scorer_output.txt", 10));
-    ranker.score(query, qrel, "SVM_Ranker", "scorer_output.txt", 10);
+    ranker.score(query, qrel, "SVM_Ranker", "ndcg_output.txt", 10);
+    ranker.score(query, qrel, "SVM_Ranker", "err_output.txt", 10, "ERRScore");
 
     return true;
 }
@@ -261,7 +263,8 @@ DEFINE_TESTCASE(listmle_ranker, generated)
     TEST_EXCEPTION(Xapian::FileNotFoundError,
 		   ranker.score(qrel, "", "ListMLE_Ranker",
 				"scorer_output.txt", 10));
-    ranker.score(query, qrel, "ListMLE_Ranker", "scorer_output.txt", 10);
+    ranker.score(query, qrel, "ListMLE_Ranker", "ndcg_output.txt", 10);
+    ranker.score(query, qrel, "ListMLE_Ranker", "err_output.txt", 10, "ERRScore");
 
     return true;
 }

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -286,3 +286,24 @@ DEFINE_TESTCASE(featurename, !backend)
 
     return true;
 }
+
+DEFINE_TESTCASE(err_scorer, !backend)
+{
+    // demonstrating the example mentioned in the paper goo.gl/Cs3ydQ
+    vector<Xapian::FeatureVector> fvv;
+    Xapian::FeatureVector temp1;
+    Xapian::FeatureVector temp2;
+    Xapian::FeatureVector temp3;
+    temp1.set_label(3);
+    fvv.push_back(temp1);
+    temp2.set_label(2);
+    fvv.push_back(temp2);
+    temp3.set_label(4);
+    fvv.push_back(temp3);
+    Xapian::ERRScore err;
+    double err_score = err.score(fvv);
+
+    TEST(abs(err_score - 0.63) < 0.01);
+
+    return true;
+}


### PR DESCRIPTION
Have integrated the ERR Scorer from [vhasu's 2014 repository](https://github.com/v-hasu/xapian/tree/gsoc2014/xapian-letor). It meets
xapian coding standards. The changes made to xapian-letor have been
accomodated while integrating this scorer. Tests have also been added
for the scorer.