### PR TITLE
emscripten: patches for compiling with emscripten, js example, ci-setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,35 @@ matrix:
       # We also have to disable an error, because (older?)
       # perl header files don't play nicely with clang.
       env: USE_CC=clang USE_CXX='clang++ -stdlib=libc++' CXXFLAGS=-Wno-error=reserved-user-defined-literal
+    - os: linux
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - doxygen
+            - graphviz
+            - help2man
+            - python-docutils
+            - python-pygments
+            - pngcrush
+      language: node_js
+      node_js:
+        - node
+      services:
+        - docker
+      before_script:
+        # Bootstrap only xapian-core for emscripten build.
+        - ./bootstrap xapian-core
+        - ./configure CXXFLAGS=-O0 --disable-backend-honey --disable-backend-inmemory --disable-backend-remote
+        - make -j2
+        - make -j2 distclean
+          # -w needs docker API 1.35+: - docker exec -it -w xapian-core emscripten emconfigure ./configure $confargs CXXFLAGS='-O3 -s USE_ZLIB=1' --disable-backend-honey --disable-backend-inmemory --disable-backend-remote
+        - cd xapian-core
+        - docker run -v $(pwd):/src trzeci/emscripten emconfigure ./configure CPPFLAGS='-DFLINTLOCK_USE_FLOCK' CXXFLAGS='-Oz -s USE_ZLIB=1' --disable-backend-honey --disable-backend-inmemory --disable-shared --disable-backend-remote
+      script:
+        - docker run -v $(pwd):/src trzeci/emscripten emmake make
+        - docker run -v $(pwd):/src trzeci/emscripten em++ -Oz -s USE_ZLIB=1 -std=c++11 -s WASM=1 -Iinclude -I. -Icommon emscripten/xapianjstest.cc .libs/libxapian-1.5.a -o emscripten/xapianjstest.js
+        - cd emscripten && node xapianjstest.js
     - os: osx
       before_install:
         - brew update

--- a/xapian-core/.gitignore
+++ b/xapian-core/.gitignore
@@ -37,3 +37,4 @@
 /xapian-core-*.tar.xz
 /xapian-core.spec
 /xapian-config.1
+/a.out*

--- a/xapian-core/backends/glass/glass_version.cc
+++ b/xapian-core/backends/glass/glass_version.cc
@@ -295,7 +295,23 @@ GlassVersion::write(glass_revision_number_t new_rev, int flags)
 	else
 	    tmpfile += "/v.tmp";
 
-	fd = posixy_open(tmpfile.c_str(), O_CREAT|O_TRUNC|O_WRONLY|O_BINARY, 0666);
+#ifdef __EMSCRIPTEN__
+	/*
+	* Emscripten crashes if trying to
+	* truncate a non-existing file. Skip
+	* using O_TRUNC and rather truncate
+	* when the file is opened
+	*/
+	fd = posixy_open(tmpfile.c_str(),
+			O_CREAT|O_WRONLY|O_BINARY, 0666);
+	if (fd >= 0)
+		ftruncate(fd, 0);
+#else
+	fd = posixy_open(tmpfile.c_str(),
+			O_CREAT|O_TRUNC|O_WRONLY|O_BINARY,
+			0666);
+#endif
+
 	if (rare(fd < 0))
 	    throw Xapian::DatabaseOpeningError("Couldn't write new rev file: " + tmpfile,
 					       errno);

--- a/xapian-core/emscripten/.gitignore
+++ b/xapian-core/emscripten/.gitignore
@@ -1,0 +1,3 @@
+xapianjstest.js
+xapianjstest.wasm
+testdb

--- a/xapian-core/emscripten/README.md
+++ b/xapian-core/emscripten/README.md
@@ -1,0 +1,26 @@
+Building for Emscripten
+=======================
+
+Emscripten support has been tested with glass backend.
+
+Instructions below was tested on ubuntu 16.04, after doing a regular platform build.
+
+Build xapian (from `xapian-core` folder):
+```
+emconfigure ./configure CPPFLAGS='-DFLINTLOCK_USE_FLOCK' CXXFLAGS='-Oz -s USE_ZLIB=1' --disable-backend-honey --disable-backend-inmemory --disable-shared --disable-backend-remote
+emmake make
+```
+
+Change directory to the emscripten folder
+
+`cd emscripten`
+
+Test compiling a webassembly binary (from source `xapianjstest.cc`):
+
+``
+XAPIAN=.. && em++ -Oz -s USE_ZLIB=1 -std=c++11 -s WASM=1 -I$XAPIAN/include -I$XAPIAN -I$XAPIAN/common xapianjstest.cc $XAPIAN/.libs/libxapian-1.5.a -o xapianjstest.js
+``
+
+and then you can run it using nodejs:
+
+`node xapianjstest.js`

--- a/xapian-core/emscripten/xapianjstest.cc
+++ b/xapian-core/emscripten/xapianjstest.cc
@@ -1,0 +1,30 @@
+/** @file xapianjstest.cc
+ * @brief Emscripten main program test
+ */
+#include <emscripten.h>
+#include <xapian.h>
+#include <cstdlib>
+#include <iostream>
+
+using namespace std;
+
+int main() {
+	Xapian::WritableDatabase db;
+
+	EM_ASM_({
+		FS.mkdir("/work");
+		FS.mount(NODEFS, {root: '.'},"/work");
+		FS.chdir("/work");
+    });
+
+    db = Xapian::WritableDatabase("testdb", Xapian::DB_CREATE_OR_OPEN);
+
+	Xapian::TermGenerator termgenerator;
+	Xapian::Document doc;
+	termgenerator.set_document(doc);
+	termgenerator.index_text("This is a test document.");
+	db.replace_document("Q1", doc);
+
+	cout << "Created database with " << db.get_doccount() <<
+			" document" << endl;
+}


### PR DESCRIPTION
This PR adds support for compiling with emscripten, a simple example that can be run with nodejs and ci-setup.