### PR TITLE
Fix handler_poppler and avoid using clear_text in metadata

### DIFF
--- a/xapian-applications/omega/Makefile.am
+++ b/xapian-applications/omega/Makefile.am
@@ -178,6 +178,7 @@ omindex_LDADD = $(MAGIC_LIBS) $(XAPIAN_LIBS) $(ZLIB_LIBS) libutf8convert.la
 
 omindex_pdf_SOURCES = assistant.cc worker_comms.cc common/str.cc handler_poppler.cc
 omindex_pdf_LDADD = $(POPPLER_LIBS) $(XAPIAN_LIBS)
+omindex_pdf_CXXFLAGS = $(POPPLER_CFLAGS)
 
 scriptindex_SOURCES = scriptindex.cc myhtmlparse.cc htmlparse.cc\
  common/getopt.cc common/str.cc commonhelp.cc utils.cc hashterm.cc loadfile.cc\

--- a/xapian-applications/omega/handler_poppler.cc
+++ b/xapian-applications/omega/handler_poppler.cc
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
  * USA
  */
-#include <config.h>
 
+#include <config.h>
 #include "handler.h"
 #include "str.h"
 
@@ -76,7 +76,7 @@ extract(const string& filename,
 	    page *p(doc->create_page(i));
 	    if (!p) {
 		cerr << "Poppler Error: Failed to create page " << i << endl;
-		continue;
+		return false;
 	    }
 	    dump += text_to_utf8(p->text());
 	}
@@ -85,5 +85,6 @@ extract(const string& filename,
 	cerr << "Poppler threw an exception" << endl;
 	return false;
     }
+
     return true;
 }

--- a/xapian-applications/omega/handler_poppler.cc
+++ b/xapian-applications/omega/handler_poppler.cc
@@ -18,6 +18,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
  * USA
  */
+#include <config.h>
+
 #include "handler.h"
 #include "str.h"
 


### PR DESCRIPTION
There are some issues with handler_poppler. The main of them is that we 
can avoid calling the function clear_text for metadata. Beside, it is 
also possible to improve the error messages.