### PR TITLE
Add testcases for feature related api's

### DIFF
--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -938,8 +938,9 @@ DEFINE_TESTCASE(createfeaturevector_tffeature, generated)
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
-    // As the feature values depend on "title","body" and "whole",
-    // we need to seperate it out instead of just writing Query("score").
+    // As the feature values depend on different prefixed terms in the query
+    // like "title","body" and "whole", so we need to separate it out instead
+    // of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -1016,8 +1017,9 @@ DEFINE_TESTCASE(createfeaturevector_idffeature, generated)
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
-    // As the feature values depend on "title","body" and "whole",
-    // we need to seperate it out instead of just writing Query("score").
+    // As the feature values depend on different prefixed terms in the query
+    // like "title","body" and "whole", so we need to separate it out instead
+    // of just writing Query("score").
     string querystring = "title:tigers description:tigers tigers"
 			 " title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
@@ -1092,8 +1094,9 @@ DEFINE_TESTCASE(createfeaturevector_tfdoclenfeature, generated)
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
-    // As the feature values depend on "title","body" and "whole",
-    // we need to seperate it out instead of just writing Query("score").
+    // As the feature values depend on different prefixed terms in the query
+    // like "title","body" and "whole", so we need to separate it out instead
+    // of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -1172,8 +1175,9 @@ DEFINE_TESTCASE(createfeaturevector_colltfcolllenfeature, generated)
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
-    // As the feature values depend on "title","body" and "whole",
-    // we need to seperate it out instead of just writing Query("score").
+    // As the feature values depend on different prefixed terms in the query
+    // like "title","body" and "whole", so we need to separate it out instead
+    // of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -1251,8 +1255,9 @@ DEFINE_TESTCASE(createfeaturevector_tfidfdoclenfeature, generated)
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
-    // As the feature values depend on "title","body" and "whole",
-    // we need to seperate it out instead of just writing Query("score").
+    // As the feature values depend on different prefixed terms in the query
+    // like "title","body" and "whole", so we need to separate it out instead
+    // of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -1329,8 +1334,9 @@ DEFINE_TESTCASE(createfeaturevector_tfdoclencolllfcolllen, generated)
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
-    // As the feature values depend on "title","body" and "whole",
-    // we need to seperate it out instead of just writing Query("score").
+    // As the feature values depend on different prefixed terms in the query
+    // like "title","body" and "whole", so we need to separate it out instead
+    // of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -156,6 +156,57 @@ db_index_three_documents(Xapian::WritableDatabase& db, const string&)
     db.add_document(doc);
 }
 
+// To check for three documents in which one has no common terms with other two.
+static void
+db_index_three_documents_no_common(Xapian::WritableDatabase& db, const string&)
+{
+    Xapian::Document doc;
+    Xapian::TermGenerator termgenerator;
+    termgenerator.set_document(doc);
+    termgenerator.set_stemmer(Xapian::Stem("en"));
+    termgenerator.index_text("The will", 1, "S");
+    termgenerator.index_text("The will are considered stop words in xapian and "
+			     "would be thrown off, so the query I want to say "
+			     "is score, yes, score. The Score of a game is "
+			     "the determining factor of a game, the score is "
+			     "what matters at the end of the day. so my advise "
+			     "to everyone is to Score it!.", 1, "XD");
+    termgenerator.index_text("Score might be something else too, but this para "
+			     "refers to score only at an abstract. Scores are "
+			     "in general scoring. Score it!");
+    termgenerator.increase_termpos();
+    termgenerator.index_text("Score score score is important.");
+    db.add_document(doc);
+    doc.clear_terms();
+    termgenerator.index_text("Document has nothing to do with score", 1, "S");
+    termgenerator.index_text("This is just to check if score is given a higher "
+			     "score if it is in the subject or not. Nothing "
+			     "special, just juding scores by the look of it. "
+			     "Some more scores but a bad qrel should be enough "
+			     "to make sure it is ranked down.", 1, "XD");
+    termgenerator.index_text("Score might be something else too, but this para "
+			     "refers to score only at an abstract. Scores are "
+			     "in general scoring. Score it!");
+    termgenerator.increase_termpos();
+    termgenerator.index_text("Score score score is important.");
+    db.add_document(doc);
+    doc.clear_terms();
+    termgenerator.index_text("Tigers are solitary animals", 1, "S");
+    termgenerator.index_text("Might be that only one Tiger is good enough to "
+			     "Take out a ranker, a Tiger is a good way to "
+			     "check if a test is working or Tiger not. Tiger."
+			     "What if the next line contains no Tigers? Would "
+			     "it make a difference to your ranker ?  Tigers  "
+			     "for the win.", 1, "XD");
+    termgenerator.index_text("The will.");
+    termgenerator.increase_termpos();
+    termgenerator.index_text("Tigers would not be caught if one calls out the "
+			     "Tiger from the den. This document is to check if "
+			     "in the massive dataset, you forget the sense of "
+			     "something you would not like to stop.");
+    db.add_document(doc);
+}
+
 DEFINE_TESTCASE(createfeaturevector, generated)
 {
     Xapian::FeatureList fl;
@@ -226,6 +277,36 @@ DEFINE_TESTCASE(emptyfeaturelist, !backend)
 {
     vector<Xapian::Feature*> f;
     TEST_EXCEPTION(Xapian::InvalidArgumentError, Xapian::FeatureList fl(f));
+    return true;
+}
+
+DEFINE_TESTCASE(bigfeaturelist, generated)
+{
+    vector<Xapian::Feature*> f;
+    f.push_back(new Xapian::TfFeature());
+    f.push_back(new Xapian::TfDoclenFeature());
+    f.push_back(new Xapian::IdfFeature());
+    f.push_back(new Xapian::CollTfCollLenFeature());
+    f.push_back(new Xapian::TfIdfDoclenFeature());
+    f.push_back(new Xapian::TfDoclenCollTfCollLenFeature());
+    f.push_back(new Xapian::TfFeature());
+    f.push_back(new Xapian::TfDoclenFeature());
+
+    // pass big feature list.
+    Xapian::FeatureList fl(f);
+    Xapian::Database db = get_database("apitest_checkbigfeaturelist",
+				       db_index_two_documents);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("tigers"));
+    Xapian::MSet mset;
+    mset = enquire.get_mset(0, 10);
+
+    TEST(!mset.empty());
+
+    auto fv = fl.create_feature_vectors(mset, Xapian::Query("tigers"), db);
+    TEST_EQUAL(fv.size(), 2);
+    TEST_EQUAL(fv[0].get_fcount(), 25);
+    TEST_EQUAL(fv[1].get_fcount(), 25);
     return true;
 }
 
@@ -831,5 +912,458 @@ DEFINE_TESTCASE(ndcg_score_test, generated)
     ranker.score(query, qrel, "ListNet_Ranker", "ndcg_score_test.txt", 10);
     TEST(file_exists("ndcg_score_test.txt"));
     unlink("ndcg_score_test.txt");
+    return true;
+}
+
+// Test createfeaturevector method for TfFeature
+DEFINE_TESTCASE(createfeaturevector_tffeature, generated)
+{
+    vector<Xapian::Feature*> f;
+    Xapian::TfFeature* f1 = new Xapian::TfFeature();
+    f.push_back(f1);
+
+    Xapian::FeatureList fl(f);
+    Xapian::Database db = get_database("db_index_three_documents",
+				       db_index_three_documents);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("score"));
+    Xapian::MSet mset;
+    mset = enquire.get_mset(0, 10);
+
+    TEST(!mset.empty());
+
+    Xapian::QueryParser queryparser;
+    queryparser.set_stemmer(Xapian::Stem("en"));
+    queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
+    queryparser.add_prefix("title", "S");
+    queryparser.add_prefix("description", "XD");
+
+    string querystring = "title:score description:score score";
+    Xapian::Query query = queryparser.parse_query(querystring);
+
+    auto fv = fl.create_feature_vectors(mset, query, db);
+    TEST_EQUAL(fv.size(), 2);
+    TEST_EQUAL(fv[0].get_fcount(), 4);
+    TEST_EQUAL(fv[1].get_fcount(), 4);
+
+    vector<double> fvals_doc1 = fv[0].get_fvals();
+    vector<double> fvals_doc2 = fv[1].get_fvals();
+    TEST_EQUAL(fvals_doc1.size(), 4);
+    TEST_EQUAL(fvals_doc2.size(), 4);
+
+    vector<double> test_vals_doc1(4);
+    test_vals_doc1[0] = 0.301029995663981;
+    test_vals_doc1[1] = 1.653212513775344;
+    test_vals_doc1[2] = 1.954242509439325;
+
+    Xapian::MSetIterator it = mset.begin();
+    test_vals_doc1[3] = it.get_weight();
+
+    vector<double> test_vals_doc2(4);
+    test_vals_doc2[0] = 0;
+    test_vals_doc2[1] = 1.732393759822969;
+    test_vals_doc2[2] = 1.732393759822969;
+
+    ++it;
+    test_vals_doc2[3] = it.get_weight();
+
+    double max_val[4];
+    for (int i = 0; i < 4; ++i) {
+	max_val[i] = max(test_vals_doc1[i], test_vals_doc2[i]);
+    }
+
+    // test for title in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[0], test_vals_doc1[0] / max_val[0]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[0], test_vals_doc2[0] / max_val[0]);
+
+    // test for body in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[1], test_vals_doc1[1] / max_val[1]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[1], test_vals_doc2[1] / max_val[1]);
+
+    // test for whole in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[2], test_vals_doc1[2] / max_val[2]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[2], test_vals_doc2[2] / max_val[2]);
+
+    // test for weight in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[3], test_vals_doc1[3] / max_val[3]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[3], test_vals_doc2[3] / max_val[3]);
+
+    return true;
+}
+
+// Test createfeaturevector method for IdfFeature
+DEFINE_TESTCASE(createfeaturevector_idffeature, generated)
+{
+    vector<Xapian::Feature*> f;
+    Xapian::IdfFeature* f1 = new Xapian::IdfFeature();
+    f.push_back(f1);
+
+    Xapian::FeatureList fl(f);
+    Xapian::Database db = get_database("db_index_three_documents",
+				       db_index_three_documents);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("score"));
+    Xapian::MSet mset;
+    mset = enquire.get_mset(0, 10);
+
+    TEST(!mset.empty());
+
+    Xapian::QueryParser queryparser;
+    queryparser.set_stemmer(Xapian::Stem("en"));
+    queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
+    queryparser.add_prefix("title", "S");
+    queryparser.add_prefix("description", "XD");
+
+    string querystring = "title:tigers description:tigers tigers"
+			 " title:score description:score score";
+    Xapian::Query query = queryparser.parse_query(querystring);
+
+    auto fv = fl.create_feature_vectors(mset, query, db);
+    TEST_EQUAL(fv.size(), 2);
+    TEST_EQUAL(fv[0].get_fcount(), 4);
+    TEST_EQUAL(fv[1].get_fcount(), 4);
+
+    vector<double> fvals_doc1 = fv[0].get_fvals();
+    vector<double> fvals_doc2 = fv[1].get_fvals();
+    TEST_EQUAL(fvals_doc1.size(), 4);
+    TEST_EQUAL(fvals_doc2.size(), 4);
+
+    vector<double> test_vals_doc1(4);
+    test_vals_doc1[0] = 0.0;
+    test_vals_doc1[1] = 0.0;
+    test_vals_doc1[2] = 0.0;
+
+    Xapian::MSetIterator it = mset.begin();
+    test_vals_doc1[3] = it.get_weight();
+
+    vector<double> test_vals_doc2(4);
+    test_vals_doc2[0] = 0.0;
+    test_vals_doc2[1] = 0.0;
+    test_vals_doc2[2] = 0.0;
+
+    ++it;
+    test_vals_doc2[3] = it.get_weight();
+
+    double max_weight = max(test_vals_doc1[3], test_vals_doc2[3]);
+
+    // test for title in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[0], 0.0);
+    TEST_EQUAL_DOUBLE(fvals_doc2[0], 0.0);
+
+    // test for body in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[1], 0.0);
+    TEST_EQUAL_DOUBLE(fvals_doc2[1], 0.0);
+
+    // test for whole in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[2], 0.0);
+    TEST_EQUAL_DOUBLE(fvals_doc2[2], 0.0);
+
+    // test for weight in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[3], test_vals_doc1[3] / max_weight);
+    TEST_EQUAL_DOUBLE(fvals_doc2[3], test_vals_doc2[3] / max_weight);
+
+    return true;
+}
+
+// Test createfeaturevector method for TfDoclenFeature
+DEFINE_TESTCASE(createfeaturevector_tfdoclenfeature, generated)
+{
+    vector<Xapian::Feature*> f;
+    Xapian::TfDoclenFeature* f1 = new Xapian::TfDoclenFeature();
+    f.push_back(f1);
+
+    Xapian::FeatureList fl(f);
+    Xapian::Database db = get_database("db_index_three_documents_no_common",
+				       db_index_three_documents_no_common);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("score"));
+    Xapian::MSet mset;
+    mset = enquire.get_mset(0, 10);
+
+    TEST(!mset.empty());
+
+    Xapian::QueryParser queryparser;
+    queryparser.set_stemmer(Xapian::Stem("en"));
+    queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
+    queryparser.add_prefix("title", "S");
+    queryparser.add_prefix("description", "XD");
+
+    string querystring = "title:score description:score score";
+    Xapian::Query query = queryparser.parse_query(querystring);
+
+    auto fv = fl.create_feature_vectors(mset, query, db);
+    TEST_EQUAL(fv.size(), 2);
+    TEST_EQUAL(fv[0].get_fcount(), 4);
+    TEST_EQUAL(fv[1].get_fcount(), 4);
+
+    vector<double> fvals_doc1 = fv[0].get_fvals();
+    vector<double> fvals_doc2 = fv[1].get_fvals();
+    TEST_EQUAL(fvals_doc1.size(), 4);
+    TEST_EQUAL(fvals_doc2.size(), 4);
+
+    vector<double> test_vals_doc1(4);
+    test_vals_doc1[0] = 0.0511525224473813;
+    test_vals_doc1[1] = 0.0323089286738408;
+    test_vals_doc1[2] = 0.0335890631408052;
+
+    Xapian::MSetIterator it = mset.begin();
+    test_vals_doc1[3] = it.get_weight();
+
+    vector<double> test_vals_doc2(4);
+    test_vals_doc2[0] = 0.0;
+    test_vals_doc2[1] = 0.03237347800973529;
+    test_vals_doc2[2] = 0.03200637092048766;
+
+    ++it;
+    test_vals_doc2[3] = it.get_weight();
+
+    double max_val[4];
+    for (int i = 0; i < 4; ++i) {
+	max_val[i] = max(test_vals_doc1[i], test_vals_doc2[i]);
+    }
+
+    // test for title in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[0], test_vals_doc1[0] / max_val[0]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[0], test_vals_doc2[0] / max_val[0]);
+
+    // test for body in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[1], test_vals_doc1[1] / max_val[1]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[1], test_vals_doc2[1] / max_val[1]);
+
+    // test for whole in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[2], test_vals_doc1[2] / max_val[2]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[2], test_vals_doc2[2] / max_val[2]);
+
+    // test for weight in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[3], test_vals_doc1[3] / max_val[3]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[3], test_vals_doc2[3] / max_val[3]);
+
+    return true;
+}
+
+// Test createfeaturevector method for CollTfCollLenFeature
+DEFINE_TESTCASE(createfeaturevector_colltfcolllenfeature, generated)
+{
+    vector<Xapian::Feature*> f;
+    Xapian::CollTfCollLenFeature* f1 = new Xapian::CollTfCollLenFeature();
+    f.push_back(f1);
+
+    Xapian::FeatureList fl(f);
+    Xapian::Database db = get_database("db_index_three_documents_no_common",
+				       db_index_three_documents_no_common);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("score"));
+    Xapian::MSet mset;
+    mset = enquire.get_mset(0, 10);
+
+    TEST(!mset.empty());
+
+    Xapian::QueryParser queryparser;
+    queryparser.set_stemmer(Xapian::Stem("en"));
+    queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
+    queryparser.add_prefix("title", "S");
+    queryparser.add_prefix("description", "XD");
+
+    string querystring = "title:score description:score score";
+    Xapian::Query query = queryparser.parse_query(querystring);
+
+    auto fv = fl.create_feature_vectors(mset, query, db);
+    TEST_EQUAL(fv.size(), 2);
+    TEST_EQUAL(fv[0].get_fcount(), 4);
+    TEST_EQUAL(fv[1].get_fcount(), 4);
+
+    vector<double> fvals_doc1 = fv[0].get_fvals();
+    vector<double> fvals_doc2 = fv[1].get_fvals();
+    TEST_EQUAL(fvals_doc1.size(), 4);
+    TEST_EQUAL(fvals_doc2.size(), 4);
+
+    vector<double> test_vals_doc1(4);
+    test_vals_doc1[0] = 0.45863784902564930;
+    test_vals_doc1[1] = 3.13291481930625260;
+    test_vals_doc1[2] = 4.94672282004904673;
+
+    Xapian::MSetIterator it = mset.begin();
+    test_vals_doc1[3] = it.get_weight();
+
+    vector<double> test_vals_doc2(4);
+    // values will be same as that of the first document
+    test_vals_doc2[0] = 0.45863784902564930;
+    test_vals_doc2[1] = 3.13291481930625260;
+    test_vals_doc2[2] = 4.94672282004904673;
+
+    ++it;
+    test_vals_doc2[3] = it.get_weight();
+
+    double max_val[4];
+    for (int i = 0; i < 4; ++i) {
+	max_val[i] = max(test_vals_doc1[i], test_vals_doc2[i]);
+    }
+
+    // test for title in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[0], test_vals_doc1[0] / max_val[0]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[0], test_vals_doc2[0] / max_val[0]);
+
+    // test for body in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[1], test_vals_doc1[1] / max_val[1]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[1], test_vals_doc2[1] / max_val[1]);
+
+    // test for whole in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[2], test_vals_doc1[2] / max_val[2]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[2], test_vals_doc2[2] / max_val[2]);
+
+    // test for weight in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[3], test_vals_doc1[3] / max_val[3]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[3], test_vals_doc2[3] / max_val[3]);
+
+    return true;
+}
+
+// Test createfeaturevector method for TfIdfDoclenFeature
+DEFINE_TESTCASE(createfeaturevector_tfidfdoclenfeature, generated)
+{
+    vector<Xapian::Feature*> f;
+    Xapian::TfIdfDoclenFeature* f1 = new Xapian::TfIdfDoclenFeature();
+    f.push_back(f1);
+
+    Xapian::FeatureList fl(f);
+    Xapian::Database db = get_database("db_index_three_documents",
+				       db_index_three_documents);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("score"));
+    Xapian::MSet mset;
+    mset = enquire.get_mset(0, 10);
+
+    TEST(!mset.empty());
+
+    Xapian::QueryParser queryparser;
+    queryparser.set_stemmer(Xapian::Stem("en"));
+    queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
+    queryparser.add_prefix("title", "S");
+    queryparser.add_prefix("description", "XD");
+
+    string querystring = "title:score description:score score";
+    Xapian::Query query = queryparser.parse_query(querystring);
+
+    auto fv = fl.create_feature_vectors(mset, query, db);
+    TEST_EQUAL(fv.size(), 2);
+    TEST_EQUAL(fv[0].get_fcount(), 4);
+    TEST_EQUAL(fv[1].get_fcount(), 4);
+
+    vector<double> fvals_doc1 = fv[0].get_fvals();
+    vector<double> fvals_doc2 = fv[1].get_fvals();
+    TEST_EQUAL(fvals_doc1.size(), 4);
+    TEST_EQUAL(fvals_doc2.size(), 4);
+
+    vector<double> test_vals_doc1(4);
+    test_vals_doc1[0] = 0.0;
+    test_vals_doc1[1] = 0.0;
+    test_vals_doc1[2] = 0.0;
+
+    Xapian::MSetIterator it = mset.begin();
+    test_vals_doc1[3] = it.get_weight();
+
+    vector<double> test_vals_doc2(4);
+    test_vals_doc2[0] = 0.0;
+    test_vals_doc2[1] = 0.0;
+    test_vals_doc2[2] = 0.0;
+
+    ++it;
+    test_vals_doc2[3] = it.get_weight();
+
+    double max_weight = max(test_vals_doc1[3], test_vals_doc2[3]);
+
+    // test for title in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[0], 0.0);
+    TEST_EQUAL_DOUBLE(fvals_doc2[0], 0.0);
+
+    // test for body in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[1], 0.0);
+    TEST_EQUAL_DOUBLE(fvals_doc2[1], 0.0);
+
+    // test for whole in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[2], 0.0);
+    TEST_EQUAL_DOUBLE(fvals_doc2[2], 0.0);
+
+    // test for weight in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[3], test_vals_doc1[3] / max_weight);
+    TEST_EQUAL_DOUBLE(fvals_doc2[3], test_vals_doc2[3] / max_weight);
+
+    return true;
+}
+
+// Test createfeaturevector method for TfDoclenCollTfCollLenFeature
+DEFINE_TESTCASE(createfeaturevector_tfdoclencolllfcolllen, generated)
+{
+    vector<Xapian::Feature*> f;
+    Xapian::TfDoclenCollTfCollLenFeature* f1 =
+				new Xapian::TfDoclenCollTfCollLenFeature();
+    f.push_back(f1);
+
+    Xapian::FeatureList fl(f);
+    Xapian::Database db = get_database("db_index_three_documents",
+				       db_index_three_documents);
+    Xapian::Enquire enquire(db);
+    enquire.set_query(Xapian::Query("score"));
+    Xapian::MSet mset;
+    mset = enquire.get_mset(0, 10);
+
+    TEST(!mset.empty());
+
+    Xapian::QueryParser queryparser;
+    queryparser.set_stemmer(Xapian::Stem("en"));
+    queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
+    queryparser.add_prefix("title", "S");
+    queryparser.add_prefix("description", "XD");
+
+    string querystring = "title:score description:score score";
+    Xapian::Query query = queryparser.parse_query(querystring);
+
+    auto fv = fl.create_feature_vectors(mset, query, db);
+    TEST_EQUAL(fv.size(), 2);
+    TEST_EQUAL(fv[0].get_fcount(), 4);
+    TEST_EQUAL(fv[1].get_fcount(), 4);
+
+    vector<double> fvals_doc1 = fv[0].get_fvals();
+    vector<double> fvals_doc2 = fv[1].get_fvals();
+    TEST_EQUAL(fvals_doc1.size(), 4);
+    TEST_EQUAL(fvals_doc2.size(), 4);
+
+    vector<double> test_vals_doc1(4);
+    test_vals_doc1[0] = 0.11394335230683678;
+    test_vals_doc1[1] = 0.76130720333102619;
+    test_vals_doc1[2] = 0.90738326700002048;
+
+    Xapian::MSetIterator it = mset.begin();
+    test_vals_doc1[3] = it.get_weight();
+
+    vector<double> test_vals_doc2(4);
+    test_vals_doc2[0] = 0.0;
+    test_vals_doc2[1] = 0.77758890362035493;
+    test_vals_doc2[2] = 0.78786362447009839;
+
+    ++it;
+    test_vals_doc2[3] = it.get_weight();
+
+    double max_val[4];
+    for (int i = 0; i < 4; ++i) {
+	max_val[i] = max(test_vals_doc1[i], test_vals_doc2[i]);
+    }
+
+    // test for title in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[0], test_vals_doc1[0] / max_val[0]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[0], test_vals_doc2[0] / max_val[0]);
+
+    // test for body in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[1], test_vals_doc1[1] / max_val[1]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[1], test_vals_doc2[1] / max_val[1]);
+
+    // test for whole in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[2], test_vals_doc1[2] / max_val[2]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[2], test_vals_doc2[2] / max_val[2]);
+
+    // test for weight in normalized form
+    TEST_EQUAL_DOUBLE(fvals_doc1[3], test_vals_doc1[3] / max_val[3]);
+    TEST_EQUAL_DOUBLE(fvals_doc2[3], test_vals_doc2[3] / max_val[3]);
+
     return true;
 }

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -294,7 +294,7 @@ DEFINE_TESTCASE(bigfeaturelist, generated)
 
     // pass big feature list.
     Xapian::FeatureList fl(f);
-    Xapian::Database db = get_database("apitest_checkbigfeaturelist",
+    Xapian::Database db = get_database("db_index_two_documents",
 				       db_index_two_documents);
     Xapian::Enquire enquire(db);
     enquire.set_query(Xapian::Query("tigers"));
@@ -305,6 +305,8 @@ DEFINE_TESTCASE(bigfeaturelist, generated)
 
     auto fv = fl.create_feature_vectors(mset, Xapian::Query("tigers"), db);
     TEST_EQUAL(fv.size(), 2);
+    // Each feature contributes three values and weight as the default one
+    // making total as 25.
     TEST_EQUAL(fv[0].get_fcount(), 25);
     TEST_EQUAL(fv[1].get_fcount(), 25);
     return true;
@@ -930,14 +932,14 @@ DEFINE_TESTCASE(createfeaturevector_tffeature, generated)
     Xapian::MSet mset;
     mset = enquire.get_mset(0, 10);
 
-    TEST(!mset.empty());
-
     Xapian::QueryParser queryparser;
     queryparser.set_stemmer(Xapian::Stem("en"));
     queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
+    // As the feature values depend on "title","body" and "whole",
+    // we need to seperate it out instead of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -952,6 +954,7 @@ DEFINE_TESTCASE(createfeaturevector_tffeature, generated)
     TEST_EQUAL(fvals_doc2.size(), 4);
 
     vector<double> test_vals_doc1(4);
+    // These are the appropriate TfFeature values for the first document.
     test_vals_doc1[0] = 0.301029995663981;
     test_vals_doc1[1] = 1.653212513775344;
     test_vals_doc1[2] = 1.954242509439325;
@@ -960,6 +963,7 @@ DEFINE_TESTCASE(createfeaturevector_tffeature, generated)
     test_vals_doc1[3] = it.get_weight();
 
     vector<double> test_vals_doc2(4);
+    // These are the appropriate TfFeature values for the second document.
     test_vals_doc2[0] = 0;
     test_vals_doc2[1] = 1.732393759822969;
     test_vals_doc2[2] = 1.732393759822969;
@@ -1006,14 +1010,14 @@ DEFINE_TESTCASE(createfeaturevector_idffeature, generated)
     Xapian::MSet mset;
     mset = enquire.get_mset(0, 10);
 
-    TEST(!mset.empty());
-
     Xapian::QueryParser queryparser;
     queryparser.set_stemmer(Xapian::Stem("en"));
     queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
+    // As the feature values depend on "title","body" and "whole",
+    // we need to seperate it out instead of just writing Query("score").
     string querystring = "title:tigers description:tigers tigers"
 			 " title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
@@ -1029,6 +1033,7 @@ DEFINE_TESTCASE(createfeaturevector_idffeature, generated)
     TEST_EQUAL(fvals_doc2.size(), 4);
 
     vector<double> test_vals_doc1(4);
+    // These are the appropriate IdfFeature values for the first document.
     test_vals_doc1[0] = 0.0;
     test_vals_doc1[1] = 0.0;
     test_vals_doc1[2] = 0.0;
@@ -1037,6 +1042,7 @@ DEFINE_TESTCASE(createfeaturevector_idffeature, generated)
     test_vals_doc1[3] = it.get_weight();
 
     vector<double> test_vals_doc2(4);
+    // These are the appropriate IdfFeature values for the second document.
     test_vals_doc2[0] = 0.0;
     test_vals_doc2[1] = 0.0;
     test_vals_doc2[2] = 0.0;
@@ -1080,14 +1086,14 @@ DEFINE_TESTCASE(createfeaturevector_tfdoclenfeature, generated)
     Xapian::MSet mset;
     mset = enquire.get_mset(0, 10);
 
-    TEST(!mset.empty());
-
     Xapian::QueryParser queryparser;
     queryparser.set_stemmer(Xapian::Stem("en"));
     queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
+    // As the feature values depend on "title","body" and "whole",
+    // we need to seperate it out instead of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -1102,6 +1108,8 @@ DEFINE_TESTCASE(createfeaturevector_tfdoclenfeature, generated)
     TEST_EQUAL(fvals_doc2.size(), 4);
 
     vector<double> test_vals_doc1(4);
+    // These are the appropriate TfDoclenFeature values for the first
+    // document.
     test_vals_doc1[0] = 0.0511525224473813;
     test_vals_doc1[1] = 0.0323089286738408;
     test_vals_doc1[2] = 0.0335890631408052;
@@ -1110,6 +1118,8 @@ DEFINE_TESTCASE(createfeaturevector_tfdoclenfeature, generated)
     test_vals_doc1[3] = it.get_weight();
 
     vector<double> test_vals_doc2(4);
+    // These are the appropriate TfDoclenFeature values for the second
+    // document.
     test_vals_doc2[0] = 0.0;
     test_vals_doc2[1] = 0.03237347800973529;
     test_vals_doc2[2] = 0.03200637092048766;
@@ -1156,14 +1166,14 @@ DEFINE_TESTCASE(createfeaturevector_colltfcolllenfeature, generated)
     Xapian::MSet mset;
     mset = enquire.get_mset(0, 10);
 
-    TEST(!mset.empty());
-
     Xapian::QueryParser queryparser;
     queryparser.set_stemmer(Xapian::Stem("en"));
     queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
+    // As the feature values depend on "title","body" and "whole",
+    // we need to seperate it out instead of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -1178,6 +1188,8 @@ DEFINE_TESTCASE(createfeaturevector_colltfcolllenfeature, generated)
     TEST_EQUAL(fvals_doc2.size(), 4);
 
     vector<double> test_vals_doc1(4);
+    // These are the appropriate CollTfCollLenFeature values for the first
+    // document.
     test_vals_doc1[0] = 0.45863784902564930;
     test_vals_doc1[1] = 3.13291481930625260;
     test_vals_doc1[2] = 4.94672282004904673;
@@ -1233,14 +1245,14 @@ DEFINE_TESTCASE(createfeaturevector_tfidfdoclenfeature, generated)
     Xapian::MSet mset;
     mset = enquire.get_mset(0, 10);
 
-    TEST(!mset.empty());
-
     Xapian::QueryParser queryparser;
     queryparser.set_stemmer(Xapian::Stem("en"));
     queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
+    // As the feature values depend on "title","body" and "whole",
+    // we need to seperate it out instead of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -1255,6 +1267,8 @@ DEFINE_TESTCASE(createfeaturevector_tfidfdoclenfeature, generated)
     TEST_EQUAL(fvals_doc2.size(), 4);
 
     vector<double> test_vals_doc1(4);
+    // These are the appropriate TfIdfDoclenFeature values for the first
+    // document.
     test_vals_doc1[0] = 0.0;
     test_vals_doc1[1] = 0.0;
     test_vals_doc1[2] = 0.0;
@@ -1263,6 +1277,8 @@ DEFINE_TESTCASE(createfeaturevector_tfidfdoclenfeature, generated)
     test_vals_doc1[3] = it.get_weight();
 
     vector<double> test_vals_doc2(4);
+    // These are the appropriate TfIdfDoclenFeature values for the second
+    // document.
     test_vals_doc2[0] = 0.0;
     test_vals_doc2[1] = 0.0;
     test_vals_doc2[2] = 0.0;
@@ -1307,14 +1323,14 @@ DEFINE_TESTCASE(createfeaturevector_tfdoclencolllfcolllen, generated)
     Xapian::MSet mset;
     mset = enquire.get_mset(0, 10);
 
-    TEST(!mset.empty());
-
     Xapian::QueryParser queryparser;
     queryparser.set_stemmer(Xapian::Stem("en"));
     queryparser.set_stemming_strategy(queryparser.STEM_ALL_Z);
     queryparser.add_prefix("title", "S");
     queryparser.add_prefix("description", "XD");
 
+    // As the feature values depend on "title","body" and "whole",
+    // we need to seperate it out instead of just writing Query("score").
     string querystring = "title:score description:score score";
     Xapian::Query query = queryparser.parse_query(querystring);
 
@@ -1329,6 +1345,8 @@ DEFINE_TESTCASE(createfeaturevector_tfdoclencolllfcolllen, generated)
     TEST_EQUAL(fvals_doc2.size(), 4);
 
     vector<double> test_vals_doc1(4);
+    // These are the appropriate TfDoclenCollTfCollLenFeature values for
+    // the first document.
     test_vals_doc1[0] = 0.11394335230683678;
     test_vals_doc1[1] = 0.76130720333102619;
     test_vals_doc1[2] = 0.90738326700002048;
@@ -1337,6 +1355,8 @@ DEFINE_TESTCASE(createfeaturevector_tfdoclencolllfcolllen, generated)
     test_vals_doc1[3] = it.get_weight();
 
     vector<double> test_vals_doc2(4);
+    // These are the appropriate TfDoclenCollTfCollLenFeature values for
+    // the second document.
     test_vals_doc2[0] = 0.0;
     test_vals_doc2[1] = 0.77758890362035493;
     test_vals_doc2[2] = 0.78786362447009839;


### PR DESCRIPTION
These include unit testcases for the 4 features such as TfFeature,IdfFeature, TfIdfDoclenFeature,TfDoclenCollTfCollLenFeature.Additionally it includes test
for FeatureList class which includes testing an empty featurelist and a
featurelist containing more than it's default features and also for generating
a database with three documents in which one has no common terms with other two.
Also consists of testing the output of create_feature_vetors method for all six
features like TfIdfDoclenFeature etc.