### PR TITLE
Extend test of behavior of database objects after database close

### DIFF
--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -307,7 +307,7 @@ DEFINE_TESTCASE(closedb5, transactions) {
 	Xapian::WritableDatabase wdb = get_writable_database();
 	wdb.close();
 	TEST_EXCEPTION(Xapian::InvalidOperationError,
-		wdb.commit_transaction());
+		       wdb.commit_transaction());
 	try {
 	    wdb.begin_transaction();
 	} catch (const Xapian::DatabaseError &) {

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -325,6 +325,11 @@ DEFINE_TESTCASE(closedb7, writable) {
     // is a no-op, and so doesn't have to fail.  Similarly we may be able to
     // call db.begin_transaction(), but we can't make any changes inside that
     // transaction.
+    try {
+	db.commit();
+    } catch (const Xapian::DatabaseError &) {
+    }
+
     TEST_EXCEPTION(Xapian::DatabaseError,
 		   db.add_document(Xapian::Document()));
     TEST_EXCEPTION(Xapian::DatabaseError,

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -55,6 +55,8 @@ struct closedb1_iterators {
     Xapian::TermIterator tlend;
     Xapian::TermIterator atl1;
     Xapian::TermIterator atlend;
+    Xapian::PositionIterator pil1;
+    Xapian::PositionIterator pilend;
 
     void setup(Xapian::Database db_) {
 	db = db_;
@@ -68,6 +70,8 @@ struct closedb1_iterators {
 	tlend = db.termlist_end(1);
 	atl1 = db.allterms_begin("t");
 	atlend = db.allterms_end("t");
+	pil1 = db.positionlist_begin(1, "paragraph");
+	pilend = db.positionlist_end(1, "paragraph");
     }
 
     int perform() {
@@ -105,6 +109,7 @@ struct closedb1_iterators {
 	TEST_NOT_EQUAL(pl1, plend);
 	TEST_NOT_EQUAL(tl1, tlend);
 	TEST_NOT_EQUAL(atl1, atlend);
+	TEST_NOT_EQUAL(pil1, pilend);
 
 	COUNT_CLOSEDEXC(db.postlist_begin("paragraph"));
 
@@ -118,6 +123,8 @@ struct closedb1_iterators {
 
 	COUNT_CLOSEDEXC(TEST_EQUAL(*atl1, "test"));
 	COUNT_CLOSEDEXC(TEST_EQUAL(atl1.get_termfreq(), 1));
+
+	COUNT_CLOSEDEXC(TEST_EQUAL(*pil1, 12));
 
 	// Advancing the iterator may or may not raise an error, but if it
 	// doesn't it must return the correct answers.
@@ -154,6 +161,16 @@ struct closedb1_iterators {
 	if (advanced) {
 	    COUNT_CLOSEDEXC(TEST_EQUAL(*atl1, "that"));
 	    COUNT_CLOSEDEXC(TEST_EQUAL(atl1.get_termfreq(), 2));
+	}
+
+	advanced = false;
+	try {
+	    ++pil1;
+	    advanced = true;
+	} catch (const Xapian::DatabaseError &) {}
+
+	if (advanced) {
+	    COUNT_CLOSEDEXC(TEST_EQUAL(*pil1, 28));
 	}
 
 	return closedexc_count;

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -53,6 +53,8 @@ struct closedb1_iterators {
     Xapian::PostingIterator plend;
     Xapian::TermIterator tl1;
     Xapian::TermIterator tlend;
+    Xapian::TermIterator atl1;
+    Xapian::TermIterator atlend;
 
     void setup(Xapian::Database db_) {
 	db = db_;
@@ -64,6 +66,8 @@ struct closedb1_iterators {
 	plend = db.postlist_end("paragraph");
 	tl1 = db.termlist_begin(1);
 	tlend = db.termlist_end(1);
+	atl1 = db.allterms_begin("t");
+	atlend = db.allterms_end("t");
     }
 
     int perform() {
@@ -100,6 +104,7 @@ struct closedb1_iterators {
 
 	TEST_NOT_EQUAL(pl1, plend);
 	TEST_NOT_EQUAL(tl1, tlend);
+	TEST_NOT_EQUAL(atl1, atlend);
 
 	COUNT_CLOSEDEXC(db.postlist_begin("paragraph"));
 
@@ -110,6 +115,9 @@ struct closedb1_iterators {
 	COUNT_CLOSEDEXC(TEST_EQUAL(*tl1, "a"));
 	COUNT_CLOSEDEXC(TEST_EQUAL(tl1.get_wdf(), 2));
 	COUNT_CLOSEDEXC(TEST_EQUAL(tl1.get_termfreq(), 3));
+
+	COUNT_CLOSEDEXC(TEST_EQUAL(*atl1, "test"));
+	COUNT_CLOSEDEXC(TEST_EQUAL(atl1.get_termfreq(), 1));
 
 	// Advancing the iterator may or may not raise an error, but if it
 	// doesn't it must return the correct answers.
@@ -135,6 +143,17 @@ struct closedb1_iterators {
 	    COUNT_CLOSEDEXC(TEST_EQUAL(*tl1, "api"));
 	    COUNT_CLOSEDEXC(TEST_EQUAL(tl1.get_wdf(), 1));
 	    COUNT_CLOSEDEXC(TEST_EQUAL(tl1.get_termfreq(), 1));
+	}
+
+	advanced = false;
+	try {
+	    ++atl1;
+	    advanced = true;
+	} catch (const Xapian::DatabaseError &) {}
+
+	if (advanced) {
+	    COUNT_CLOSEDEXC(TEST_EQUAL(*atl1, "that"));
+	    COUNT_CLOSEDEXC(TEST_EQUAL(atl1.get_termfreq(), 2));
 	}
 
 	return closedexc_count;

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -299,6 +299,20 @@ DEFINE_TESTCASE(closedb5, transactions) {
 	Xapian::Database db = get_writable_database_as_database();
 	TEST_EQUAL(db.get_doccount(), 0);
     }
+
+    {
+	// commit_transaction() throws InvalidOperationError when
+	// not in a transaction. begin_transaction() is no-op or
+	// throws DatabaseError
+	Xapian::WritableDatabase wdb = get_writable_database();
+	wdb.close();
+	TEST_EXCEPTION(Xapian::InvalidOperationError,
+		wdb.commit_transaction());
+	try {
+	    wdb.begin_transaction();
+	} catch (const Xapian::DatabaseError &) {
+	}
+    }
     return true;
 }
 

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -50,7 +50,8 @@ struct closedb1_iterators {
     Xapian::Document doc1;
     Xapian::PostingIterator pl1;
     Xapian::PostingIterator pl2;
-    Xapian::PostingIterator plend;
+    Xapian::PostingIterator pl1end;
+    Xapian::PostingIterator pl2end;
     Xapian::TermIterator tl1;
     Xapian::TermIterator tlend;
     Xapian::TermIterator atl1;
@@ -63,9 +64,10 @@ struct closedb1_iterators {
 
 	// Set up the iterators for the test.
 	pl1 = db.postlist_begin("paragraph");
-	pl2 = db.postlist_begin("paragraph");
+	pl2 = db.postlist_begin("this");
 	++pl2;
-	plend = db.postlist_end("paragraph");
+	pl1end = db.postlist_end("paragraph");
+	pl2end = db.postlist_end("this");
 	tl1 = db.termlist_begin(1);
 	tlend = db.termlist_end(1);
 	atl1 = db.allterms_begin("t");
@@ -106,7 +108,8 @@ struct closedb1_iterators {
 	// Reopen raises the "database closed" error.
 	COUNT_CLOSEDEXC(db.reopen());
 
-	TEST_NOT_EQUAL(pl1, plend);
+	TEST_NOT_EQUAL(pl1, pl1end);
+	TEST_NOT_EQUAL(pl2, pl2end);
 	TEST_NOT_EQUAL(tl1, tlend);
 	TEST_NOT_EQUAL(atl1, atlend);
 	TEST_NOT_EQUAL(pil1, pilend);
@@ -116,6 +119,10 @@ struct closedb1_iterators {
 	COUNT_CLOSEDEXC(TEST_EQUAL(*pl1, 1));
 	COUNT_CLOSEDEXC(TEST_EQUAL(pl1.get_doclength(), 28));
 	COUNT_CLOSEDEXC(TEST_EQUAL(pl1.get_unique_terms(), 21));
+
+	COUNT_CLOSEDEXC(TEST_EQUAL(*pl2, 2));
+	COUNT_CLOSEDEXC(TEST_EQUAL(pl2.get_doclength(), 81));
+	COUNT_CLOSEDEXC(TEST_EQUAL(pl2.get_unique_terms(), 56));
 
 	COUNT_CLOSEDEXC(TEST_EQUAL(*tl1, "a"));
 	COUNT_CLOSEDEXC(TEST_EQUAL(tl1.get_wdf(), 2));
@@ -138,6 +145,18 @@ struct closedb1_iterators {
 	    COUNT_CLOSEDEXC(TEST_EQUAL(*pl1, 2));
 	    COUNT_CLOSEDEXC(TEST_EQUAL(pl1.get_doclength(), 81));
 	    COUNT_CLOSEDEXC(TEST_EQUAL(pl1.get_unique_terms(), 56));
+	}
+
+	advanced = false;
+	try {
+	    ++pl2;
+	    advanced = true;
+	} catch (const Xapian::DatabaseError &) {}
+
+	if (advanced) {
+	    COUNT_CLOSEDEXC(TEST_EQUAL(*pl2, 3));
+	    COUNT_CLOSEDEXC(TEST_EQUAL(pl2.get_doclength(), 15));
+	    COUNT_CLOSEDEXC(TEST_EQUAL(pl2.get_unique_terms(), 14));
 	}
 
 	advanced = false;

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -309,10 +309,11 @@ DEFINE_TESTCASE(closedb5, transactions) {
 	TEST_EXCEPTION(Xapian::InvalidOperationError,
 		       wdb.commit_transaction());
 
-	// begin_transaction() is no-op or throws DatabaseError. We may be able to
-	// call db.begin_transaction(), but we can't make any changes inside that
-	// transaction. If begin_transaction() succeeds, then commit_transaction()
-	// either end the transaction or throw DatabaseError.
+	// begin_transaction() is no-op or throws DatabaseError. We may be
+	// able to call db.begin_transaction(), but we can't make any changes
+	// inside that transaction. If begin_transaction() succeeds, then
+	// commit_transaction() either end the transaction or throw
+	// DatabaseError.
 	bool advanced = false;
 	try {
 	    wdb.begin_transaction();


### PR DESCRIPTION
Changes:
Added tests to cover termlist, alltermlist, positionlist iterator. Ran the api test on all backend types. No failure. 
I will update this PR with additional tests w.r.t ticket #337.

Questions:
* Should I squash the commits to make single one?
* It is mentioned in the comment that iterator increment may not raise exception. Is it because block of values will be fetched from database when iterator object is assigned with begin method?
