### PR TITLE
Fix Exception in generate_sample with 0 as sample size (#754). 

### DIFF
--- a/xapian-applications/omega/omegatest
+++ b/xapian-applications/omega/omegatest
@@ -567,6 +567,12 @@ testcase 'XCASE|TITLE' B='XCASE:TITLE'
 testcase 'XNUM|42' B='XNUM42'
 testcase 'XNUM|3bad' B='XNUM3bad'
 
+# Test to make sure out generate_sample function in sample.cc
+# Doesn't run into negative memory access
+printf '$truncate{$cgi{input},$cgi{maxlen},$cgi{ind},$cgi{ind2}}$seterror{$opt{error}}' > "$TEST_TEMPLATE"
+testcase 'w...' input='wwwwww' maxlen=4 ind='...' ind2='...'
+testcase '' input='s' maxlen=0 ind='...' ind2='...'
+
 # Simple tests of $subdb and $subid.
 rm -rf "$TEST_DB"
 printf 'inmemory' > "$TEST_DB"

--- a/xapian-applications/omega/sample.cc
+++ b/xapian-applications/omega/sample.cc
@@ -50,8 +50,14 @@ generate_sample(const string & input, size_t maxlen,
 	if (output.size() >= maxlen) {
 	    // Need to truncate output.
 	    if (last_word_end <= maxlen / 2) {
-		// Monster word!  We'll have to just split it.
-		output.replace(maxlen - ind.size(), string::npos, ind);
+		// Fixed when maxlen < ind.size leading to a negative
+		// reference
+		if (maxlen < ind.size()) {
+		    output.resize(0);
+		} else {
+		    // Monster word!  We'll have to just split it.
+		    output.replace(maxlen - ind.size(), string::npos, ind);
+		}
 	    } else {
 		output.replace(last_word_end, string::npos, ind2);
 	    }


### PR DESCRIPTION
Setting output to an empty string to avoid negative index reference.
Ticket link: https://trac.xapian.org/ticket/754