### PR TITLE
 #771 Handling iWork directory as a single document 

### DIFF
--- a/xapian-applications/omega/daflist.h
+++ b/xapian-applications/omega/daflist.h
@@ -1,0 +1,8 @@
+#include <string>
+#include <vector>
+
+std::vector<std::string> dasfile { 
+".key", 
+".numbers", 
+".pages" 
+};

--- a/xapian-applications/omega/daflist.h
+++ b/xapian-applications/omega/daflist.h
@@ -1,3 +1,7 @@
+/** @file daflist.h
+ * @brief 'Extensions' of directories to be indexed as files.
+ */
+
 #include <string>
 #include <vector>
 

--- a/xapian-applications/omega/daflist.h
+++ b/xapian-applications/omega/daflist.h
@@ -1,8 +1,4 @@
 #include <string>
 #include <vector>
 
-std::vector<std::string> dasfile { 
-".key", 
-".numbers", 
-".pages" 
-};
+std::vector<std::string> dasfile {".key", ".numbers", ".pages"};

--- a/xapian-applications/omega/diritor.h
+++ b/xapian-applications/omega/diritor.h
@@ -148,7 +148,7 @@ class DirectoryIterator {
 	    case DT_DIR: {
 			char * dot_ptr = strrchr(entry->d_name, '.');
 			std::vector<std::string> dasfile {".key", ".numbers", ".pages", "\0"};
-			if(std::find(dasfile.begin(), dasfile.end(), dot_ptr) != array.end())
+			if(std::find(dasfile.begin(), dasfile.end(), dot_ptr) != dasfile.end())
 				return REGULAR_FILE;
 			else return DIRECTORY;
 		}

--- a/xapian-applications/omega/diritor.h
+++ b/xapian-applications/omega/diritor.h
@@ -145,8 +145,13 @@ class DirectoryIterator {
 		break;
 	    case DT_REG:
 		return REGULAR_FILE;
-	    case DT_DIR:
-		return DIRECTORY;
+	    case DT_DIR: {
+			char * dot_ptr = strrchr(entry->d_name, '.');
+			std::vector<std::string> dasfile {".key", ".numbers", ".pages", "\0"};
+			if(std::find(dasfile.begin(), dasfile.end(), dot_ptr) != array.end())
+				return REGULAR_FILE;
+			else return DIRECTORY;
+		}
 #ifdef HAVE_LSTAT
 	    case DT_LNK:
 		if (follow_symlinks) break;

--- a/xapian-applications/omega/diritor.h
+++ b/xapian-applications/omega/diritor.h
@@ -145,13 +145,8 @@ class DirectoryIterator {
 		break;
 	    case DT_REG:
 		return REGULAR_FILE;
-	    case DT_DIR: {
-			char * dot_ptr = strrchr(entry->d_name, '.');
-			std::vector<std::string> dasfile {".key", ".numbers", ".pages", "\0"};
-			if(std::find(dasfile.begin(), dasfile.end(), dot_ptr) != dasfile.end())
-				return REGULAR_FILE;
-			else return DIRECTORY;
-		}
+	    case DT_DIR:
+		return DIRECTORY;
 #ifdef HAVE_LSTAT
 	    case DT_LNK:
 		if (follow_symlinks) break;

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -196,7 +196,7 @@ index_directory(const string &path, const string &url_, size_t depth_limit,
 			const char * pt = strrchr(d.leafname(), '.');
 			if (pt)
 			if (binary_search(dasfile.begin(), dasfile.end(), pt)) {
-            	index_file(file, url, d, mime_map);
+            			index_file(file, url, d, mime_map);
 				break;
 			}
 			size_t new_limit = depth_limit;

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -193,10 +193,10 @@ index_directory(const string &path, const string &url_, size_t depth_limit,
 	    try {
 		switch (d.get_type()) {
 		    case DirectoryIterator::DIRECTORY: {
-			const char * dot_pt = strrchr(d.leafname(), '.');
-			if (dot_ptr)
-			if (binary_search(dasfile.begin(), dasfile.end(), dot_pt)) {
-			index_file(file, url, d, mime_map);
+			const char * pt = strrchr(d.leafname(), '.');
+			if (pt)
+			if (binary_search(dasfile.begin(), dasfile.end(), pt)) {
+                            index_file(file, url, d, mime_map);
 			break;
 			}
 			size_t new_limit = depth_limit;

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -193,7 +193,7 @@ index_directory(const string &path, const string &url_, size_t depth_limit,
 	    try {
 		switch (d.get_type()) {
 		    case DirectoryIterator::DIRECTORY: {
-			char * dot_ptr = strrchr(d.leafname, '.');	
+			char * dot_ptr = strrchr(d.leafname(), '.');	
 			if (dot_ptr && binary_search (dasfile.begin(), dasfile.end(), dot_ptr)) {
 				index_file(file, url, d, mime_map);
 				break;

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -55,6 +55,7 @@
 #include "str.h"
 #include "stringutils.h"
 #include "urlencode.h"
+#include "daflist.h"
 
 #include "gnu_getopt.h"
 
@@ -192,6 +193,11 @@ index_directory(const string &path, const string &url_, size_t depth_limit,
 	    try {
 		switch (d.get_type()) {
 		    case DirectoryIterator::DIRECTORY: {
+			char * dot_ptr = strrchr(d.leafname, '.');	
+			if (dot_ptr && binary_search (dasfile.begin(), dasfile.end(), dot_ptr)) {
+				index_file(file, url, d, mime_map);
+				break;
+			}
 			size_t new_limit = depth_limit;
 			if (new_limit) {
 			    if (--new_limit == 0) continue;
@@ -767,6 +773,8 @@ main(int argc, char **argv)
 	root += start_url;
 	url_encode_path(baseurl, start_url);
     }
+
+	std::sort (dasfile.begin(), dasfile.end());
 
     int exitcode = 1;
     try {

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -195,9 +195,9 @@ index_directory(const string &path, const string &url_, size_t depth_limit,
 		    case DirectoryIterator::DIRECTORY: {
 			const char * pt = strrchr(d.leafname(), '.');
 			if (pt)
-			if (binary_search(dasfile.begin(), dasfile.end(), pt)) {
-			    index_file(file, url, d, mime_map);
-			    break;
+				if (binary_search(dasfile.begin(), dasfile.end(), pt)) {
+					index_file(file, url, d, mime_map);
+					break;
 			}
 			size_t new_limit = depth_limit;
 			if (new_limit) {

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -193,10 +193,11 @@ index_directory(const string &path, const string &url_, size_t depth_limit,
 	    try {
 		switch (d.get_type()) {
 		    case DirectoryIterator::DIRECTORY: {
-			char * dot_ptr = strrchr(d.leafname(), '.');	
-			if (dot_ptr && binary_search (dasfile.begin(), dasfile.end(), dot_ptr)) {
-				index_file(file, url, d, mime_map);
-				break;
+			const char * dot_pt = strrchr(d.leafname(), '.');
+			if (dot_ptr)
+			if (binary_search(dasfile.begin(), dasfile.end(), dot_pt)) {
+			index_file(file, url, d, mime_map);
+			break;
 			}
 			size_t new_limit = depth_limit;
 			if (new_limit) {
@@ -774,7 +775,7 @@ main(int argc, char **argv)
 	url_encode_path(baseurl, start_url);
     }
 
-	std::sort (dasfile.begin(), dasfile.end());
+	sort(dasfile.begin(), dasfile.end());
 
     int exitcode = 1;
     try {

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -195,9 +195,9 @@ index_directory(const string &path, const string &url_, size_t depth_limit,
 		    case DirectoryIterator::DIRECTORY: {
 			const char * pt = strrchr(d.leafname(), '.');
 			if (pt)
-				if (binary_search(dasfile.begin(), dasfile.end(), pt)) {
-					index_file(file, url, d, mime_map);
-					break;
+			if (binary_search(dasfile.begin(), dasfile.end(), pt)) {
+			    index_file(file, url, d, mime_map);
+			    break;
 			}
 			size_t new_limit = depth_limit;
 			if (new_limit) {

--- a/xapian-applications/omega/omindex.cc
+++ b/xapian-applications/omega/omindex.cc
@@ -196,8 +196,8 @@ index_directory(const string &path, const string &url_, size_t depth_limit,
 			const char * pt = strrchr(d.leafname(), '.');
 			if (pt)
 			if (binary_search(dasfile.begin(), dasfile.end(), pt)) {
-                            index_file(file, url, d, mime_map);
-			break;
+            	index_file(file, url, d, mime_map);
+				break;
 			}
 			size_t new_limit = depth_limit;
 			if (new_limit) {


### PR DESCRIPTION
So far most straightforward fix. Leafnames are checked against iWork 'extensions' and d.get_type() returns as files on matching.