### PR TITLE
Fix re-extracting text without modifications

### DIFF
--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -597,7 +597,7 @@ index_update_entry(const string& urlterm,
     time_t lower_ctime = binary_string_to_int(value_lower_ctime);
     time_t upper_mtime = binary_string_to_int(value_upper_mtime);
 
-    if(upper_mtime < mtime || ctime < lower_ctime)
+    if (upper_mtime < mtime || ctime < lower_ctime)
 	return false;
 
     Xapian::Document doc = db.get_document(did);

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -546,7 +546,7 @@ index_add_document(const string & urlterm, time_t last_altered,
 }
 
 static void
-index_ctime_terms(Xapian::Document & doc, DirectoryIterator & d,
+index_ctime_terms(Xapian::Document& doc, DirectoryIterator& d,
 		  time_t mtime, time_t ctime)
 {
     bool inc_tag_added = false;
@@ -554,19 +554,17 @@ index_ctime_terms(Xapian::Document & doc, DirectoryIterator & d,
 	inc_tag_added = true;
 	doc.add_boolean_term("I*");
     } else if (d.is_group_readable()) {
-	const char * group = d.get_group();
+	const char* group = d.get_group();
 	if (group) {
 	    doc.add_boolean_term(string("I#") + group);
 	}
     }
-
-    const char * owner = d.get_owner();
+    const char* owner = d.get_owner();
     if (owner) {
 	doc.add_boolean_term(string("O") + owner);
 	if (!inc_tag_added && d.is_owner_readable())
 	    doc.add_boolean_term(string("I@") + owner);
     }
-
     // Update document mtime and ctime
     doc.add_value(VALUE_LASTMOD,
 		  int_to_binary_string(uint32_t(mtime)));
@@ -574,15 +572,14 @@ index_ctime_terms(Xapian::Document & doc, DirectoryIterator & d,
 	doc.add_value(VALUE_CTIME,
 		      int_to_binary_string(uint32_t(ctime)));
     }
-
 }
 
 /// Update a document without re-extracting text
 static bool
-index_update_entry(const string & urlterm,
-		   DirectoryIterator & d,
-		   Xapian::docid & did,
-		   string & md5)
+index_update_entry(const string& urlterm,
+		   DirectoryIterator& d,
+		   Xapian::docid& did,
+		   string& md5)
 {
     if (!did) {
 	Xapian::PostingIterator p = db.postlist_begin(urlterm);
@@ -594,35 +591,41 @@ index_update_entry(const string & urlterm,
 
     time_t mtime = d.get_mtime();
     time_t ctime = d.get_ctime();
+
+    const string& value_lower_ctime = db.get_value_lower_bound(VALUE_CTIME);
+    const string& value_upper_mtime = db.get_value_upper_bound(VALUE_LASTMOD);
+    time_t lower_ctime = binary_string_to_int(value_lower_ctime);
+    time_t upper_mtime = binary_string_to_int(value_upper_mtime);
+
+    if(upper_mtime < mtime || ctime < lower_ctime)
+	return false;
+
     Xapian::Document doc = db.get_document(did);
-    const string & value_ctime = doc.get_value(VALUE_CTIME);
+    const string& value_ctime = doc.get_value(VALUE_CTIME);
+    const string& value_mtime = doc.get_value(VALUE_LASTMOD);
     time_t doc_ctime = binary_string_to_int(value_ctime);
-    const string & value_mtime = doc.get_value(VALUE_LASTMOD);
     time_t doc_mtime = binary_string_to_int(value_mtime);
 
     if (doc_mtime == mtime && doc_ctime <= ctime) {
-
 	// Check the size of the document
-	const string & value_size = doc.get_value(VALUE_SIZE);
+	const string& value_size = doc.get_value(VALUE_SIZE);
 	off_t doc_size = Xapian::sortable_unserialise(value_size);
 	off_t size = d.get_size();
 	if (size != doc_size)
 	    return false;
-
 	// Check the MD5 of the document
-	const string & text = d.file_to_string();
-	const string & doc_md5 = doc.get_value(VALUE_MD5);
+	const string& text = d.file_to_string();
+	const string& doc_md5 = doc.get_value(VALUE_MD5);
 	md5_string(text, md5);
 	if (doc_md5 != md5)
 	    return false;
-
 	// Here we are sure that the content of the file hasn't change
-
 	if (verbose)
-	    cout << "Updating entry without re-extracting text" << endl;
+	    cout << "Updating " << urlterm
+		 << " without re-extracting text" << endl;
 	// Remove terms from the document
 	Xapian::TermIterator term_iterator = doc.termlist_begin();
-	term_iterator.skip_to("I");// I: term for "can see" permission
+	term_iterator.skip_to("I");
 	while (term_iterator != doc.termlist_end()) {
 	    const string& term = *term_iterator;
 	    if (startswith(term, "I")) {
@@ -633,7 +636,7 @@ index_update_entry(const string & urlterm,
 	    term_iterator++;
 	}
 
-	term_iterator.skip_to("O");// O: Owner
+	term_iterator.skip_to("O");
 	while (term_iterator != doc.termlist_end()) {
 	    const string& term = *term_iterator;
 	    if (startswith(term, "O")) {
@@ -692,7 +695,7 @@ index_mimetype(const string & file, const string & urlterm, const string & url,
 
     // if the ctime has changed but the mtime is unchanged, we can just
     // update the existing Document and avoid having to re-extract text, etc.
-    string md5 = "";
+    string md5;
     if (use_ctime && d.get_ctime() != d.get_mtime()) {
 	if (index_update_entry(urlterm, d, did, md5))
 	    return;
@@ -929,13 +932,13 @@ index_mimetype(const string & file, const string & urlterm, const string & url,
 	    sample = p.sample;
 	    author = p.author;
 	    created = p.created;
-	    if (md5 == "")
+	    if (md5.empty())
 		md5_string(text, md5);
 	} else if (mimetype == "text/plain") {
 	    // Currently we assume that text files are UTF-8 unless they have a
 	    // byte-order mark.
 	    dump = d.file_to_string();
-	    if (md5 == "")
+	    if (md5.empty())
 		md5_string(dump, md5);
 
 	    // Look for Byte-Order Mark (BOM).
@@ -1113,7 +1116,7 @@ index_mimetype(const string & file, const string & urlterm, const string & url,
 	    const string & text = d.file_to_string();
 	    xmlparser.parse_xml(text);
 	    dump = xmlparser.dump;
-	    if (md5 == "")
+	    if (md5.empty())
 		md5_string(text, md5);
 	} else if (mimetype == "application/x-abiword-compressed") {
 	    // FIXME: Implement support for metadata.
@@ -1146,7 +1149,7 @@ index_mimetype(const string & file, const string & urlterm, const string & url,
 	    // Currently we assume that text files are UTF-8 unless they have a
 	    // byte-order mark.
 	    dump = d.file_to_string();
-	    if (md5 == "")
+	    if (md5.empty())
 		md5_string(dump, md5);
 
 	    // Look for Byte-Order Mark (BOM).
@@ -1167,7 +1170,7 @@ index_mimetype(const string & file, const string & urlterm, const string & url,
 	} else if (mimetype == "image/svg+xml") {
 	    SvgParser svgparser;
 	    const string & text = d.file_to_string();
-	    if (md5 == "")
+	    if (md5.empty())
 		md5_string(text, md5);
 	    svgparser.parse(text);
 	    dump = svgparser.dump;
@@ -1201,7 +1204,7 @@ index_mimetype(const string & file, const string & urlterm, const string & url,
 	} else if (mimetype == "application/atom+xml") {
 	    AtomParser atomparser;
 	    const string & text = d.file_to_string();
-	    if (md5 == "")
+	    if (md5.empty())
 		md5_string(text, md5);
 	    atomparser.parse(text);
 	    dump = atomparser.dump;

--- a/xapian-applications/omega/index_file.h
+++ b/xapian-applications/omega/index_file.h
@@ -126,6 +126,10 @@ void
 index_add_document(const std::string & urlterm, time_t last_altered,
 		   Xapian::docid did, const Xapian::Document & doc);
 
+void
+index_ctime_terms(Xapian::Document & doc, DirectoryIterator & d,
+		  const time_t & mtime, const time_t & ctime);
+
 /// Update a document without re-extracting text
 bool
 index_update_entry(const std::string & urlterm,

--- a/xapian-applications/omega/index_file.h
+++ b/xapian-applications/omega/index_file.h
@@ -126,6 +126,12 @@ void
 index_add_document(const std::string & urlterm, time_t last_altered,
 		   Xapian::docid did, const Xapian::Document & doc);
 
+/// Update a document without re-extracting text
+bool
+index_update_entry(const std::string & urlterm,
+		   DirectoryIterator & d,
+		   Xapian::docid & did);
+
 /// Index a file into the database.
 void
 index_mimetype(const std::string & file, const std::string & urlterm,

--- a/xapian-applications/omega/index_file.h
+++ b/xapian-applications/omega/index_file.h
@@ -126,16 +126,6 @@ void
 index_add_document(const std::string & urlterm, time_t last_altered,
 		   Xapian::docid did, const Xapian::Document & doc);
 
-void
-index_ctime_terms(Xapian::Document & doc, DirectoryIterator & d,
-		  const time_t & mtime, const time_t & ctime);
-
-/// Update a document without re-extracting text
-bool
-index_update_entry(const std::string & urlterm,
-		   DirectoryIterator & d,
-		   Xapian::docid & did);
-
 /// Index a file into the database.
 void
 index_mimetype(const std::string & file, const std::string & urlterm,


### PR DESCRIPTION
If ominex is using ctime to check modifications on files, it is possible 
to update the document without re-extracting its text (using mtime).
Trying to solve FIXME comment a line 558 in index_file.cc