### PR TITLE
Fix rfc822tohtml entry in index_file.cc

### DIFF
--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -247,11 +247,9 @@ index_add_default_filters()
 		  Filter(get_pkglibbindir() + "/mhtml2html", "text/html",
 			 PIPE_DEV_STDIN));
     index_command("message/news",
-		  Filter(get_pkglibbindir() + "/rfc822tohtml", "text/html",
-			 PIPE_DEV_STDIN));
+		  Filter(get_pkglibbindir() + "/rfc822tohtml", "text/html"));
     index_command("message/rfc822",
-		  Filter(get_pkglibbindir() + "/rfc822tohtml", "text/html",
-			 PIPE_DEV_STDIN));
+		  Filter(get_pkglibbindir() + "/rfc822tohtml", "text/html"));
     index_command("text/vcard",
 		  Filter(get_pkglibbindir() + "/vcard2text", PIPE_DEV_STDIN));
     index_command("application/vnd.apple.keynote",


### PR DESCRIPTION
It seems that there is an error with ‘rfc822tohtml’. This script takes a 
file name as an argument, but we are indexing it as if it reads the file 
from the standard input.