### PR TITLE
Fix assertion error with hash command in scriptindex.

### DIFF
--- a/xapian-applications/omega/omegatest
+++ b/xapian-applications/omega/omegatest
@@ -710,6 +710,16 @@ else
     failed=`expr $failed + 1`
 fi
 
+# Regression test to check hash works without argument, was failing earlier with ASSERTION error.
+printf 'url : hash boolean=Q unique=Q' > "$TEST_INDEXSCRIPT"
+rm -rf "$TEST_DB"
+if echo 'url=http://xapian.org' | $SCRIPTINDEX "$TEST_DB" "$TEST_INDEXSCRIPT" > /dev/null 2>&1 ; then
+    : # OK
+else
+    echo "scriptindex rejected 'hash'"
+    failed=`expr $failed + 1`
+fi
+
 rm "$OMEGA_CONFIG_FILE" "$TEST_INDEXSCRIPT" "$TEST_TEMPLATE"
 rm -rf "$TEST_DB"
 if [ "$failed" = 0 ] ; then

--- a/xapian-applications/omega/scriptindex.cc
+++ b/xapian-applications/omega/scriptindex.cc
@@ -395,6 +395,8 @@ parse_index_script(const string &filename)
 		if (code == Action::INDEX || code == Action::INDEXNOPOS) {
 		    useless_weight_pos = string::npos;
 		    actions.push_back(Action(code, "", weight));
+		} else if (code == Action::HASH) {
+		    actions.push_back(Action(code, "", MAX_SAFE_TERM_LENGTH - 1));
 		} else {
 		    actions.push_back(Action(code));
 		}


### PR DESCRIPTION
* Currently hash command doesn't work without argument and get's assertion error.
* num_argument is taken as zero when argument is not given, which should be defaulted to max safe term length.
* hash command fails with default argument of zero and raises an exception.
* set the default to MAX_SAFE_TERM_LENGTH - 1 also when argument is not provided to hash command.

Orignal Error :
scriptindex: ../../hashterm.cc:65: std::string hash_long_term(const string&, unsigned int): Assertion `max_length >= HASH_LEN' failed.
Aborted