### PR TITLE
Add C++11 move support for smart pointer classes

### DIFF
--- a/xapian-core/include/xapian/intrusive_ptr.h
+++ b/xapian-core/include/xapian/intrusive_ptr.h
@@ -236,7 +236,33 @@ public:
 
     ~intrusive_ptr_nonnull()
     {
-        if(--px->_refs == 0 ) delete px;
+        if(px != 0 && --px->_refs == 0 ) delete px;
+    }
+
+    intrusive_ptr_nonnull(intrusive_ptr_nonnull && rhs) : px( rhs.px )
+    {
+        rhs.px = 0;
+    }
+
+    intrusive_ptr_nonnull & operator=(intrusive_ptr_nonnull && rhs)
+    {
+        this_type( static_cast< intrusive_ptr_nonnull && >( rhs ) ).swap(*this);
+        return *this;
+    }
+
+    template<class U> friend class intrusive_ptr_nonnull;
+
+    template<class U>
+    intrusive_ptr_nonnull(intrusive_ptr_nonnull<U> && rhs) : px( rhs.px )
+    {
+        rhs.px = 0;
+    }
+
+    template<class U>
+    intrusive_ptr_nonnull & operator=(intrusive_ptr_nonnull<U> && rhs)
+    {
+        this_type( static_cast< intrusive_ptr_nonnull<U> && >( rhs ) ).swap(*this);
+        return *this;
     }
 
     intrusive_ptr_nonnull & operator=(intrusive_ptr_nonnull const & rhs)

--- a/xapian-core/include/xapian/intrusive_ptr.h
+++ b/xapian-core/include/xapian/intrusive_ptr.h
@@ -430,6 +430,35 @@ public:
 	if( counting && --px->_refs == 1 ) delete px;
     }
 
+    opt_intrusive_ptr(opt_intrusive_ptr && rhs)
+    : px( rhs.px ), counting( rhs.counting )
+    {
+        rhs.px = 0;
+	rhs.counting = 0;
+    }
+
+    opt_intrusive_ptr & operator=(opt_intrusive_ptr && rhs)
+    {
+        this_type( static_cast< opt_intrusive_ptr && >( rhs ) ).swap(*this);
+        return *this;
+    }
+
+    template<class U> friend class opt_intrusive_ptr;
+
+    template<class U>
+    opt_intrusive_ptr(opt_intrusive_ptr<U> && rhs)
+    : px( rhs.px ), counting( rhs.counting )
+    {
+        rhs.px = 0;
+	rhs.counting = 0;
+    }
+
+    template<class U>
+    opt_intrusive_ptr & operator=(opt_intrusive_ptr<U> && rhs)
+    {
+        this_type( static_cast< opt_intrusive_ptr<U> && >( rhs ) ).swap(*this);
+        return *this;
+    }
     opt_intrusive_ptr & operator=(opt_intrusive_ptr const & rhs)
     {
 	this_type(rhs).swap(*this);

--- a/xapian-core/include/xapian/intrusive_ptr.h
+++ b/xapian-core/include/xapian/intrusive_ptr.h
@@ -113,6 +113,32 @@ public:
         if( px != 0 && --px->_refs == 0 ) delete px;
     }
 
+    intrusive_ptr(intrusive_ptr && rhs) : px( rhs.px )
+    {
+        rhs.px = 0;
+    }
+
+    intrusive_ptr & operator=(intrusive_ptr && rhs)
+    {
+        this_type( static_cast< intrusive_ptr && >( rhs ) ).swap(*this);
+        return *this;
+    }
+
+    template<class U> friend class intrusive_ptr;
+
+    template<class U>
+    intrusive_ptr(intrusive_ptr<U> && rhs) : px( rhs.px )
+    {
+        rhs.px = 0;
+    }
+
+    template<class U>
+    intrusive_ptr & operator=(intrusive_ptr<U> && rhs)
+    {
+        this_type( static_cast< intrusive_ptr<U> && >( rhs ) ).swap(*this);
+        return *this;
+    }
+
     intrusive_ptr & operator=(intrusive_ptr const & rhs)
     {
         this_type(rhs).swap(*this);

--- a/xapian-core/include/xapian/intrusive_ptr.h
+++ b/xapian-core/include/xapian/intrusive_ptr.h
@@ -236,12 +236,12 @@ public:
 
     ~intrusive_ptr_nonnull()
     {
-        if(px != 0 && --px->_refs == 0 ) delete px;
+        if(--px->_refs == 0 ) delete px;
     }
 
     intrusive_ptr_nonnull(intrusive_ptr_nonnull && rhs) : px( rhs.px )
     {
-        rhs.px = 0;
+        ++px->_refs;
     }
 
     intrusive_ptr_nonnull & operator=(intrusive_ptr_nonnull && rhs)
@@ -255,7 +255,7 @@ public:
     template<class U>
     intrusive_ptr_nonnull(intrusive_ptr_nonnull<U> && rhs) : px( rhs.px )
     {
-        rhs.px = 0;
+        ++px->_refs;
     }
 
     template<class U>
@@ -459,6 +459,7 @@ public:
         this_type( static_cast< opt_intrusive_ptr<U> && >( rhs ) ).swap(*this);
         return *this;
     }
+
     opt_intrusive_ptr & operator=(opt_intrusive_ptr const & rhs)
     {
 	this_type(rhs).swap(*this);

--- a/xapian-core/tests/unittest.cc
+++ b/xapian-core/tests/unittest.cc
@@ -28,6 +28,7 @@
 #include <cmath>
 #include <cstring>
 #include <iostream>
+#include <utility>
 
 #include "safeunistd.h"
 
@@ -91,6 +92,7 @@ using namespace std;
 #include "../net/serialise-error.cc"
 #include "../api/error.cc"
 #include "../api/sortable-serialise.cc"
+#include "../include/xapian/intrusive_ptr.h"
 
 // fileutils.cc uses opendir(), etc though not in a function we currently test.
 #include "../common/msvc_dirent.cc"
@@ -680,6 +682,86 @@ static bool test_uuid1()
     return true;
 }
 
+// Classes used by movesupport1 test
+class A : public Xapian::Internal::intrusive_base {
+    int x = 0;
+  public:
+    A(int x_) : x(x_) {}
+    int get_x() const {
+	return x;
+    }
+};
+
+class B : public Xapian::Internal::opt_intrusive_base {
+    int x = 0;
+  public:
+    B(int x_) : x(x_) {}
+    int get_x() const {
+	return x;
+    }
+    B * release() {
+	opt_intrusive_base::release();
+	return this;
+    }
+};
+
+static bool test_movesupport1()
+{
+    {
+	// Test move semantics support for intrusive_ptr class
+	Xapian::Internal::intrusive_ptr<A> p1(new A{5});
+	Xapian::Internal::intrusive_ptr<A> p3;
+
+	// Test move constructor
+	Xapian::Internal::intrusive_ptr<A> p2(std::move(p1));
+	TEST_EQUAL(p2->get_x(), 5);
+	TEST_EQUAL(p1.get(), 0);
+
+	// Test move assignment
+	p3 = std::move(p2);
+	TEST_EQUAL(p3->get_x(), 5);
+	TEST_EQUAL(p2.get(), 0);
+    }
+
+
+    {
+	// Same test for intrusive_ptr_nonnull class
+	Xapian::Internal::intrusive_ptr_nonnull<A> p1(new A{5});
+	Xapian::Internal::intrusive_ptr_nonnull<A> p3(new A{6});
+
+	// Test move constructor
+	Xapian::Internal::intrusive_ptr_nonnull<A> p2(std::move(p1));
+	TEST_EQUAL(p2->get_x(), 5);
+	TEST_EQUAL(p1.get(), 0);
+
+	// Test move assignment
+	p3 = std::move(p2);
+	TEST_EQUAL(p3->get_x(), 5);
+	TEST_EQUAL(p2.get(), 0);
+    }
+
+    {
+	// Same test for opt_intrusive_ptr class
+	B * b1 = new B{5};
+	b1->release();
+	Xapian::Internal::opt_intrusive_ptr<B> p1(b1);
+	Xapian::Internal::opt_intrusive_ptr<B> p3;
+
+	// Test move constructor
+	Xapian::Internal::opt_intrusive_ptr<B> p2(std::move(p1));
+	TEST_EQUAL(p2->get_x(), 5);
+	TEST_EQUAL(p2->_refs, 2);
+	TEST_EQUAL(p1.get(), 0);
+
+	// Test move assignment
+	p3 = std::move(p2);
+	TEST_EQUAL(p3->get_x(), 5);
+	TEST_EQUAL(p3->_refs, 2);
+	TEST_EQUAL(p2.get(), 0);
+    }
+    return true;
+}
+
 static const test_desc tests[] = {
     TESTCASE(simple_exceptions_work1),
     TESTCASE(class_exceptions_work1),
@@ -697,6 +779,7 @@ static const test_desc tests[] = {
     TESTCASE(closefrom1),
     TESTCASE(shard1),
     TESTCASE(uuid1),
+    TESTCASE(movesupport1),
     END_OF_TESTCASES
 };
 


### PR DESCRIPTION
Address issue #642 -
* Add move support for intrusive_ptr, intrusive_ptr_nonnull and opt_intrusive_ptr.
* Add unit tests