### PR TITLE
Update Vagrantfile to Ubuntu 1804

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ set -e
 echo 'Updating package list.'
 apt-get -qq update
 echo 'Installing required packages (can take a long while the first time).'
-apt-get -yqq install git build-essential m4 perl python zlib1g-dev uuid-dev wget bison tcl libpcre3-dev libmagic-dev doxygen graphviz ghostscript texlive-latex-base texlive-extra-utils texlive-binaries texlive-fonts-extra texlive-fonts-recommended texlive-latex-extra texlive-latex-recommended help2man python-docutils pngcrush mono-devel openjdk-6-jdk lua5.2 liblua5.2-dev php5-dev php5-cli python-dev ruby-dev tcl-dev eatmydata valgrind
+apt-get -yqq install git build-essential m4 perl python zlib1g-dev uuid-dev wget bison tcl libpcre3-dev libmagic-dev valgrind ccache eatmydata doxygen graphviz ghostscript texlive-latex-base texlive-extra-utils texlive-binaries texlive-fonts-extra texlive-fonts-recommended texlive-latex-extra texlive-latex-recommended help2man python-docutils pngcrush python-sphinx python3-sphinx mono-devel default-jdk lua5.2 liblua5.2-dev php-dev php-cli python-dev python3-dev ruby-dev tcl-dev texinfo
 echo 'Upgrading existing packages as needed.'
 apt-get -yqq upgrade
 END
@@ -34,8 +34,7 @@ END
 
 Vagrant.configure("2") do |config|
   config.vm.hostname = "xapian"
-  config.vm.box      = "devfort-ubuntu-13.04-provisionerless"
-  config.vm.box_url  = "http://devfort.s3.amazonaws.com/boxes/devfort-ubuntu-13.04-provisionerless-virtualbox.box"
+  config.vm.box      = "ubuntu/bionic64"
 
   config.vm.provision "shell", inline: $packages
   config.vm.provision "shell", inline: $bootstrap, privileged: false


### PR DESCRIPTION
In the process, update to the latest package names for things like
PHP and Java. Also install the requirements for building PDFs of the
documentation, since it's a one-off cost and may make people's lives
easier (it certainly makes it easier to get people going to not have
to say "oh and if you want X then also install...", and matches the
approach taken in the developer guide more closely).