### PR TITLE
BugFix: #754 Exception in generate_sample with 0 as sample size

### DIFF
--- a/xapian-applications/omega/sample.cc
+++ b/xapian-applications/omega/sample.cc
@@ -49,10 +49,14 @@ generate_sample(const string & input, size_t maxlen,
     for ( ; i != Xapian::Utf8Iterator(); ++i) {
 	if (output.size() >= maxlen) {
 	    // Need to truncate output.
-	    if (last_word_end <= maxlen / 2) {
-		// Monster word!  We'll have to just split it.
-		output.replace(maxlen - ind.size(), string::npos, ind);
-	    } else {
+		if (last_word_end <= maxlen / 2) {
+		    if (maxlen <= ind.size()) {
+			     output.resize(0);
+		    } else {
+		       // Monster word!  We'll have to just split it.
+			output.replace(maxlen - ind.size(), string::npos, ind);
+			}
+		} else {
 		output.replace(last_word_end, string::npos, ind2);
 	    }
 	    break;


### PR DESCRIPTION
Handling the case when maxlen <= ind.size() by returning an empty string to avoid referencing negative indices.