### PR TITLE
Support sphinx >= 1.7 while still working with < 1.7

### DIFF
--- a/xapian-bindings/python/Makefile.am
+++ b/xapian-bindings/python/Makefile.am
@@ -165,6 +165,14 @@ all-local: $(sphinxdocs)
 $(sphinxdocs): xapian/__init__.py xapian/_xapian$(PYTHON2_SO) docs/conf.py $(RST_DOCS) $(dist_exampledata_DATA)
 ## We need to run Sphinx for the right version of Python here, so we can't
 ## just run sphinx-build as that might be for a different version.
+##
+## sphinx >= 1.7.0 no longer skips the first argument passed to
+## sphinx.main(). Therefore we have to skip it ourselves (by
+## taking a slice of sys.argv), and then have a skippable first
+## argument for sphinx < 1.7.0. -bhtml duplicates the subsequent
+## -b html, and so apparently is safe.
+##
+## Change was merged here: https://github.com/sphinx-doc/sphinx/pull/3668
 	PYTHONPATH=..:$$PYTHONPATH $(OSX_SIP_HACK_ENV) $(PYTHON2) \
-		-c 'import sphinx,sys;sys.exit(sphinx.main(sys.argv))' \
-		-b html -d doctrees -c docs $(srcdir)/docs docs/html
+		-c 'import sphinx,sys;sys.exit(sphinx.main(sys.argv[1:]))' \
+		-bhtml -b html -d doctrees -c docs $(srcdir)/docs docs/html

--- a/xapian-bindings/python3/Makefile.am
+++ b/xapian-bindings/python3/Makefile.am
@@ -170,6 +170,14 @@ all-local: $(sphinxdocs)
 $(sphinxdocs): xapian/__init__.py xapian/_xapian$(PYTHON3_SO) docs/conf.py $(RST_DOCS) $(dist_exampledata_DATA)
 ## We need to run Sphinx for the right version of Python here, so we can't
 ## just run sphinx-build as that might be for a different version.
+##
+## sphinx >= 1.7.0 no longer skips the first argument passed to
+## sphinx.main(). Therefore we have to skip it ourselves (by
+## taking a slice of sys.argv), and then have a skippable first
+## argument for sphinx < 1.7.0. -bhtml duplicates the subsequent
+## -b html, and so apparently is safe.
+##
+## Change was merged here: https://github.com/sphinx-doc/sphinx/pull/3668
 	PYTHONPATH=..:$$PYTHONPATH $(OSX_SIP_HACK_ENV) $(PYTHON3) \
-		-c 'import sphinx,sys;sys.exit(sphinx.main(sys.argv))' \
-		-b html -d doctrees -c docs $(srcdir)/docs docs/html
+		-c 'import sphinx,sys;sys.exit(sphinx.main(sys.argv[1:]))' \
+		-bhtml -b html -d doctrees -c docs $(srcdir)/docs docs/html


### PR DESCRIPTION
Sphinx 1.7.0 changed the behaviour of the internal sphinx "main"
functions: https://github.com/sphinx-doc/sphinx/pull/3668

In order to support both, we now need to manually strip argv[0]
before calling sphinx.main(), and also provide a dummy first
argument for pre-1.7 sphinx to skip automatically. We do this
by effectively duplicating our first "real" argument (-b html)
as -bhtml.