### PR TITLE
[perl] Allow subclassing FieldProcessors

### DIFF
--- a/xapian-bindings/perl/perl.i
+++ b/xapian-bindings/perl/perl.i
@@ -1,4 +1,4 @@
-%module xapian
+%module(directors="1") xapian
 %{
 /* perl.i: SWIG interface file for the Perl bindings
  *
@@ -50,6 +50,9 @@ extern "C" {
 
 /* The XS Xapian never wrapped these, and they're now deprecated. */
 #define XAPIAN_BINDINGS_SKIP_DEPRECATED_DB_FACTORIES
+
+/* Use SWIG directors for Perl wrappers. */
+#define XAPIAN_SWIG_DIRECTORS
 
 %include ../xapian-head.i
 

--- a/xapian-bindings/perl/t/parser.t
+++ b/xapian-bindings/perl/t/parser.t
@@ -174,8 +174,11 @@ my $tfp = Testfieldprocessor->new;
 $qp->add_prefix("spam", $tfp);
 $qp->add_boolean_prefix("boolspam", $tfp);
 $qp->add_boolean_prefix("boolspam5", $tfp, undef);
+$qp->add_prefix("spamimplicitref", Testfieldprocessor->new);
+$qp->add_boolean_prefix("boolspamimplicitref", Testfieldprocessor->new);
 $qp->parse_query('spam:ignored');
-#$qp->parse_query('spamimplicitref:ignored');
+$qp->parse_query('spamimplicitref:ignored');
+$qp->parse_query('boolspamimplicitref:ignored');
 eval {
 	$qp->parse_query('spam:spam');
 };

--- a/xapian-bindings/perl/t/parser.t
+++ b/xapian-bindings/perl/t/parser.t
@@ -13,7 +13,7 @@ BEGIN {$SIG{__WARN__} = sub { die "Terminating test due to warning: $_[0]" } };
 
 use Test::More;
 use Devel::Peek;
-BEGIN { plan tests => 75 };
+BEGIN { plan tests => 79 };
 use Xapian qw(:standard);
 ok(1); # If we made it this far, we're ok.
 
@@ -184,6 +184,18 @@ eval {
 };
 ok($@);
 ok($@ =~ /already spam/);
+$qp->add_prefix("spamsubref", sub { die "subcalled"; });
+eval {
+    $qp->parse_query('spamsubref:ignored');
+};
+ok($@);
+ok($@ =~ /subcalled/);
+$qp->add_prefix("spamboolsubref", sub { die "boolsubcalled"; });
+eval {
+    $qp->parse_query('spamboolsubref:ignored');
+};
+ok($@);
+ok($@ =~ /boolsubcalled/);
 
 # Regression test for Search::Xapian bug fixed in 1.0.5.0.  In 1.0.0.0-1.0.4.0
 # we tried to catch const char * not Xapian::Error, so std::terminate got

--- a/xapian-bindings/perl/util.i.in
+++ b/xapian-bindings/perl/util.i.in
@@ -713,6 +713,24 @@ may be a different (nearby) value on other platforms.
 
 =back
 
+=head1 Extensions of the perl bindings over plain C++-Api
+
+=over 4
+
+=item L<Xapian::QueryParser::add_prefix> and L<Xapian::QueryParser::add_boolean_prefix>
+
+In addition to the standard overloaded variants generated from C++, these
+methods allow passing a perl coderef in the place of a manually created
+L<Xapian::FieldProcessor> instance. The sub will automatically be wrapped.
+
+    my $qp = new Xapian::QueryParser();
+    $qp->add_prefix("myprefix", sub {
+        my ($s) = @_;
+        # Do stuff, e.g. return a Xapian::Query instance...
+    });
+
+=back
+
 =head1 TODO
 
 =over 4


### PR DESCRIPTION
This pullrequest allows to subclass FieldProcessors within perl and encompasses two steps:
  1. Enable generation of SWIG director classes for the perl bindings
  2. Perform manual refcounting for the FieldProcessor instances by generating shadow-instances for `Xapian::QueryParser::{add_prefix,add_boolean_prefix}`

The third commit makes handling these instances more convenient by allowing the user to pass subroutine references in the place of FieldProcessors to the above functions.

The first two commits should hopefully be ready to be merged "as is" and represent more of a bugfix than new functionality. The third commit represents a suggestion to the perl-api and as such should be discussed in isolation and I do not have too strong feelings about it, so feel free to discard that one.

Note on commit 3: As far as I can see, results from `Xapian::FieldProcessor::__call__` need to be refcounted as well, to prohibit that they get garbagecollected before the C++-code might call back into the returned Query instances. I've tried to do so in tne `Xapian::FieldProcessor::AutomaticCodeWrapper`, however I'm not really sure whether the lifetime of the FieldProcessor-Object I have attachted the reference to actually surpasses the desired one of the Query-Object, so a review of that portion of code by someone with a better understanding of the codebase would be especially welcome.

A special "thank you" should be given to Olly for his help and patience during development of this bugfix, I would not have managed without the help, so thank you :)