### PR TITLE
Add caching for function pointers and fix comments in profiler.c

### DIFF
--- a/xapian-maintainer-tools/profiling/profiler.c
+++ b/xapian-maintainer-tools/profiling/profiler.c
@@ -72,7 +72,7 @@ int open(const char *pathname, int flags, ...)
 {
     int fd;
     if (!cached_function_ptrs[CALL_OPEN]) {
-        cached_function_ptrs[CALL_OPEN] = dlsym(RTLD_NEXT, "open");
+	cached_function_ptrs[CALL_OPEN] = dlsym(RTLD_NEXT, "open");
     }
     if (flags & (O_CREAT | O_TMPFILE)) {
 	va_list args_ptr;
@@ -105,7 +105,7 @@ int open64(const char *pathname, int flags, ...)
 {
     int fd;
     if (!cached_function_ptrs[CALL_OPEN64]) {
-        cached_function_ptrs[CALL_OPEN64] = dlsym(RTLD_NEXT, "open64");
+	cached_function_ptrs[CALL_OPEN64] = dlsym(RTLD_NEXT, "open64");
     }
     if (flags & (O_CREAT | O_TMPFILE)) {
 	va_list args_ptr;
@@ -137,7 +137,7 @@ typedef int (*real_close_t)(int);
 int close(int fd)
 {
     if (!cached_function_ptrs[CALL_CLOSE]) {
-        cached_function_ptrs[CALL_CLOSE] = dlsym(RTLD_NEXT, "close");
+	cached_function_ptrs[CALL_CLOSE] = dlsym(RTLD_NEXT, "close");
     }
     int return_val = ((real_close_t)cached_function_ptrs[CALL_CLOSE])(fd);
     logcall("close(%d) = %d\n", fd, return_val);
@@ -151,7 +151,7 @@ typedef ssize_t (*real_fdatasync_t)(int);
 ssize_t fdatasync(int fd)
 {
     if (!cached_function_ptrs[CALL_FDATASYNC]) {
-        cached_function_ptrs[CALL_FDATASYNC] = dlsym(RTLD_NEXT, "fdatasync");
+	cached_function_ptrs[CALL_FDATASYNC] = dlsym(RTLD_NEXT, "fdatasync");
     }
     ssize_t return_val = ((real_fdatasync_t)cached_function_ptrs[CALL_FDATASYNC])(fd);
     logcall("fdatasync(%d) = %ld\n", fd, return_val);
@@ -165,7 +165,7 @@ typedef ssize_t (*real_fsync_t)(int);
 ssize_t fsync(int fd)
 {
     if (!cached_function_ptrs[CALL_FSYNC]) {
-        cached_function_ptrs[CALL_FSYNC] = dlsym(RTLD_NEXT, "fsync");
+	cached_function_ptrs[CALL_FSYNC] = dlsym(RTLD_NEXT, "fsync");
     }
     ssize_t return_val = ((real_fsync_t)cached_function_ptrs[CALL_FSYNC])(fd);
     logcall("fsync(%d) = %ld\n", fd, return_val);
@@ -179,7 +179,7 @@ typedef ssize_t (*real_pread_t)(int, void *, size_t, off_t);
 ssize_t pread(int fd, void *buf, size_t count, off_t offset)
 {
     if (!cached_function_ptrs[CALL_PREAD]) {
-        cached_function_ptrs[CALL_PREAD] = dlsym(RTLD_NEXT, "pread");
+	cached_function_ptrs[CALL_PREAD] = dlsym(RTLD_NEXT, "pread");
     }
     ssize_t return_val =
 	((real_pread_t)cached_function_ptrs[CALL_PREAD])(fd, buf, count, offset);
@@ -195,7 +195,7 @@ typedef ssize_t (*real_pread64_t)(int, void *, size_t, off_t);
 ssize_t pread64(int fd, void *buf, size_t count, off_t offset)
 {
     if (!cached_function_ptrs[CALL_PREAD64]) {
-        cached_function_ptrs[CALL_PREAD64] = dlsym(RTLD_NEXT, "pread64");
+	cached_function_ptrs[CALL_PREAD64] = dlsym(RTLD_NEXT, "pread64");
     }
     ssize_t return_val =
 	((real_pread64_t)cached_function_ptrs[CALL_PREAD64])(fd, buf, count, offset);
@@ -211,7 +211,7 @@ typedef ssize_t (*real_pwrite_t)(int, const void *, size_t, off_t);
 ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
 {
     if (!cached_function_ptrs[CALL_PWRITE]) {
-        cached_function_ptrs[CALL_PWRITE] = dlsym(RTLD_NEXT, "pwrite");
+	cached_function_ptrs[CALL_PWRITE] = dlsym(RTLD_NEXT, "pwrite");
     }
     ssize_t return_val =
 	((real_pwrite_t)cached_function_ptrs[CALL_PWRITE])(fd, buf, count, offset);
@@ -227,7 +227,7 @@ typedef ssize_t (*real_pwrite64_t)(int, const void *, size_t, off_t);
 ssize_t pwrite64(int fd, const void *buf, size_t count, off_t offset)
 {
     if (!cached_function_ptrs[CALL_PWRITE64]) {
-        cached_function_ptrs[CALL_PWRITE64] = dlsym(RTLD_NEXT, "pwrite64");
+	cached_function_ptrs[CALL_PWRITE64] = dlsym(RTLD_NEXT, "pwrite64");
     }
     ssize_t return_val =
 	((real_pwrite64_t)cached_function_ptrs[CALL_PWRITE64])(fd, buf, count, offset);

--- a/xapian-maintainer-tools/profiling/profiler.c
+++ b/xapian-maintainer-tools/profiling/profiler.c
@@ -40,7 +40,7 @@ enum func{
     CALL_PWRITE64
 };
 
-void *cached_function_ptrs[9] = { NULL };
+static void *cached_function_ptrs[9] = { NULL };
 
 void logcall(const char *format, ...)
 {

--- a/xapian-maintainer-tools/profiling/profiler.c
+++ b/xapian-maintainer-tools/profiling/profiler.c
@@ -170,7 +170,7 @@ ssize_t fsync(int fd)
     if (!cached_function_ptrs[CALL_FSYNC]) {
 	cached_function_ptrs[CALL_FSYNC] = dlsym(RTLD_NEXT, "fsync");
     }
-    ssize_t return_val = 
+    ssize_t return_val =
 	((real_fsync_t)cached_function_ptrs[CALL_FSYNC])(fd);
     logcall("fsync(%d) = %ld\n", fd, return_val);
     return return_val;

--- a/xapian-maintainer-tools/profiling/profiler.c
+++ b/xapian-maintainer-tools/profiling/profiler.c
@@ -28,7 +28,7 @@
 
 static int is_reset = 0;
 
-enum func{
+enum syscalls {
     CALL_OPEN,
     CALL_OPEN64,
     CALL_CLOSE,
@@ -115,7 +115,8 @@ int open64(const char *pathname, int flags, ...)
 	     (pathname, flags, va_arg(args_ptr, mode_t));
 	va_end(args_ptr);
     } else {
-	fd = ((real_open64_t)cached_function_ptrs[CALL_OPEN64])(pathname, flags);
+	fd = ((real_open64_t)cached_function_ptrs[CALL_OPEN64])
+	     (pathname, flags);
     }
     // realpath can set errno
     int saved_errno = errno;
@@ -154,7 +155,8 @@ ssize_t fdatasync(int fd)
     if (!cached_function_ptrs[CALL_FDATASYNC]) {
 	cached_function_ptrs[CALL_FDATASYNC] = dlsym(RTLD_NEXT, "fdatasync");
     }
-    ssize_t return_val = ((real_fdatasync_t)cached_function_ptrs[CALL_FDATASYNC])(fd);
+    ssize_t return_val =
+	((real_fdatasync_t)cached_function_ptrs[CALL_FDATASYNC])(fd);
     logcall("fdatasync(%d) = %ld\n", fd, return_val);
     return return_val;
 }
@@ -168,7 +170,8 @@ ssize_t fsync(int fd)
     if (!cached_function_ptrs[CALL_FSYNC]) {
 	cached_function_ptrs[CALL_FSYNC] = dlsym(RTLD_NEXT, "fsync");
     }
-    ssize_t return_val = ((real_fsync_t)cached_function_ptrs[CALL_FSYNC])(fd);
+    ssize_t return_val = 
+	((real_fsync_t)cached_function_ptrs[CALL_FSYNC])(fd);
     logcall("fsync(%d) = %ld\n", fd, return_val);
     return return_val;
 }
@@ -183,7 +186,8 @@ ssize_t pread(int fd, void *buf, size_t count, off_t offset)
 	cached_function_ptrs[CALL_PREAD] = dlsym(RTLD_NEXT, "pread");
     }
     ssize_t return_val =
-	((real_pread_t)cached_function_ptrs[CALL_PREAD])(fd, buf, count, offset);
+	((real_pread_t)cached_function_ptrs[CALL_PREAD])
+	(fd, buf, count, offset);
     logcall("pread(%d, \"\", %lu, %ld) = %ld\n",
 	    fd, count, offset, return_val);
     return return_val;
@@ -199,7 +203,8 @@ ssize_t pread64(int fd, void *buf, size_t count, off_t offset)
 	cached_function_ptrs[CALL_PREAD64] = dlsym(RTLD_NEXT, "pread64");
     }
     ssize_t return_val =
-	((real_pread64_t)cached_function_ptrs[CALL_PREAD64])(fd, buf, count, offset);
+	((real_pread64_t)cached_function_ptrs[CALL_PREAD64])
+	(fd, buf, count, offset);
     logcall("pread(%d, \"\", %lu, %ld) = %ld\n",
 	    fd, count, offset, return_val);
     return return_val;
@@ -215,7 +220,8 @@ ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
 	cached_function_ptrs[CALL_PWRITE] = dlsym(RTLD_NEXT, "pwrite");
     }
     ssize_t return_val =
-	((real_pwrite_t)cached_function_ptrs[CALL_PWRITE])(fd, buf, count, offset);
+	((real_pwrite_t)cached_function_ptrs[CALL_PWRITE])
+	(fd, buf, count, offset);
     logcall("pwrite(%d, \"\", %lu, %ld) = %ld\n",
 	    fd, count, offset, return_val);
     return return_val;
@@ -231,7 +237,8 @@ ssize_t pwrite64(int fd, const void *buf, size_t count, off_t offset)
 	cached_function_ptrs[CALL_PWRITE64] = dlsym(RTLD_NEXT, "pwrite64");
     }
     ssize_t return_val =
-	((real_pwrite64_t)cached_function_ptrs[CALL_PWRITE64])(fd, buf, count, offset);
+	((real_pwrite64_t)cached_function_ptrs[CALL_PWRITE64])
+	(fd, buf, count, offset);
     logcall("pwrite(%d, \"\", %lu, %ld) = %ld\n",
 	    fd, count, offset, return_val);
     return return_val;

--- a/xapian-maintainer-tools/profiling/profiler.c
+++ b/xapian-maintainer-tools/profiling/profiler.c
@@ -8,7 +8,7 @@
  * xapian-io-profile script, then use:
  * ./xapian-io-profile --log=log_file_name ./executable
  *
- * Running this library will produce an log file,
+ * Running this library will produce a log file,
  * which can be fed to strace-analyse to produce a log, by running:
  * ./strace-analyse log_file_name
  */
@@ -37,10 +37,11 @@ enum func{
     CALL_PREAD,
     CALL_PREAD64,
     CALL_PWRITE,
-    CALL_PWRITE64
+    CALL_PWRITE64,
+    NUM_CALLS
 };
 
-static void *cached_function_ptrs[9] = { NULL };
+static void *cached_function_ptrs[NUM_CALLS] = { NULL };
 
 void logcall(const char *format, ...)
 {

--- a/xapian-maintainer-tools/profiling/profiler.c
+++ b/xapian-maintainer-tools/profiling/profiler.c
@@ -8,9 +8,9 @@
  * xapian-io-profile script, then use:
  * ./xapian-io-profile --log=log_file_name ./executable
  *
- * Running this library will produce an strace.log file,
+ * Running this library will produce an log file,
  * which can be fed to strace-analyse to produce a log, by running:
- * ./strace-analyse strace.log
+ * ./strace-analyse log_file_name
  */
 
 #define _GNU_SOURCE
@@ -27,6 +27,20 @@
 // function for logging calls
 
 static int is_reset = 0;
+
+enum func{
+    CALL_OPEN,
+    CALL_OPEN64,
+    CALL_CLOSE,
+    CALL_FDATASYNC,
+    CALL_FSYNC,
+    CALL_PREAD,
+    CALL_PREAD64,
+    CALL_PWRITE,
+    CALL_PWRITE64
+};
+
+void *cached_function_ptrs[9] = { NULL };
 
 void logcall(const char *format, ...)
 {
@@ -57,15 +71,17 @@ typedef int (*real_open_t)(const char *, int, ...);
 int open(const char *pathname, int flags, ...)
 {
     int fd;
+    if (!cached_function_ptrs[CALL_OPEN]) {
+        cached_function_ptrs[CALL_OPEN] = dlsym(RTLD_NEXT, "open");
+    }
     if (flags & (O_CREAT | O_TMPFILE)) {
 	va_list args_ptr;
 	va_start(args_ptr, flags);
-	fd =
-	    ((real_open_t)dlsym(RTLD_NEXT, "open"))
-	    (pathname, flags, va_arg(args_ptr, mode_t));
+	fd = ((real_open_t)cached_function_ptrs[CALL_OPEN])
+	     (pathname, flags, va_arg(args_ptr, mode_t));
 	va_end(args_ptr);
     } else {
-	fd = ((real_open_t)dlsym(RTLD_NEXT, "open"))(pathname, flags);
+	fd = ((real_open_t)cached_function_ptrs[CALL_OPEN])(pathname, flags);
     }
     // realpath can set errno
     int saved_errno = errno;
@@ -88,15 +104,17 @@ typedef int (*real_open64_t)(const char *, int, ...);
 int open64(const char *pathname, int flags, ...)
 {
     int fd;
+    if (!cached_function_ptrs[CALL_OPEN64]) {
+        cached_function_ptrs[CALL_OPEN64] = dlsym(RTLD_NEXT, "open64");
+    }
     if (flags & (O_CREAT | O_TMPFILE)) {
 	va_list args_ptr;
 	va_start(args_ptr, flags);
-	fd =
-	    ((real_open_t)dlsym(RTLD_NEXT, "open64"))
-	    (pathname, flags, va_arg(args_ptr, mode_t));
+	fd = ((real_open64_t)cached_function_ptrs[CALL_OPEN64])
+	     (pathname, flags, va_arg(args_ptr, mode_t));
 	va_end(args_ptr);
     } else {
-	fd = ((real_open_t)dlsym(RTLD_NEXT, "open64"))(pathname, flags);
+	fd = ((real_open64_t)cached_function_ptrs[CALL_OPEN64])(pathname, flags);
     }
     // realpath can set errno
     int saved_errno = errno;
@@ -118,7 +136,10 @@ typedef int (*real_close_t)(int);
 
 int close(int fd)
 {
-    int return_val = ((real_close_t)dlsym(RTLD_NEXT, "close"))(fd);
+    if (!cached_function_ptrs[CALL_CLOSE]) {
+        cached_function_ptrs[CALL_CLOSE] = dlsym(RTLD_NEXT, "close");
+    }
+    int return_val = ((real_close_t)cached_function_ptrs[CALL_CLOSE])(fd);
     logcall("close(%d) = %d\n", fd, return_val);
     return return_val;
 }
@@ -129,7 +150,10 @@ typedef ssize_t (*real_fdatasync_t)(int);
 
 ssize_t fdatasync(int fd)
 {
-    ssize_t return_val = ((real_fdatasync_t)dlsym(RTLD_NEXT, "fdatasync"))(fd);
+    if (!cached_function_ptrs[CALL_FDATASYNC]) {
+        cached_function_ptrs[CALL_FDATASYNC] = dlsym(RTLD_NEXT, "fdatasync");
+    }
+    ssize_t return_val = ((real_fdatasync_t)cached_function_ptrs[CALL_FDATASYNC])(fd);
     logcall("fdatasync(%d) = %ld\n", fd, return_val);
     return return_val;
 }
@@ -140,7 +164,10 @@ typedef ssize_t (*real_fsync_t)(int);
 
 ssize_t fsync(int fd)
 {
-    ssize_t return_val = ((real_fsync_t)dlsym(RTLD_NEXT, "fsync"))(fd);
+    if (!cached_function_ptrs[CALL_FSYNC]) {
+        cached_function_ptrs[CALL_FSYNC] = dlsym(RTLD_NEXT, "fsync");
+    }
+    ssize_t return_val = ((real_fsync_t)cached_function_ptrs[CALL_FSYNC])(fd);
     logcall("fsync(%d) = %ld\n", fd, return_val);
     return return_val;
 }
@@ -151,8 +178,11 @@ typedef ssize_t (*real_pread_t)(int, void *, size_t, off_t);
 
 ssize_t pread(int fd, void *buf, size_t count, off_t offset)
 {
+    if (!cached_function_ptrs[CALL_PREAD]) {
+        cached_function_ptrs[CALL_PREAD] = dlsym(RTLD_NEXT, "pread");
+    }
     ssize_t return_val =
-	((real_pread_t)dlsym(RTLD_NEXT, "pread"))(fd, buf, count, offset);
+	((real_pread_t)cached_function_ptrs[CALL_PREAD])(fd, buf, count, offset);
     logcall("pread(%d, \"\", %lu, %ld) = %ld\n",
 	    fd, count, offset, return_val);
     return return_val;
@@ -164,8 +194,11 @@ typedef ssize_t (*real_pread64_t)(int, void *, size_t, off_t);
 
 ssize_t pread64(int fd, void *buf, size_t count, off_t offset)
 {
+    if (!cached_function_ptrs[CALL_PREAD64]) {
+        cached_function_ptrs[CALL_PREAD64] = dlsym(RTLD_NEXT, "pread64");
+    }
     ssize_t return_val =
-	((real_pread64_t)dlsym(RTLD_NEXT, "pread64"))(fd, buf, count, offset);
+	((real_pread64_t)cached_function_ptrs[CALL_PREAD64])(fd, buf, count, offset);
     logcall("pread(%d, \"\", %lu, %ld) = %ld\n",
 	    fd, count, offset, return_val);
     return return_val;
@@ -177,8 +210,11 @@ typedef ssize_t (*real_pwrite_t)(int, const void *, size_t, off_t);
 
 ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
 {
+    if (!cached_function_ptrs[CALL_PWRITE]) {
+        cached_function_ptrs[CALL_PWRITE] = dlsym(RTLD_NEXT, "pwrite");
+    }
     ssize_t return_val =
-	((real_pwrite_t)dlsym(RTLD_NEXT, "pwrite"))(fd, buf, count, offset);
+	((real_pwrite_t)cached_function_ptrs[CALL_PWRITE])(fd, buf, count, offset);
     logcall("pwrite(%d, \"\", %lu, %ld) = %ld\n",
 	    fd, count, offset, return_val);
     return return_val;
@@ -190,8 +226,11 @@ typedef ssize_t (*real_pwrite64_t)(int, const void *, size_t, off_t);
 
 ssize_t pwrite64(int fd, const void *buf, size_t count, off_t offset)
 {
+    if (!cached_function_ptrs[CALL_PWRITE64]) {
+        cached_function_ptrs[CALL_PWRITE64] = dlsym(RTLD_NEXT, "pwrite64");
+    }
     ssize_t return_val =
-	((real_pwrite64_t)dlsym(RTLD_NEXT, "pwrite64"))(fd, buf, count, offset);
+	((real_pwrite64_t)cached_function_ptrs[CALL_PWRITE64])(fd, buf, count, offset);
     logcall("pwrite(%d, \"\", %lu, %ld) = %ld\n",
 	    fd, count, offset, return_val);
     return return_val;


### PR DESCRIPTION
Function pointers are now cached, to prevent
calling dlsym() repeatedly, improving performance.

Comments now refer to the log_file instead of strace.log.