### PR TITLE
Fix memory leak in createfeature_vector method

### DIFF
--- a/xapian-letor/api/featurelist.cc
+++ b/xapian-letor/api/featurelist.cc
@@ -50,9 +50,12 @@ FeatureList::FeatureList() : internal(new FeatureList::Internal())
 }
 
 FeatureList::FeatureList(const std::vector<Feature*> & f)
-    : internal(new FeatureList::Internal())
 {
     LOGCALL_CTOR(API, "FeatureList", f);
+    if (f.empty()) {
+	throw InvalidArgumentError("FeatureList cannot be empty");
+    }
+    internal = new Internal();
     internal->feature = f;
     for (Feature* it : internal->feature) {
 	internal->stats_needed = Internal::stat_flags(internal->stats_needed |
@@ -108,11 +111,6 @@ FeatureList::create_feature_vectors(const Xapian::MSet & mset,
     LOGCALL(API, std::vector<FeatureVector>, "FeatureList::create_feature_vectors", mset | letor_query | letor_db);
     if (mset.empty())
 	return vector<FeatureVector>();
-
-    if (!internal->feature.empty()) {
-	throw InvalidArgumentError("FeatureList cannot be empty");
-    }
-
     std::vector<FeatureVector> fvec;
 
     for (Xapian::MSetIterator i = mset.begin(); i != mset.end(); ++i) {

--- a/xapian-letor/api/featurelist.cc
+++ b/xapian-letor/api/featurelist.cc
@@ -28,8 +28,8 @@
 #include "featurelist_internal.h"
 #include "feature_internal.h"
 
-#include "omassert.h"
 #include "debuglog.h"
+#include "omassert.h"
 
 using namespace std;
 

--- a/xapian-letor/api/featurelist.cc
+++ b/xapian-letor/api/featurelist.cc
@@ -114,16 +114,18 @@ FeatureList::create_feature_vectors(const Xapian::MSet & mset,
 	Xapian::Document doc = i.get_document();
 	std::vector<double> fvals;
 	internal->set_data(letor_query, letor_db, doc);
-	Feature::Internal* internal_feature = new Feature::Internal(letor_db,
+	if (!internal->feature.empty()) {
+	    Feature::Internal* internal_feature = new Feature::Internal(letor_db,
 								    letor_query,
 								    doc);
-	// Computes and populates the Feature::Internal with required stats.
-	internal->populate_feature_internal(internal_feature);
-	for (Feature* it : internal->feature) {
-	    it->internal = internal_feature;
-	    const vector<double>& values = it->get_values();
-	    // Append feature values
-	    fvals.insert(fvals.end(), values.begin(), values.end());
+	    // Computes and populates the Feature::Internal with required stats.
+	    internal->populate_feature_internal(internal_feature);
+	    for (Feature* it : internal->feature) {
+		it->internal = internal_feature;
+		const vector<double>& values = it->get_values();
+		// Append feature values
+		fvals.insert(fvals.end(), values.begin(), values.end());
+	    }
 	}
 	double wt = i.get_weight();
 	// Weight is added as a feature by default.

--- a/xapian-letor/api/featurelist.cc
+++ b/xapian-letor/api/featurelist.cc
@@ -28,6 +28,7 @@
 #include "featurelist_internal.h"
 #include "feature_internal.h"
 
+#include "omassert.h"
 #include "debuglog.h"
 
 using namespace std;
@@ -112,6 +113,7 @@ FeatureList::create_feature_vectors(const Xapian::MSet & mset,
     if (mset.empty())
 	return vector<FeatureVector>();
     std::vector<FeatureVector> fvec;
+    Assert(!internal->feature.empty());
 
     for (Xapian::MSetIterator i = mset.begin(); i != mset.end(); ++i) {
 	Xapian::Document doc = i.get_document();

--- a/xapian-letor/api/featurelist.cc
+++ b/xapian-letor/api/featurelist.cc
@@ -115,9 +115,8 @@ FeatureList::create_feature_vectors(const Xapian::MSet & mset,
 	std::vector<double> fvals;
 	internal->set_data(letor_query, letor_db, doc);
 	if (!internal->feature.empty()) {
-	    Feature::Internal* internal_feature = new Feature::Internal(letor_db,
-								    letor_query,
-								    doc);
+	    Feature::Internal* internal_feature = new Feature::Internal(
+						  letor_db, letor_query, doc);
 	    // Computes and populates the Feature::Internal with required stats.
 	    internal->populate_feature_internal(internal_feature);
 	    for (Feature* it : internal->feature) {

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -222,7 +222,7 @@ DEFINE_TESTCASE(createfeaturevectorthree, generated)
     return true;
 }
 
-DEFINE_TESTCASE(checkemptyfeaturelist, generated)
+DEFINE_TESTCASE(emptyfeaturelist, !backend)
 {
     vector<Xapian::Feature*> f;
     TEST_EXCEPTION(Xapian::InvalidArgumentError, Xapian::FeatureList fl(f));

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -225,21 +225,7 @@ DEFINE_TESTCASE(createfeaturevectorthree, generated)
 DEFINE_TESTCASE(checkemptyfeaturelist, generated)
 {
     vector<Xapian::Feature*> f;
-    // pass empty feature list.
-    Xapian::FeatureList fl(f);
-    Xapian::Database db = get_database("db_index_two_documents",
-				       db_index_two_documents);
-
-    Xapian::Enquire enquire(db);
-    enquire.set_query(Xapian::Query("tigers"));
-    Xapian::MSet mset;
-    mset = enquire.get_mset(0, 10);
-
-    TEST(!mset.empty());
-
-    TEST_EXCEPTION(Xapian::InvalidArgumentError,
-		   fl.create_feature_vectors(mset, Xapian::Query("tigers"),
-					     db));
+    TEST_EXCEPTION(Xapian::InvalidArgumentError, Xapian::FeatureList fl(f));
     return true;
 }
 

--- a/xapian-letor/tests/api_letor.cc
+++ b/xapian-letor/tests/api_letor.cc
@@ -237,25 +237,9 @@ DEFINE_TESTCASE(checkemptyfeaturelist, generated)
 
     TEST(!mset.empty());
 
-    vector<double> vt;
-    Xapian::MSetIterator i = mset.begin();
-    vt.push_back(i.get_weight());
-    ++i;
-    TEST_NOT_EQUAL(i, mset.end());
-    vt.push_back(i.get_weight());
-    ++i;
-    TEST_EQUAL(i, mset.end());
-    double max_val = max(vt[0], vt[1]);
-
-    auto fv = fl.create_feature_vectors(mset, Xapian::Query("tigers"), db);
-    TEST_EQUAL(fv.size(), 2);
-    // only weight feature of the document will be captured.
-    TEST_EQUAL(fv[0].get_fcount(), 1);
-    TEST_EQUAL(fv[1].get_fcount(), 1);
-
-    // weight will be in normalized form.
-    TEST_EQUAL(fv[0].get_fvals()[0], vt[0] / max_val);
-    TEST_EQUAL(fv[1].get_fvals()[0], vt[1] / max_val);
+    TEST_EXCEPTION(Xapian::InvalidArgumentError,
+		   fl.create_feature_vectors(mset, Xapian::Query("tigers"),
+					     db));
     return true;
 }
 


### PR DESCRIPTION
If there are no features then we still create a new Feature::Internal
but we never assign it anywhere so the reference counting doesn't get
a chance to delete it again.