### PR TITLE
No argument takes next action as input When command has = sign and doesn't have next command it's takes next action as input

### DIFF
--- a/xapian-applications/omega/omegatest
+++ b/xapian-applications/omega/omegatest
@@ -479,7 +479,7 @@ else
     failed=`expr $failed + 1`
 fi
 
-rm "$OMEGA_CONFIG_FILE" "$TEST_INDEXSCRIPT" "$TEST_TEMPLATE"
+rm "$OMEGA_CONFIG_FILE" "$TEST_INDEXSCRIPT" "$TEST_TEMPLATE" "$TEST_INPUT"
 rm -rf "$TEST_DB"
 if [ "$failed" = 0 ] ; then
     exit 0

--- a/xapian-applications/omega/omegatest
+++ b/xapian-applications/omega/omegatest
@@ -37,6 +37,8 @@ printf '$querydescription' > "$TEST_TEMPLATE"
 
 TEST_INDEXSCRIPT=test-indexscript
 
+TEST_INPUT=test-inut
+
 OMEGA_CONFIG_FILE=test-omega.conf
 export OMEGA_CONFIG_FILE
 cat > "$OMEGA_CONFIG_FILE" <<__END__
@@ -464,6 +466,15 @@ else
     echo "scriptindex didn't reject 'hash' with a non-integer argument"
     failed=`expr $failed + 1`
 fi
+
+# Test we check for hash's argument being an integer (new in 1.4.6).
+printf 'url : field= unhtml' > "$TEST_INDEXSCRIPT"
+printf 'url=xapian.org' > "$TEST_INPUT"
+rm -rf "$TEST_DB"
+$SCRIPTINDEX "$TEST_DB" "$TEST_INDEXSCRIPT" < $TEST_INPUT > /dev/null
+
+printf '$field{unhtml,1}' > "$TEST_TEMPLATE"
+testcase '' text="test"
 
 rm "$OMEGA_CONFIG_FILE" "$TEST_INDEXSCRIPT" "$TEST_TEMPLATE"
 rm -rf "$TEST_DB"

--- a/xapian-applications/omega/omegatest
+++ b/xapian-applications/omega/omegatest
@@ -471,10 +471,13 @@ fi
 printf 'url : field= unhtml' > "$TEST_INDEXSCRIPT"
 printf 'url=xapian.org' > "$TEST_INPUT"
 rm -rf "$TEST_DB"
-$SCRIPTINDEX "$TEST_DB" "$TEST_INDEXSCRIPT" < $TEST_INPUT > /dev/null
-
-printf '$field{unhtml,1}' > "$TEST_TEMPLATE"
-testcase '' text="test"
+if $SCRIPTINDEX "$TEST_DB" "$TEST_INDEXSCRIPT" < $TEST_INPUT \
+    | grep -q "Index action 'field' takes next action as argument" ; then
+    : # OK
+else
+    echo "scriptindex didn't warn about 'field' takes next action as argument"
+    failed=`expr $failed + 1`
+fi
 
 rm "$OMEGA_CONFIG_FILE" "$TEST_INDEXSCRIPT" "$TEST_TEMPLATE"
 rm -rf "$TEST_DB"

--- a/xapian-applications/omega/scriptindex.cc
+++ b/xapian-applications/omega/scriptindex.cc
@@ -96,7 +96,7 @@ prefix_needs_colon(const string & prefix, unsigned ch)
 const char * action_names[] = {
     "bad", "new",
     "boolean", "date", "field", "hash", "index", "indexnopos", "load", "lower",
-    "spell", "truncate", "unhtml", "unique", "value", "valuenumeric", "weight"
+    "spell", "truncate", "unhtml", "unique", "value", "valuenumeric", "weight", '\0'
 };
 
 // For debugging:
@@ -302,6 +302,15 @@ parse_index_script(const string &filename)
 			     << ": Warning: Index action '" << action
 			     << "' takes an integer argument" << endl;
 		    }
+		}
+		int iter = 0;
+		while (action_names[iter] != '\0') {
+		    if (val == (action_names[iter])) {
+			cout << filename << ':' << line_no
+			     << ": Warning: Index action '" << action
+			     << "' takes next action as argument" << endl;
+		    }
+		    iter++;
 		}
 		switch (code) {
 		    case Action::INDEX:


### PR DESCRIPTION
Currently if someone writes something like this

```
md5: boolean= unhtml boolean=XAFTERTRUNCATE
```

DB will contain :

```
Term List for record #2:
XAFTERTRUNCATE:E752DEB0C8E42A7D73CCA0C7818C2F23
unhtml:E752DEB0C8E42A7D73CCA0C7818C2F23
```

which seems wrong. Complete Example:

```
~$xapian-delve -r 2 fjd
Term List for record #2:
XAFTERUNHTML:E752DEB0C8E42A7D73CCA0C7818C2F23
unhtml:E752DEB0C8E42A7D73CCA0C7818C2F23
~$ cat extractmd5.script
md5: boolean= unhtml boolean=XAFTERUNHTML
```