### PR TITLE
Fix Apple iWork document mimetypes

### DIFF
--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -243,11 +243,11 @@ index_add_default_filters()
 			 PIPE_DEV_STDIN));
     index_command("text/vcard",
 		  Filter(get_pkglibbindir() + "/vcard2text", PIPE_DEV_STDIN));
-    index_command("application/vnd.apply.keynote",
+    index_command("application/vnd.apple.keynote",
 		  Filter("key2text", SEEK_DEV_STDIN));
-    index_command("application/vnd.apply.numbers",
+    index_command("application/vnd.apple.numbers",
 		  Filter("numbers2text", SEEK_DEV_STDIN));
-    index_command("application/vnd.apply.pages",
+    index_command("application/vnd.apple.pages",
 		  Filter("pages2text", SEEK_DEV_STDIN));
 }
 


### PR DESCRIPTION
It seems that there is a little error on the Apple iWork document 
mimetypes. It is defined “application/vnd.apple.keynote” at 
mimemap.tokens. However we use “application/vnd.apply.keynote” in 
index_file.cc.