### PR TITLE
Use a brief description for xapian-core.pc.

### DIFF
--- a/xapian-core/pkgconfig/xapian-core.pc.in
+++ b/xapian-core/pkgconfig/xapian-core.pc.in
@@ -4,10 +4,7 @@ libdir=@libdir@
 includedir=@incdir@
 
 Name: The Xapian Probabilistic Information Retrieval Library
-Description: Xapian is an Open Source Probabilistic Information Retrieval framework. It
-offers a highly adaptable toolkit that allows developers to easily add advanced
-indexing and search facilities to applications. This package provides the
-libraries for applications using Xapian functionality.
+Description: Xapian is an Open Source Probabilistic Information Retrieval framework.
 URL: https://xapian.org/
 Version: @VERSION@
 Cflags: -I${includedir} @abi_affecting_cxxflags@


### PR DESCRIPTION
According to the pkg-config(1) man page the 'Description' field should be brief and pkgconf will print warnings with --validate. A multi line 'Description' is not valid and neither pkg-config or pkgconf will print more than the first line with --list-all.

This description is better suited for a man page or README.

See:
```
Description:
  This should be a brief description of the package
```
https://linux.die.net/man/1/pkg-config

pkgconf will print warnings.
```
$ pkgconf --validate xapian-core
/usr/lib64/pkgconfig/xapian-core.pc:8: warning: whitespace encountered while parsing key section
/usr/lib64/pkgconfig/xapian-core.pc:9: warning: whitespace encountered while parsing key section
/usr/lib64/pkgconfig/xapian-core.pc:10: warning: whitespace encountered while parsing key section
```