### PR TITLE
bootstrap: Adding pkg.m4 directory on Mac OS.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -637,6 +637,10 @@ aclocal_system_needed=
 if [ ! -r "$aclocal_ac_dir/pkg.m4" ] ; then
   if [ -r /usr/share/aclocal/pkg.m4 ] ; then
     aclocal_system_needed=/usr/share/aclocal
+  elif [ -r /usr/local/share/aclocal/pkg.m4 ] ; then
+    aclocal_system_needed=/usr/local/share/aclocal
+  elif [ -r /opt/local/share/aclocal/pkg.m4 ] ; then
+    aclocal_system_needed=/opt/local/share/aclocal
   fi
 fi
 

--- a/xapian-core/HACKING
+++ b/xapian-core/HACKING
@@ -64,7 +64,7 @@ On Mac OS X, if you're using macports you'll want the following:
 
 If you're using homebrew you'll want the following::
 
-    brew install libmagic pcre
+    brew install libmagic pcre pkgconfig
 
 If you're doing much development work, you'll probably also want the following
 tools installed:


### PR DESCRIPTION
 Currently, if aclocal is installed by bootstrap, it will try to find pkg.m4 at /usr/share/aclocal. However, if we are on Mac OS it is necessary to add /usr/local/share/aclocal and /opt/local/share/aclocal. If pkg-config was installed with homebrew, pkg.m4 would be at /usr/local/share/aclocal. But if it was installed with darwing ports we need /opt/local/share/aclocal.