### PR TITLE
Use IEEE-754 interchange format in serialise-double

### DIFF
--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -78,11 +78,11 @@ double unserialise_double(const char ** p, const char * end)
 #else
 
 string serialise_double(double v){
-    /* 
+    /*
      * First bit(msb) -> sign (1 means negative)
      * next 11 bits -> exponent
      * last 52 bits -> mantissa
-     * 
+     *
      * frexp gives fraction within the range [0.5, 1)
      * We multiply it by 2 to change the range to [1.0, 2.0)
      * and reduce exp by 1, since this is the way doubles
@@ -92,7 +92,7 @@ string serialise_double(double v){
      * to bits is done by repeatedly multiplying it by 2,
      * checking if it is greater than 1, and turning the
      * corresponding bit on, if it is.
-     * 
+     *
      */
     uint64_t result = 0;
 
@@ -108,7 +108,8 @@ string serialise_double(double v){
 
     if (exp == 0 && v == 0.0) {
 	result = 0;
-	return string(reinterpret_cast<const char *>(&result), sizeof(uint64_t));
+	return string(reinterpret_cast<const char *>(&result), 
+		      sizeof(uint64_t));
     }
 
     exp += 1022;
@@ -152,7 +153,7 @@ double unserialise_double(const char ** p, const char * end) {
     exp |= (second & (15 << 4)) >> 4;
     exp -= 1023;
 
-    double mantissa = 1.0; //implicit 1 in IEEE
+    double mantissa = 1.0; // implicit 1 in IEEE
     double pows2 = 0.5; // powers of 2
 
     int second_byte_counter = 1 << 3;
@@ -168,7 +169,7 @@ double unserialise_double(const char ** p, const char * end) {
 	--byte_counter;
 	int cur_byte_counter = 1 << 7;
 	for (int i = 0; i < 8; ++i) {
-	    if(cur_byte & cur_byte_counter) mantissa += pows2;
+	    if (cur_byte & cur_byte_counter) mantissa += pows2;
 	    pows2 /= 2.0;
 	    cur_byte_counter >>= 1;
 	}

--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -181,7 +181,7 @@ double unserialise_double(const char ** p, const char * end) {
 # if FLT_RADIX == 2
     double result = scalbn(mantissa, exp);
 # else
-    double result = ldexp(mantissa, exp >> 2);
+    double result = ldexp(mantissa, exp);
 # endif
     if (negative) result = -result;
     return result;

--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -157,22 +157,16 @@ double unserialise_double(const char ** p, const char * end) {
     memcpy(&mantissa_bp, *p, sizeof(double));
     mantissa_bp &= (uint64_t(1) << 52) - 1;
 
-# if FLT_RADIX == 2
-    double mantissa = scalbn(mantissa_bp, -52);
-# else
-    double mantissa = ldexp(mantissa_bp, -52);
-# endif
-
-    mantissa += 1.0;
-
     *p += 8;
 
-    if (exp + 1023 == 0 && mantissa == 1.0) return 0.0;
+    if (exp + 1023 == 0 && mantissa_bp == 0) return 0.0;
 
 # if FLT_RADIX == 2
-    double result = scalbn(mantissa, exp);
+    double result = scalbn(mantissa_bp, -52);
+    result = scalbn(result + 1.0, exp);
 # else
-    double result = ldexp(mantissa, exp);
+    double result = ldexp(mantissa_bp, -52);
+    result = ldexp(result + 1.0, exp);
 # endif
 
     if (negative) result = -result;

--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -30,6 +30,8 @@
 
 #include "serialise-double.h"
 
+#include "wordaccess.h"
+
 #include <cfloat>
 #include <cmath>
 
@@ -38,175 +40,36 @@
 
 using namespace std;
 
-// The serialisation we use for doubles is inspired by a comp.lang.c post
-// by Jens Moeller:
-//
-// https://groups.google.com/group/comp.lang.c/browse_thread/thread/6558d4653f6dea8b/75a529ec03148c98
-//
-// The clever part is that the mantissa is encoded as a base-256 number which
-// means there's no rounding error provided both ends have FLT_RADIX as some
-// power of two.
-//
-// FLT_RADIX == 2 seems to be ubiquitous on modern UNIX platforms, while
-// some older platforms used FLT_RADIX == 16 (IBM machines for example).
-// FLT_RADIX == 10 seems to be very rare (the only instance Google finds
-// is for a cross-compiler to some TI calculators).
-
-#if FLT_RADIX == 2
-# define MAX_MANTISSA_BYTES ((DBL_MANT_DIG + 7 + 7) / 8)
-# define MAX_EXP ((DBL_MAX_EXP + 1) / 8)
-# define MAX_MANTISSA (1 << (DBL_MAX_EXP & 7))
-#elif FLT_RADIX == 16
-# define MAX_MANTISSA_BYTES ((DBL_MANT_DIG + 1 + 1) / 2)
-# define MAX_EXP ((DBL_MAX_EXP + 1) / 2)
-# define MAX_MANTISSA (1 << ((DBL_MAX_EXP & 1) * 4))
-#else
-# error FLT_RADIX is a value not currently handled (not 2 or 16)
-// # define MAX_MANTISSA_BYTES (sizeof(double) + 1)
+string serialise_double(double v)
+{
+    size_t double_size = sizeof(double);
+#ifdef WORDS_BIGENDIAN
+    uint64_t temp;
+    static_assert(sizeof(temp) == sizeof(v));
+    memcpy(&temp, &v, double_size);
+    temp = do_bswap(temp);
+    return string(reinterpret_cast<const char *>(&temp), double_size);
 #endif
-
-static int base256ify_double(double &v) {
-    int exp;
-    v = frexp(v, &exp);
-    // v is now in the range [0.5, 1.0)
-    --exp;
-#if FLT_RADIX == 2
-    v = scalbn(v, (exp & 7) + 1);
-#else
-    v = ldexp(v, (exp & 7) + 1);
-#endif
-    // v is now in the range [1.0, 256.0)
-    exp >>= 3;
-    return exp;
+    return string(reinterpret_cast<const char *>(&v), double_size);
 }
 
-std::string serialise_double(double v)
+double unserialise_double(const char ** p, const char * end)
 {
-    /* First byte:
-     *  bit 7 Negative flag
-     *  bit 4..6 Mantissa length - 1
-     *  bit 0..3 --- 0-13 -> Exponent + 7
-     *            \- 14 -> Exponent given by next byte
-     *             - 15 -> Exponent given by next 2 bytes
-     *
-     * Then optional medium (1 byte) or large exponent (2 bytes, lsb first)
-     *
-     * Then mantissa (0 iff value is 0)
-     */
-
-    bool negative = (v < 0.0);
-
-    if (negative) v = -v;
-
-    int exp = base256ify_double(v);
-
-    string result;
-
-    if (exp <= 6 && exp >= -7) {
-	unsigned char b = static_cast<unsigned char>(exp + 7);
-	if (negative) b |= static_cast<unsigned char>(0x80);
-	result += char(b);
-    } else {
-	if (exp >= -128 && exp < 127) {
-	    result += negative ? char(0x8e) : char(0x0e);
-	    result += char(exp + 128);
-	} else {
-	    if (exp < -32768 || exp > 32767) {
-		throw Xapian::InternalError("Insane exponent in floating point number");
-	    }
-	    result += negative ? char(0x8f) : char(0x0f);
-	    result += char(unsigned(exp + 32768) & 0xff);
-	    result += char(unsigned(exp + 32768) >> 8);
-	}
+    if (end - *p < 8) {
+		throw Xapian::SerialisationError(
+				"Bad encoded double: insufficient data");
     }
-
-    int maxbytes = min(MAX_MANTISSA_BYTES, 8);
-
-    size_t n = result.size();
-    do {
-	unsigned char byte = static_cast<unsigned char>(v);
-	result += char(byte);
-	v -= double(byte);
-	v *= 256.0;
-    } while (v != 0.0 && --maxbytes);
-
-    n = result.size() - n;
-    if (n > 1) {
-	Assert(n <= 8);
-	result[0] = static_cast<unsigned char>(result[0] | ((n - 1) << 4));
-    }
-
+    size_t double_size = sizeof(double);
+    double result;
+    memcpy(&result, *p, double_size);
+#ifdef WORDS_BIGENDIAN
+    uint64_t temp;
+    static_assert(sizeof(temp) == sizeof(result));
+    memcpy(&temp, &result, double_size)
+    temp = do_bswap(temp);
+    memcpy(&result, &temp, double_size);
+#endif
+    *p += 8;
     return result;
 }
 
-double unserialise_double(const char ** p, const char *end)
-{
-    if (end - *p < 2) {
-	throw Xapian::SerialisationError("Bad encoded double: insufficient data");
-    }
-    unsigned char first = *(*p)++;
-    if (first == 0 && *(*p) == 0) {
-	++*p;
-	return 0.0;
-    }
-
-    bool negative = (first & 0x80) != 0;
-    size_t mantissa_len = ((first >> 4) & 0x07) + 1;
-
-    int exp = first & 0x0f;
-    if (exp >= 14) {
-	int bigexp = static_cast<unsigned char>(*(*p)++);
-	if (exp == 15) {
-	    if (*p == end) {
-		throw Xapian::SerialisationError("Bad encoded double: short large exponent");
-	    }
-	    exp = bigexp | (static_cast<unsigned char>(*(*p)++) << 8);
-	    exp -= 32768;
-	} else {
-	    exp = bigexp - 128;
-	}
-    } else {
-	exp -= 7;
-    }
-
-    if (size_t(end - *p) < mantissa_len) {
-	throw Xapian::SerialisationError("Bad encoded double: short mantissa");
-    }
-
-    double v = 0.0;
-
-    static double dbl_max_mantissa = DBL_MAX;
-    static int dbl_max_exp = base256ify_double(dbl_max_mantissa);
-    *p += mantissa_len;
-    if (exp > dbl_max_exp ||
-	(exp == dbl_max_exp &&
-	 double(static_cast<unsigned char>((*p)[-1])) > dbl_max_mantissa)) {
-	// The mantissa check should be precise provided that FLT_RADIX
-	// is a power of 2.
-	v = HUGE_VAL;
-    } else {
-	const char *q = *p;
-	while (mantissa_len--) {
-	    v *= 0.00390625; // 1/256
-	    v += double(static_cast<unsigned char>(*--q));
-	}
-
-#if FLT_RADIX == 2
-	if (exp) v = scalbn(v, exp * 8);
-#elif FLT_RADIX == 16
-	if (exp) v = scalbn(v, exp * 2);
-#else
-	if (exp) v = ldexp(v, exp * 8);
-#endif
-
-#if 0
-	if (v == 0.0) {
-	    // FIXME: handle underflow
-	}
-#endif
-    }
-
-    if (negative) v = -v;
-
-    return v;
-}

--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -46,7 +46,8 @@ string serialise_double(double v)
 {
 # ifdef WORDS_BIGENDIAN
     uint64_t temp;
-    static_assert(sizeof(temp) == sizeof(v), "Check if size of double and 64 bit int is same");
+    static_assert(sizeof(temp) == sizeof(v),
+		  "Check if size of double and 64 bit int is same");
     memcpy(&temp, &v, sizeof(double));
     temp = do_bswap(temp);
     return string(reinterpret_cast<const char *>(&temp), sizeof(double));
@@ -64,7 +65,8 @@ double unserialise_double(const char ** p, const char * end)
     double result;
 # ifdef WORDS_BIGENDIAN
     uint64_t temp;
-    static_assert(sizeof(temp) == sizeof(double), "Check if size of double and 64 bit int is same");
+    static_assert(sizeof(temp) == sizeof(double),
+		  "Check if size of double and 64 bit int is same");
     memcpy(&temp, *p, sizeof(double));
     temp = do_bswap(temp);
     memcpy(&result, &temp, sizeof(double));
@@ -190,7 +192,6 @@ double unserialise_double(const char ** p, const char * end) {
 # else
     double result = ldexp(mantissa, exp);
 # endif
-
     if (negative) result = -result;
     return result;
 }

--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -108,7 +108,7 @@ string serialise_double(double v){
 
     if (exp == 0 && v == 0.0) {
 	result = 0;
-	return string(reinterpret_cast<const char *>(&result), 
+	return string(reinterpret_cast<const char *>(&result),
 		      sizeof(uint64_t));
     }
 

--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -40,17 +40,19 @@
 
 using namespace std;
 
+#ifdef FOLLOWS_IEEE
+
 string serialise_double(double v)
 {
-#ifdef WORDS_BIGENDIAN
+# ifdef WORDS_BIGENDIAN
     uint64_t temp;
     static_assert(sizeof(temp) == sizeof(v));
     memcpy(&temp, &v, sizeof(double));
     temp = do_bswap(temp);
     return string(reinterpret_cast<const char *>(&temp), sizeof(double));
-#else
+# else
     return string(reinterpret_cast<const char *>(&v), sizeof(double));
-#endif
+# endif
 }
 
 double unserialise_double(const char ** p, const char * end)
@@ -60,16 +62,130 @@ double unserialise_double(const char ** p, const char * end)
 	    "Bad encoded double: insufficient data");
     }
     double result;
-#ifdef WORDS_BIGENDIAN
+# ifdef WORDS_BIGENDIAN
     uint64_t temp;
     static_assert(sizeof(temp) == sizeof(double));
     memcpy(&temp, *p, sizeof(double));
     temp = do_bswap(temp);
     memcpy(&result, &temp, sizeof(double));
-#else
+# else
     memcpy(&result, *p, sizeof(double));
-#endif
+# endif
     *p += 8;
     return result;
 }
+
+#else
+
+string serialise_double(double v){
+    /* 
+     * First bit(msb) -> sign (1 means negative)
+     * next 11 bits -> exponent
+     * last 52 bits -> mantissa
+     * 
+     * frexp gives fraction within the range [0.5, 1)
+     * We multiply it by 2 to change the range to [1.0, 2.0)
+     * and reduce exp by 1, since this is the way doubles
+     * are stored in IEEE-754.
+     *
+     * Conversion of the fractional part of the new mantissa
+     * to bits is done by repeatedly multiplying it by 2,
+     * checking if it is greater than 1, and turning the
+     * corresponding bit on, if it is.
+     * 
+     */
+    uint64_t result = 0;
+
+    bool negative = (v < 0.0);
+    if (negative) {
+	v = -v;
+	result |= (uint64_t)1 << 63;
+    }
+
+    int exp;
+    v = frexp(v, &exp);
+    v *= 2.0;
+
+    if (exp == 0 && v == 0.0) {
+	result = 0;
+	return string(reinterpret_cast<const char *>(&result), sizeof(uint64_t));
+    }
+
+    exp += 1022;
+
+    result |= (uint64_t)exp << 52;
+
+    // mantissa bit pointer
+    uint64_t mbp = (uint64_t)1 << 51;
+
+    v -= 1.0;
+
+    for (int i = 51; i >= 0; --i) {
+	v *= 2.0;
+	if (v >= 1.0) {
+	    result |= mbp;
+	    v -= 1.0;
+	}
+	mbp >>= 1;
+    }
+
+# ifdef WORDS_BIGENDIAN
+    result = do_bswap(result);
+# endif
+
+    return string(reinterpret_cast<const char *>(&result), sizeof(uint64_t));
+}
+
+double unserialise_double(const char ** p, const char * end) {
+    if (end - *p < 8) {
+	throw Xapian::SerialisationError(
+	    "Bad encoded double: insufficient data");
+    }
+    unsigned char first = *(*p + 7); // little-endian stored
+    unsigned char second = *(*p + 6);
+
+    bool negative = (first & (0x80)) != 0;
+
+    // bitwise operations to extract exponent
+    int exp = (first & (0x80 - 1));
+    exp <<= 4;
+    exp |= (second & (15 << 4)) >> 4;
+    exp -= 1023;
+
+    double mantissa = 1.0; //implicit 1 in IEEE
+    double pows2 = 0.5; // powers of 2
+
+    int second_byte_counter = 1 << 3;
+    for (int i = 0; i < 4; ++i) {
+	if (second & second_byte_counter) mantissa += pows2;
+	pows2 /= 2.0;
+	second_byte_counter >>= 1;
+    }
+
+    int byte_counter = 5; // starting with the third byte onwards
+    while (byte_counter >= 0) {
+	unsigned char cur_byte = *(*p + byte_counter);
+	--byte_counter;
+	int cur_byte_counter = 1 << 7;
+	for (int i = 0; i < 8; ++i) {
+	    if(cur_byte & cur_byte_counter) mantissa += pows2;
+	    pows2 /= 2.0;
+	    cur_byte_counter >>= 1;
+	}
+    }
+
+    *p += 8;
+
+    if (exp + 1023 == 0 && mantissa == 1.0) return 0.0;
+
+# if FLT_RADIX == 2
+    double result = scalbn(mantissa, exp);
+# else
+    double result = ldexp(mantissa, exp >> 2);
+# endif
+    if (negative) result = -result;
+    return result;
+}
+
+#endif
 

--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -42,32 +42,32 @@ using namespace std;
 
 string serialise_double(double v)
 {
-    size_t double_size = sizeof(double);
 #ifdef WORDS_BIGENDIAN
     uint64_t temp;
     static_assert(sizeof(temp) == sizeof(v));
-    memcpy(&temp, &v, double_size);
+    memcpy(&temp, &v, sizeof(double));
     temp = do_bswap(temp);
-    return string(reinterpret_cast<const char *>(&temp), double_size);
+    return string(reinterpret_cast<const char *>(&temp), sizeof(double));
+#else
+    return string(reinterpret_cast<const char *>(&v), sizeof(double));
 #endif
-    return string(reinterpret_cast<const char *>(&v), double_size);
 }
 
 double unserialise_double(const char ** p, const char * end)
 {
     if (end - *p < 8) {
-		throw Xapian::SerialisationError(
-				"Bad encoded double: insufficient data");
+	throw Xapian::SerialisationError(
+	    "Bad encoded double: insufficient data");
     }
-    size_t double_size = sizeof(double);
     double result;
-    memcpy(&result, *p, double_size);
 #ifdef WORDS_BIGENDIAN
     uint64_t temp;
-    static_assert(sizeof(temp) == sizeof(result));
-    memcpy(&temp, &result, double_size)
+    static_assert(sizeof(temp) == sizeof(double));
+    memcpy(&temp, *p, sizeof(double));
     temp = do_bswap(temp);
-    memcpy(&result, &temp, double_size);
+    memcpy(&result, &temp, sizeof(double));
+#else
+    memcpy(&result, *p, sizeof(double));
 #endif
     *p += 8;
     return result;

--- a/xapian-core/common/serialise-double.cc
+++ b/xapian-core/common/serialise-double.cc
@@ -96,13 +96,13 @@ string serialise_double(double v){
      * double.
      */
 
-    static_assert((uint64_t)1 << 52 <= numeric_limits<double>::max(),
+    static_assert(uint64_t(1) << 52 < numeric_limits<double>::max(),
 		  "Check if 2^52 can be represented by a double");
 
     uint64_t result = 0;
 
     if (v == 0.0) {
-	result = 0.0;
+	result = 0;
 	return string(reinterpret_cast<const char *>(&result),
 		      sizeof(uint64_t));
     }
@@ -110,23 +110,16 @@ string serialise_double(double v){
     bool negative = (v < 0.0);
     if (negative) {
 	v = -v;
-	result |= (uint64_t)1 << 63;
+	result |= uint64_t(1) << 63;
     }
 
     int exp;
     v = frexp(v, &exp);
-
-    if (exp == 0 && v == 0.0) {
-	result = 0.0;
-	return string(reinterpret_cast<const char *>(&result),
-		      sizeof(uint64_t));
-    }
-
     v *= 2.0;
     v -= 1.0;
     exp += 1022;
 
-    result |= (uint64_t)exp << 52;
+    result |= uint64_t(exp) << 52;
 
 # if FLT_RADIX == 2
     double scaled_v = scalbn(v, 52);

--- a/xapian-core/common/wordaccess.h
+++ b/xapian-core/common/wordaccess.h
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <type_traits>
+#include <cstring>
 
 #include "alignment_cast.h"
 #include "omassert.h"

--- a/xapian-core/configure.ac
+++ b/xapian-core/configure.ac
@@ -801,7 +801,6 @@ using namespace std;
     [ac_cv_func_snprintf=unknown;break]
   )
 done
-
 AC_MSG_RESULT([$ac_cv_func_snprintf])
 case $ac_cv_func_snprintf in
   no)
@@ -1227,8 +1226,7 @@ using namespace std;
     ]],
     [[
       double a = 2353.3523423;
-      uint64_t bit_pattern =
-      0b0100000010100010011000101011010001100110001101011011111011111111;
+      uint64_t bit_pattern = 0x40A262B46635BEFF;
       if (memcmp(&bit_pattern, &a, sizeof(double)) == 0) return 0;
       return 1;
     ]]

--- a/xapian-core/configure.ac
+++ b/xapian-core/configure.ac
@@ -801,6 +801,7 @@ using namespace std;
     [ac_cv_func_snprintf=unknown;break]
   )
 done
+
 AC_MSG_RESULT([$ac_cv_func_snprintf])
 case $ac_cv_func_snprintf in
   no)
@@ -1214,6 +1215,31 @@ fi
 if test yes = "$enable_log"; then
   AC_DEFINE([XAPIAN_DEBUG_LOG],,
     [Define if you want a log of methods called and other debug messages])
+fi
+
+dnl Check if IEEE-754 is followed for representing floating point numbers by the platform.
+AC_RUN_IFELSE([
+  AC_LANG_PROGRAM(
+    [[
+#include <cstdint>
+#include <cstring>
+using namespace std;
+    ]],
+    [[
+      double a = 2353.3523423;
+      uint64_t bit_pattern =
+      0b0100000010100010011000101011010001100110001101011011111011111111;
+      if (memcmp(&bit_pattern, &a, sizeof(double)) == 0) return 0;
+      return 1;
+    ]]
+  )],
+  [ieee_followed=1],
+  [ieee_followed=0],
+  [ieee_followed=0]
+)
+
+if test "$ieee_followed" = 1; then
+    AC_DEFINE([FOLLOWS_IEEE], [1], [Defined if system uses ieee format to store floating point numbers])
 fi
 
 dnl ******************************


### PR DESCRIPTION
This pull request modifies the serialise_double and unserialise_double functions to use IEEE format.

https://trac.xapian.org/ticket/673