### PR TITLE
Fix tostring method when a minimum representable value of a particular type is passed

### DIFF
--- a/xapian-core/common/str.cc
+++ b/xapian-core/common/str.cc
@@ -60,16 +60,23 @@ tostring(T value)
     if (value < 10 && value >= 0) return string(1, '0' + char(value));
 
     bool negative = (value < 0);
-    if (negative) value = -value;
 
-    char buf[(sizeof(T) * 5 + 1) / 2 + 1];
+    typedef typename std::make_unsigned<T>::type unsigned_type;
+    unsigned_type val;
+    if (negative) {
+	val = -value;
+    } else {
+	val = value;
+    }
+
+    char buf[(sizeof(unsigned_type) * 5 + 1) / 2 + 1];
     char * p = buf + sizeof(buf);
     do {
 	AssertRel(p,>,buf);
-	char ch = static_cast<char>(value % 10);
-	value /= 10;
+	char ch = static_cast<char>(val % 10);
+	val /= 10;
 	*(--p) = ch + '0';
-    } while (value);
+    } while (val);
 
     if (negative) {
 	AssertRel(p,>,buf);

--- a/xapian-core/common/str.cc
+++ b/xapian-core/common/str.cc
@@ -62,11 +62,9 @@ tostring(T value)
     bool negative = (value < 0);
 
     typedef typename std::make_unsigned<T>::type unsigned_type;
-    unsigned_type val;
+    unsigned_type val(value);
     if (negative) {
-	val = -value;
-    } else {
-	val = value;
+	val = -val;
     }
 
     char buf[(sizeof(unsigned_type) * 5 + 1) / 2 + 1];

--- a/xapian-core/tests/unittest.cc
+++ b/xapian-core/tests/unittest.cc
@@ -536,10 +536,22 @@ static bool test_tostring1()
     TEST_EQUAL(str(-1), "-1");
     TEST_EQUAL(str(-9), "-9");
     TEST_EQUAL(str(-10), "-10");
+    TEST_EQUAL(str(0x7f), "127");
+    TEST_EQUAL(str(-0x80), "-128");
+    TEST_EQUAL(str(0x7fff), "32767");
+    // test for lvalue with minimum value for short type.
+    short temp = -32768;
+    TEST_EQUAL(str(temp), "-32768");
+
     TEST_EQUAL(str(0xffffffff), "4294967295");
     TEST_EQUAL(str(0x7fffffff), "2147483647");
     TEST_EQUAL(str(0x7fffffffu), "2147483647");
-    TEST_EQUAL(str(-0x7fffffff), "-2147483647");
+
+    // test for lvalue with minimum value for int type.
+    int temp1 = -2147483648;
+    TEST_EQUAL(str(temp1), "-2147483648");
+
+    TEST_EQUAL(str(0x7fffffffffffffff), "9223372036854775807");
 
 #ifdef __WIN32__
     /* Test the 64 bit integer conversion to string.

--- a/xapian-core/tests/unittest.cc
+++ b/xapian-core/tests/unittest.cc
@@ -539,14 +539,14 @@ static bool test_tostring1()
     TEST_EQUAL(str(0x7f), "127");
     TEST_EQUAL(str(-0x80), "-128");
     TEST_EQUAL(str(0x7fff), "32767");
-    TEST_EQUAL(str(short(-32768)), "-32768");
+    TEST_EQUAL(str(short(-0x8000)), "-32768");
 
     TEST_EQUAL(str(0xffffffff), "4294967295");
     TEST_EQUAL(str(0x7fffffff), "2147483647");
     TEST_EQUAL(str(0x7fffffffu), "2147483647");
     TEST_EQUAL(str(-0x7fffffff), "-2147483647");
 
-    TEST_EQUAL(str(int(-2147483648)), "-2147483648");
+    TEST_EQUAL(str(int(-0x80000000)), "-2147483648");
 
     TEST_EQUAL(str(0x7fffffffffffffff), "9223372036854775807");
 

--- a/xapian-core/tests/unittest.cc
+++ b/xapian-core/tests/unittest.cc
@@ -523,6 +523,23 @@ static bool test_sortableserialise1()
     return true;
 }
 
+template<typename S>
+inline static void tostring_helper() {
+    const S max_val = numeric_limits<S>::max();
+    const S min_val = numeric_limits<S>::min();
+    tout << "Testing with tostring_helper" << endl;
+    std::ostringstream oss;
+    oss << (long long)max_val;
+    TEST_EQUAL(str(max_val), oss.str());
+    oss.str("");
+    oss.clear();
+
+    oss << (long long)min_val;
+    TEST_EQUAL(str(min_val), oss.str());
+    oss.str("");
+    oss.clear();
+}
+
 static bool test_tostring1()
 {
     TEST_EQUAL(str(0), "0");
@@ -539,26 +556,16 @@ static bool test_tostring1()
     TEST_EQUAL(str(0x7f), "127");
     TEST_EQUAL(str(-0x80), "-128");
     TEST_EQUAL(str(0x7fff), "32767");
-
-    const short min_short = std::numeric_limits<short>::min();
-    std::ostringstream oss;
-    oss << min_short;
-    TEST_EQUAL(str(min_short), oss.str());
-    oss.str("");
-    oss.clear();
-
     TEST_EQUAL(str(0xffffffff), "4294967295");
     TEST_EQUAL(str(0x7fffffff), "2147483647");
     TEST_EQUAL(str(0x7fffffffu), "2147483647");
     TEST_EQUAL(str(-0x7fffffff), "-2147483647");
 
-    const int min_int = std::numeric_limits<int>::min();
-    oss << min_int;
-    TEST_EQUAL(str(min_int), oss.str());
-    oss.str("");
-    oss.clear();
-
-    TEST_EQUAL(str(0x7fffffffffffffff), "9223372036854775807");
+    tostring_helper<char>();
+    tostring_helper<short>();
+    tostring_helper<int>();
+    tostring_helper<long>();
+    tostring_helper<long long>();
 
 #ifdef __WIN32__
     /* Test the 64 bit integer conversion to string.

--- a/xapian-core/tests/unittest.cc
+++ b/xapian-core/tests/unittest.cc
@@ -539,12 +539,25 @@ static bool test_tostring1()
     TEST_EQUAL(str(0x7f), "127");
     TEST_EQUAL(str(-0x80), "-128");
     TEST_EQUAL(str(0x7fff), "32767");
-    TEST_EQUAL(str(short(-0x8000)), "-32768");
+
+    const short min_short = std::numeric_limits<short>::min();
+    std::ostringstream oss;
+    oss << min_short;
+    TEST_EQUAL(str(min_short), oss.str());
+    oss.str("");
+    oss.clear();
+
     TEST_EQUAL(str(0xffffffff), "4294967295");
     TEST_EQUAL(str(0x7fffffff), "2147483647");
     TEST_EQUAL(str(0x7fffffffu), "2147483647");
     TEST_EQUAL(str(-0x7fffffff), "-2147483647");
-    TEST_EQUAL(str(int(-0x80000000)), "-2147483648");
+
+    const int min_int = std::numeric_limits<int>::min();
+    oss << min_int;
+    TEST_EQUAL(str(min_int), oss.str());
+    oss.str("");
+    oss.clear();
+
     TEST_EQUAL(str(0x7fffffffffffffff), "9223372036854775807");
 
 #ifdef __WIN32__

--- a/xapian-core/tests/unittest.cc
+++ b/xapian-core/tests/unittest.cc
@@ -539,17 +539,14 @@ static bool test_tostring1()
     TEST_EQUAL(str(0x7f), "127");
     TEST_EQUAL(str(-0x80), "-128");
     TEST_EQUAL(str(0x7fff), "32767");
-    // test for lvalue with minimum value for short type.
-    short temp = -32768;
-    TEST_EQUAL(str(temp), "-32768");
+    TEST_EQUAL(str(short(-32768)), "-32768");
 
     TEST_EQUAL(str(0xffffffff), "4294967295");
     TEST_EQUAL(str(0x7fffffff), "2147483647");
     TEST_EQUAL(str(0x7fffffffu), "2147483647");
+    TEST_EQUAL(str(-0x7fffffff), "-2147483647");
 
-    // test for lvalue with minimum value for int type.
-    int temp1 = -2147483648;
-    TEST_EQUAL(str(temp1), "-2147483648");
+    TEST_EQUAL(str(int(-2147483648)), "-2147483648");
 
     TEST_EQUAL(str(0x7fffffffffffffff), "9223372036854775807");
 

--- a/xapian-core/tests/unittest.cc
+++ b/xapian-core/tests/unittest.cc
@@ -540,14 +540,11 @@ static bool test_tostring1()
     TEST_EQUAL(str(-0x80), "-128");
     TEST_EQUAL(str(0x7fff), "32767");
     TEST_EQUAL(str(short(-0x8000)), "-32768");
-
     TEST_EQUAL(str(0xffffffff), "4294967295");
     TEST_EQUAL(str(0x7fffffff), "2147483647");
     TEST_EQUAL(str(0x7fffffffu), "2147483647");
     TEST_EQUAL(str(-0x7fffffff), "-2147483647");
-
     TEST_EQUAL(str(int(-0x80000000)), "-2147483648");
-
     TEST_EQUAL(str(0x7fffffffffffffff), "9223372036854775807");
 
 #ifdef __WIN32__


### PR DESCRIPTION
Currently, tostring method fails when a minimum lvalue of a particular signed type is passed. This PR intends to fix that.