### PR TITLE
Update duplicate test in closedb10 testcase

### DIFF
--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -463,7 +463,7 @@ DEFINE_TESTCASE(closedb10, writable && metadata) {
     TEST_EXCEPTION(Xapian::DatabaseError,
 		   db.get_metadata("foo"));
     TEST_EXCEPTION(Xapian::DatabaseError,
-		   db.get_metadata("foo"));
+		   db.get_metadata("bar"));
     TEST_EXCEPTION(Xapian::DatabaseError,
 		   db.metadata_keys_begin());
 


### PR DESCRIPTION
I noticed a minor error in `closedb10` testcase. I guess argument for second `get_metadata()` should be `bar`. Right?