### PR TITLE
Custom size range

### DIFF
--- a/xapian-bindings/csharp/Makefile.am
+++ b/xapian-bindings/csharp/Makefile.am
@@ -70,6 +70,7 @@ XAPIAN_SWIG_CS_SRCS=\
 	generated-csharp/TermIterator.cs \
 	generated-csharp/TfIdfWeight.cs \
 	generated-csharp/TradWeight.cs \
+	generated-csharp/UnitRangeProcessor.cs \
 	generated-csharp/ValueCountMatchSpy.cs \
 	generated-csharp/ValueIterator.cs \
 	generated-csharp/ValueMapPostingSource.cs \

--- a/xapian-bindings/java/Makefile.am
+++ b/xapian-bindings/java/Makefile.am
@@ -92,6 +92,7 @@ XAPIAN_SWIG_JAVA_SRCS=\
 	org/xapian/TermIterator.java\
 	org/xapian/TfIdfWeight.java\
 	org/xapian/TradWeight.java\
+	org/xapian/UnitRangeProcessor.java\
 	org/xapian/ValueCountMatchSpy.java\
 	org/xapian/ValueIterator.java\
 	org/xapian/ValueMapPostingSource.java\

--- a/xapian-core/api/valuerangeproc.cc
+++ b/xapian-core/api/valuerangeproc.cc
@@ -471,13 +471,12 @@ UnitRangeProcessor::operator()(const string& b, const string& e)
 	    // Not a valid byte unit
 	    goto not_our_range;
 	}
-	string b_ = string(b, 0, b.size() - 1);
 
 	errno = 0;
-	const char * startptr = b_.c_str();
+	const char * startptr = b.c_str();
 	char * endptr;
 	num_b = strtod(startptr, &endptr);
-	if (endptr != startptr + b_.size() || errno) {
+	if (endptr != startptr + b.size() - 1 || errno) {
 	    // Invalid characters in string || overflow or underflow.
 	    goto not_our_range;
 	}
@@ -493,13 +492,12 @@ UnitRangeProcessor::operator()(const string& b, const string& e)
     	    // Not a valid byte unit
 	    goto not_our_range;
 	}
-	string e_ = string(e, 0, e.size() - 1);
 
 	errno = 0;
-	const char * startptr = e_.c_str();
+	const char * startptr = e.c_str();
 	char * endptr;
 	num_e = strtod(startptr, &endptr);
-	if (endptr != startptr + e_.size() || errno) {
+	if (endptr != startptr + e.size() - 1 || errno) {
 	    // Invalid characters in string || overflow or underflow.
 	    goto not_our_range;
 	}

--- a/xapian-core/api/valuerangeproc.cc
+++ b/xapian-core/api/valuerangeproc.cc
@@ -439,7 +439,7 @@ not_our_range:
     return Xapian::Query(Xapian::Query::OP_INVALID);
 }
 
-static const string byte_units[4] = {
+static const char byte_units[4][2] = {
     "B", "K", "M", "G"
 };
 

--- a/xapian-core/include/xapian/queryparser.h
+++ b/xapian-core/include/xapian/queryparser.h
@@ -413,7 +413,7 @@ class XAPIAN_VISIBILITY_DEFAULT UnitRangeProcessor : public RangeProcessor {
      *  accept "size:3K..10K" as a valid range.
      */
     UnitRangeProcessor(Xapian::valueno slot_,
-                       const std::string &str_ = std::string())
+		       const std::string &str_ = std::string())
 	: RangeProcessor(slot_, str_) { }
 
     /** Check for a valid byte value range.

--- a/xapian-core/include/xapian/queryparser.h
+++ b/xapian-core/include/xapian/queryparser.h
@@ -389,6 +389,48 @@ class XAPIAN_VISIBILITY_DEFAULT NumberRangeProcessor : public RangeProcessor {
     Xapian::Query operator()(const std::string& begin, const std::string& end);
 };
 
+/** Handle a byte unit range.
+ *
+ *  This class must be used on values which have been encoded using
+ *  Xapian::sortable_serialise() which turns numbers into strings which
+ *  will sort in the same order as the numbers (the same values can be
+ *  used to implement a numeric sort).
+ */
+class XAPIAN_VISIBILITY_DEFAULT UnitRangeProcessor : public RangeProcessor {
+  public:
+    /** Constructor.
+     *
+     *  @param slot_    The value slot number to query.
+     *
+     *  @param str_     A string to look for to recognise values as belonging
+     *                  to this numeric range.
+     *
+     *  The string supplied in str_ is the prefix plus ":" that defines the field
+     *  upon which the range query is performed.
+     *
+     *  For example, if str_ is "size:", and the range
+     *  processor has been added to the queryparser, the queryparser will
+     *  accept "size:3K..10K" as a valid range.
+     */
+    UnitRangeProcessor(Xapian::valueno slot_,
+			 const std::string &str_ = std::string())
+	: RangeProcessor(slot_, str_) { }
+
+    /** Check for a valid byte value range.
+     *
+     *  If BEGIN..END is a valid numeric byte range with the specified prefix
+     *  the prefix is removed, the string converted to a number, unit
+     *  normalized and encoded with Xapian::sortable_serialise(),
+     *  and a value range query is built.
+     *
+     *  @param begin	The start of the range as specified in the query string
+     *			by the user.
+     *  @param end	The end of the range as specified in the query string
+     *			by the user.
+     */
+    Xapian::Query operator()(const std::string& begin, const std::string& end);
+};
+
 /// Base class for value range processors.
 class XAPIAN_VISIBILITY_DEFAULT ValueRangeProcessor
     : public Xapian::Internal::opt_intrusive_base {

--- a/xapian-core/include/xapian/queryparser.h
+++ b/xapian-core/include/xapian/queryparser.h
@@ -413,7 +413,7 @@ class XAPIAN_VISIBILITY_DEFAULT UnitRangeProcessor : public RangeProcessor {
      *  accept "size:3K..10K" as a valid range.
      */
     UnitRangeProcessor(Xapian::valueno slot_,
-			 const std::string &str_ = std::string())
+                       const std::string &str_ = std::string())
 	: RangeProcessor(slot_, str_) { }
 
     /** Check for a valid byte value range.

--- a/xapian-core/tests/api_queryparser.cc
+++ b/xapian-core/tests/api_queryparser.cc
@@ -1742,7 +1742,7 @@ static const test test_unitrange1_queries[] = {
     { NULL, NULL }
 };
 
-// Test chaining of UnitRangeProcessor class.
+// Simple Test of UnitRangeProcessor class.
 DEFINE_TESTCASE(qp_range5, !backend) {
     Xapian::QueryParser qp;
     Xapian::UnitRangeProcessor rp_size(1, "size:");

--- a/xapian-core/tests/api_queryparser.cc
+++ b/xapian-core/tests/api_queryparser.cc
@@ -1728,6 +1728,17 @@ DEFINE_TESTCASE(qp_range4, !backend) {
 
 static const test test_unitrange1_queries[] = {
     { "financial report size:100K..1M", "((financial@1 OR report@2) FILTER VALUE_RANGE 1 \\xe0&@ \\xe04)" },
+    { "size:1B..1G", "VALUE_RANGE 1 \\xa0 \\xe0\\x5c" },
+    // Interpret this as size:10K..100K
+    { "size:10..100K", "VALUE_RANGE 1 \\xd9 \\xe0&@" },
+    // Feature test for single-ended ranges
+    { "size:10K..", "VALUE_GE 1 \\xd9" },
+    { "size:..2M", "VALUE_LE 1 \\xe08" },
+    // Forbidden ranges
+    { "size:10B..100", "Unknown range operation" },
+    { "size:10..100", "Unknown range operation" },
+    { "size:..100", "Unknown range operation" },
+    { "size:10..", "Unknown range operation" },
     { NULL, NULL }
 };
 


### PR DESCRIPTION
Basic implementation of allowing units in range values (eg., "size:1K..2K"). Involves a test case and implementation for the same. Basically, the range values are normalized to a base unit and handled in the same way as done by NumberRangeProcessor (eg., 1K -> 1024B). Currently, only supports byte as a unit.