### PR TITLE
Optimize encode_length

### DIFF
--- a/xapian-core/net/length.h
+++ b/xapian-core/net/length.h
@@ -35,23 +35,21 @@ template<class T>
 std::string
 encode_length(T len)
 {
-    std::string result;
-    if (len < 255) {
-	result += static_cast<unsigned char>(len);
-    } else {
-	result += '\xff';
+    char result[12];
+    char* end = result;
+    unsigned char b = static_cast<unsigned char>(len);
+    if (len >= 255) {
+	b = '\xff';
 	len -= 255;
-	while (true) {
-	    unsigned char b = static_cast<unsigned char>(len & 0x7f);
+	do {
+	    *end++ = b;
+	    b = static_cast<unsigned char>(len & 0x7f);
 	    len >>= 7;
-	    if (!len) {
-		result += char(b | static_cast<unsigned char>(0x80));
-		break;
-	    }
-	    result += b;
-	}
+	} while (len);
+	b |= static_cast<unsigned char>(0x80);
     }
-    return result;
+    *end++ = b;
+    return std::string(result, end);
 }
 
 /** Decode a length encoded by encode_length.


### PR DESCRIPTION
Benchmark results are:
```
-----------------------------------------------------------------
Benchmark                          Time           CPU Iterations
-----------------------------------------------------------------
BM_EncodeLength_Original        1684 ns       1681 ns     414721
BM_EncodeLength_Optimized        481 ns        480 ns    1421164
```