### PR TITLE
Remove needless zeroing of calloc-allocated memory

### DIFF
--- a/xapian-core/queryparser/lemon.c
+++ b/xapian-core/queryparser/lemon.c
@@ -593,7 +593,6 @@ acttab *acttab_alloc(void){
     fprintf(stderr,"Unable to allocate memory for a new acttab.");
     exit(1);
   }
-  memset(p, 0, sizeof(*p));
   return p;
 }
 
@@ -2287,7 +2286,6 @@ static void parseonetoken(struct pstate *psp)
           struct symbol *origsp = msp;
           msp = (struct symbol *) calloc(1,sizeof(*msp));
           MemoryCheck(msp);
-          memset(msp, 0, sizeof(*msp));
           msp->type = MULTITERMINAL;
           msp->nsubsym = 1;
           msp->subsym = (struct symbol **) calloc(1,sizeof(struct symbol*));


### PR DESCRIPTION
There were some less obvious instances, but I erred on the side of caution so that I wouldn't break anything.

Thanks for your time,
Michael McConville
University of Utah