### PR TITLE
Throw DatabaseNotFoundError when DB doesn't exist

### DIFF
--- a/xapian-core/backends/dbfactory.cc
+++ b/xapian-core/backends/dbfactory.cc
@@ -194,7 +194,11 @@ Database::Database(const string& path, int flags)
 
     struct stat statbuf;
     if (stat(path.c_str(), &statbuf) == -1) {
-	throw DatabaseOpeningError("Couldn't stat '" + path + "'", errno);
+	if (errno == ENOENT) {
+	    throw DatabaseNotFoundError("Couldn't stat '" + path + "'", errno);
+	} else {
+	    throw DatabaseOpeningError("Couldn't stat '" + path + "'", errno);
+	}
     }
 
     if (S_ISREG(statbuf.st_mode)) {
@@ -268,7 +272,7 @@ Database::Database(const string& path, int flags)
 	throw FeatureUnavailableError("Flint backend no longer supported");
     }
 
-    throw DatabaseOpeningError("Couldn't detect type of database");
+    throw DatabaseNotFoundError("Couldn't detect type of database");
 }
 
 /** Helper factory function.


### PR DESCRIPTION
Regarding https://trac.xapian.org/ticket/773, and after having been actively using the `DatabaseNotFoundError` for a while, this is what I've found are the two missing points where Xapian should throw `DatabaseNotFoundError` instead of `DatabaseOpeningError`.