### PR TITLE
Moved GlassVersion constructor to .cc file

### DIFF
--- a/xapian-core/backends/glass/glass_version.cc
+++ b/xapian-core/backends/glass/glass_version.cc
@@ -70,6 +70,15 @@ static const char GLASS_VERSION_MAGIC[GLASS_VERSION_MAGIC_AND_VERSION_LEN] = {
     char((GLASS_FORMAT_VERSION >> 8) & 0xff), char(GLASS_FORMAT_VERSION & 0xff)
 };
 
+GlassVersion::GlassVersion(const std::string & db_dir_)
+    : rev(0), fd(-1), offset(0), db_dir(db_dir_), changes(NULL),
+      doccount(0), total_doclen(0), last_docid(0),
+      doclen_lbound(0), doclen_ubound(0),
+      wdf_ubound(0), spelling_wordfreq_ubound(0),
+      oldest_changeset(0)
+{
+}
+
 GlassVersion::GlassVersion(int fd_)
     : rev(0), fd(fd_), offset(0), db_dir(), changes(NULL),
       doccount(0), total_doclen(0), last_docid(0),

--- a/xapian-core/backends/glass/glass_version.h
+++ b/xapian-core/backends/glass/glass_version.h
@@ -157,12 +157,7 @@ class GlassVersion {
     void unserialise_stats();
 
   public:
-    explicit GlassVersion(const std::string & db_dir_ = std::string())
-	: rev(0), fd(-1), offset(0), db_dir(db_dir_), changes(NULL),
-	  doccount(0), total_doclen(0), last_docid(0),
-	  doclen_lbound(0), doclen_ubound(0),
-	  wdf_ubound(0), spelling_wordfreq_ubound(0),
-	  oldest_changeset(0) { }
+    explicit GlassVersion(const std::string & db_dir_ = std::string());
 
     explicit GlassVersion(int fd_);
 


### PR DESCRIPTION
This was the cause for a runtime crash on windows when using
clang-cl and MSVC due to an empty db_dir.
This seems like a compiler bug (the initialization in the header file should be ok I think), so this would be a workaround for that bug.

Please note that the same patch would apply to the 1.4 branch.

Let me know if you are interested in upstreaming this.

The backtrace looks like this:
```
00 KERNELBASE!RaiseException+0x68
01 VCRUNTIME140!_CxxThrowException(void * pExceptionObject = 0x000000fb`1a2f7ff0, struct _s__ThrowInfo * pThrowInfo = <Value unavailable error>)+0xc2 [f:\dd\vctools\crt\vcruntime\src\eh\throw.cpp @ 136] 
02 MSVCP140!std::_Xlength_error(char * _Message = <Value unavailable error>)+0x22 [f:\dd\vctools\crt\crtw32\stdcpp\xthrow.cpp @ 18] 
03 libxapian!std::basic_string<char,std::char_traits<char>,std::allocator<char> >::_Xlen(void)+0x10 [C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\include\xstring @ 3711] 
04 libxapian!std::basic_string<char,std::char_traits<char>,std::allocator<char> >::_Reallocate_for<`lambda at C:\Program Files (unsigned int64 _New_size = 0xbaadf00d`baadf00d, char * _Args = 0x00000000`00000000 "")+0x12a [C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\include\xstring @ 3598] 
05 libxapian!std::basic_string<char,std::char_traits<char>,std::allocator<char> >::assign+0x18 (Inline Function @ 00007ffe`96d6b19b) [C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\include\xstring @ 2429] 
06 libxapian!std::basic_string<char,std::char_traits<char>,std::allocator<char> >::operator=+0x32 (Inline Function @ 00007ffe`96d6b19b) [C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\include\xstring @ 2252] 
07 libxapian!GlassVersion::write(unsigned int new_rev = 0, int flags = 0n0)+0x26b [C:\Users\User\CraftRoot\build\win32libs\xapian-core\work\xapian-core-1.4.5\backends\glass\glass_version.cc @ 287] 
08 libxapian!GlassDatabase::create_and_open_tables(int flags = 0n0, unsigned int block_size = <Value unavailable error>)+0x4a [C:\Users\User\CraftRoot\build\win32libs\xapian-core\work\xapian-core-1.4.5\backends\glass\glass_database.cc @ 208] 
09 libxapian!GlassDatabase::GlassDatabase(class std::basic_string<char,std::char_traits<char>,std::allocator<char> > * glass_dir = <Value unavailable error>, int flags = 0n0, unsigned int block_size = 0x2000)+0x3c3 [C:\Users\User\CraftRoot\build\win32libs\xapian-core\work\xapian-core-1.4.5\backends\glass\glass_database.cc @ 144] 
0a libxapian!GlassWritableDatabase::GlassWritableDatabase(class std::basic_string<char,std::char_traits<char>,std::allocator<char> > * dir = <Value unavailable error>, int flags = <Value unavailable error>, int block_size = <Value unavailable error>)+0x1f [C:\Users\User\CraftRoot\build\win32libs\xapian-core\work\xapian-core-1.4.5\backends\glass\glass_database.cc @ 1007] 
0b libxapian!Xapian::WritableDatabase::WritableDatabase(class std::basic_string<char,std::char_traits<char>,std::allocator<char> > * path = 0x000000fb`1a2f88f8 "C:/Users/User/AppData/Local/sink/storage/{764ccfd8-68f6-4568-9e1d-6d1f92f8dd6c}/data/fulltext", int flags = 0n0, int block_size = 0n0)+0x94 [C:\Users\User\CraftRoot\build\win32libs\xapian-core\work\xapian-core-1.4.5\backends\dbfactory.cc @ 515] 
0c sink!FulltextIndex::FulltextIndex(class QByteArray * resourceInstanceIdentifier = <Value unavailable error>, Sink::Storage::DataStore::AccessMode accessMode = <Value unavailable error>)+0x1a3 [C:\Users\User\CraftRoot\download\git\extragear\sink\common\fulltextindex.cpp @ 36] 
```