### PR TITLE
Check document length bounds against document length

### DIFF
--- a/xapian-core/backends/glass/glass_dbcheck.cc
+++ b/xapian-core/backends/glass/glass_dbcheck.cc
@@ -742,7 +742,7 @@ check_glass_table(const char * tablename, const string &db_dir, int fd,
 	    if (doclen < version_file.get_doclength_lower_bound() ||
 		doclen > version_file.get_doclength_upper_bound()) {
 		if (out) {
-		    *out << "doclen not within bounds";
+		    *out << "doclen not within bounds" << endl;
 		}
 		++errors;
 		continue;

--- a/xapian-core/backends/glass/glass_dbcheck.cc
+++ b/xapian-core/backends/glass/glass_dbcheck.cc
@@ -738,6 +738,16 @@ check_glass_table(const char * tablename, const string &db_dir, int fd,
 		continue;
 	    }
 
+	    // Check doclen with doclen lower and upper bounds
+	    if (doclen < version_file.get_doclength_lower_bound() ||
+		doclen > version_file.get_doclength_upper_bound()) {
+		if (out) {
+		    *out << "doclen not within bounds";
+		}
+		++errors;
+		continue;
+	    }
+
 	    // Read termlist_size
 	    if (!unpack_uint(&pos, end, &termlist_size)) {
 		if (out) {


### PR DESCRIPTION
Cross-check the document length upper and lower bounds with the
document length in xapian-check.