### PR TITLE
Add libetonyek to Omega

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
             - pkg-config
             - libpoppler-cpp-dev
             - libe-book-dev
+            - libetonyek-dev
       env: CPPFLAGS=-D_GLIBCXX_DEBUG
     - compiler: clang
       os: linux
@@ -54,6 +55,7 @@ matrix:
             - pkg-config
             - libpoppler-cpp-dev
             - libe-book-dev
+            - libetonyek-dev
       env: USE_CC=clang USE_CXX='clang++ -stdlib=libc++'
     - compiler: gcc
       os: linux
@@ -116,6 +118,7 @@ matrix:
             - graphviz
             - help2man
             - icu4c
+            - libetonyek
             - libiconv
             - libmagic
             - libsvm

--- a/xapian-applications/omega/Makefile.am
+++ b/xapian-applications/omega/Makefile.am
@@ -44,7 +44,7 @@ BUILT_SOURCES = extra/omegascript.vim my-html-tok.h mimemap.h namedents.h
 
 MAINTAINERCLEANFILES = my-html-tok.h mimemap.h mimemap.stamp namedents.h
 
-EXTRA_PROGRAMS = omindex_pdf omindex_ebook
+EXTRA_PROGRAMS = omindex_pdf omindex_ebook omindex_idocs
 
 EXTRA_DIST =\
 	clickmodel/testdata/test1.log\
@@ -184,6 +184,10 @@ omindex_pdf_CXXFLAGS = $(POPPLER_CFLAGS)
 omindex_ebook_SOURCES = assistant.cc worker_comms.cc handler_libebook.cc
 omindex_ebook_LDADD = $(LIBEBOOK_LIBS)
 omindex_ebook_CXXFLAGS = $(LIBEBOOK_CFLAGS) $(XAPIAN_CXXFLAGS)
+
+omindex_idocs_SOURCES = assistant.cc worker_comms.cc handler_libetonyek.cc
+omindex_idocs_LDADD = $(LIBETONYEK_LIBS)
+omindex_idocs_CXXFLAGS = $(LIBETONYEK_CFLAGS) $(XAPIAN_CXXFLAGS)
 
 scriptindex_SOURCES = scriptindex.cc myhtmlparse.cc htmlparse.cc\
  common/getopt.cc common/str.cc commonhelp.cc utils.cc hashterm.cc loadfile.cc\

--- a/xapian-applications/omega/Makefile.am
+++ b/xapian-applications/omega/Makefile.am
@@ -44,7 +44,7 @@ BUILT_SOURCES = extra/omegascript.vim my-html-tok.h mimemap.h namedents.h
 
 MAINTAINERCLEANFILES = my-html-tok.h mimemap.h mimemap.stamp namedents.h
 
-EXTRA_PROGRAMS = omindex_pdf omindex_ebook omindex_libetonyek
+EXTRA_PROGRAMS = omindex_poppler omindex_libebook omindex_libetonyek
 
 EXTRA_DIST =\
 	clickmodel/testdata/test1.log\
@@ -177,13 +177,13 @@ omindex_SOURCES += portability/mkdtemp.cc
 endif
 omindex_LDADD = $(MAGIC_LIBS) $(XAPIAN_LIBS) $(ZLIB_LIBS) libutf8convert.la
 
-omindex_pdf_SOURCES = assistant.cc worker_comms.cc common/str.cc handler_poppler.cc
-omindex_pdf_LDADD = $(POPPLER_LIBS)
-omindex_pdf_CXXFLAGS = $(POPPLER_CFLAGS)
+omindex_poppler_SOURCES = assistant.cc worker_comms.cc common/str.cc handler_poppler.cc
+omindex_poppler_LDADD = $(POPPLER_LIBS)
+omindex_poppler_CXXFLAGS = $(POPPLER_CFLAGS)
 
-omindex_ebook_SOURCES = assistant.cc worker_comms.cc handler_libebook.cc
-omindex_ebook_LDADD = $(LIBEBOOK_LIBS)
-omindex_ebook_CXXFLAGS = $(LIBEBOOK_CFLAGS) $(XAPIAN_CXXFLAGS)
+omindex_libebook_SOURCES = assistant.cc worker_comms.cc handler_libebook.cc
+omindex_libebook_LDADD = $(LIBEBOOK_LIBS)
+omindex_libebook_CXXFLAGS = $(LIBEBOOK_CFLAGS) $(XAPIAN_CXXFLAGS)
 
 omindex_libetonyek_SOURCES = assistant.cc worker_comms.cc handler_libetonyek.cc
 omindex_libetonyek_LDADD = $(LIBETONYEK_LIBS)

--- a/xapian-applications/omega/Makefile.am
+++ b/xapian-applications/omega/Makefile.am
@@ -44,7 +44,7 @@ BUILT_SOURCES = extra/omegascript.vim my-html-tok.h mimemap.h namedents.h
 
 MAINTAINERCLEANFILES = my-html-tok.h mimemap.h mimemap.stamp namedents.h
 
-EXTRA_PROGRAMS = omindex_pdf omindex_ebook omindex_idocs
+EXTRA_PROGRAMS = omindex_pdf omindex_ebook omindex_libetonyek
 
 EXTRA_DIST =\
 	clickmodel/testdata/test1.log\
@@ -185,9 +185,9 @@ omindex_ebook_SOURCES = assistant.cc worker_comms.cc handler_libebook.cc
 omindex_ebook_LDADD = $(LIBEBOOK_LIBS)
 omindex_ebook_CXXFLAGS = $(LIBEBOOK_CFLAGS) $(XAPIAN_CXXFLAGS)
 
-omindex_idocs_SOURCES = assistant.cc worker_comms.cc handler_libetonyek.cc
-omindex_idocs_LDADD = $(LIBETONYEK_LIBS)
-omindex_idocs_CXXFLAGS = $(LIBETONYEK_CFLAGS) $(XAPIAN_CXXFLAGS)
+omindex_libetonyek_SOURCES = assistant.cc worker_comms.cc handler_libetonyek.cc
+omindex_libetonyek_LDADD = $(LIBETONYEK_LIBS)
+omindex_libetonyek_CXXFLAGS = $(LIBETONYEK_CFLAGS) $(XAPIAN_CXXFLAGS)
 
 scriptindex_SOURCES = scriptindex.cc myhtmlparse.cc htmlparse.cc\
  common/getopt.cc common/str.cc commonhelp.cc utils.cc hashterm.cc loadfile.cc\

--- a/xapian-applications/omega/configure.ac
+++ b/xapian-applications/omega/configure.ac
@@ -266,6 +266,11 @@ PKG_CHECK_MODULES([LIBEBOOK], [libe-book-0.1,librevenge-0.0,librevenge-generator
      AC_DEFINE(HAVE_LIBEBOOK, 1, [Define HAVE_LIBEBOOK if the library is available])
      OMINDEX_MODULES="$OMINDEX_MODULES omindex_ebook"],[ ])
 
+dnl check if libetonyek is available.
+PKG_CHECK_MODULES([LIBETONYEK], [libetonyek-0.1,librevenge-0.0,librevenge-generators-0.0,librevenge-stream-0.0], [
+     AC_DEFINE(HAVE_LIBETONYEK, 1, [Define HAVE_LIBETONYEK if the library is available])
+     OMINDEX_MODULES="$OMINDEX_MODULES omindex_idocs"],[ ])
+
 AC_SUBST([OMINDEX_MODULES])
 
 dnl Check that snprintf actually works as it's meant to.

--- a/xapian-applications/omega/configure.ac
+++ b/xapian-applications/omega/configure.ac
@@ -258,13 +258,13 @@ PKG_CHECK_MODULES([POPPLER], [poppler-cpp], [
                          return 0;
                      }],
                     [AC_DEFINE(HAVE_POPPLER, 1, [Define HAVE_POPPLER if the library is available])
-                     OMINDEX_MODULES="$OMINDEX_MODULES omindex_pdf"])
+                     OMINDEX_MODULES="$OMINDEX_MODULES omindex_poppler"])
      LIBS=$save_LIBS],[ ])
 
 dnl check if libe-book is available.
 PKG_CHECK_MODULES([LIBEBOOK], [libe-book-0.1,librevenge-0.0,librevenge-generators-0.0,librevenge-stream-0.0], [
      AC_DEFINE(HAVE_LIBEBOOK, 1, [Define HAVE_LIBEBOOK if the library is available])
-     OMINDEX_MODULES="$OMINDEX_MODULES omindex_ebook"],[ ])
+     OMINDEX_MODULES="$OMINDEX_MODULES omindex_libebook"],[ ])
 
 dnl check if libetonyek is available.
 PKG_CHECK_MODULES([LIBETONYEK], [libetonyek-0.1,librevenge-0.0,librevenge-generators-0.0,librevenge-stream-0.0], [

--- a/xapian-applications/omega/configure.ac
+++ b/xapian-applications/omega/configure.ac
@@ -269,7 +269,7 @@ PKG_CHECK_MODULES([LIBEBOOK], [libe-book-0.1,librevenge-0.0,librevenge-generator
 dnl check if libetonyek is available.
 PKG_CHECK_MODULES([LIBETONYEK], [libetonyek-0.1,librevenge-0.0,librevenge-generators-0.0,librevenge-stream-0.0], [
      AC_DEFINE(HAVE_LIBETONYEK, 1, [Define HAVE_LIBETONYEK if the library is available])
-     OMINDEX_MODULES="$OMINDEX_MODULES omindex_idocs"],[ ])
+     OMINDEX_MODULES="$OMINDEX_MODULES omindex_libetonyek"],[ ])
 
 AC_SUBST([OMINDEX_MODULES])
 

--- a/xapian-applications/omega/docs/overview.rst
+++ b/xapian-applications/omega/docs/overview.rst
@@ -286,12 +286,12 @@ other filters too - see below):
 * MS Publisher documents (.pub) if pub2xhtml is available (comes with libmspub)
 * MS Visio documents (.vsd, .vss, .vst, .vsw, .vsdx, .vssx, .vstx, .vsdm,
   .vssm, .vstm) if vsd2xhtml is available (comes with libvisio)
-* Apple Keynote documents (.key, .kth, .apxl) if key2text is available (comes
-  with libetonyek)
-* Apple Numbers documents (.numbers) if numbers2text is available (comes with
-  libetonyek)
-* Apple Pages documents (.pages) if pages2text is available (comes with
-  libetonyek)
+* Apple Keynote documents (.key, .kth, .apxl) if libetonyek is available (it is
+  also possible to use key2text as an external filter)
+* Apple Numbers documents (.numbers) if libetonyek is available (it is
+  also possible to use numbers2text as an external filter)
+* Apple Pages documents (.pages) if libetonyek is available (it is
+  also possible to use pages2text as an external filter)
 * AbiWord documents (.abw)
 * Compressed AbiWord documents (.zabw)
 * Rich Text Format documents (.rtf) if unrtf is available

--- a/xapian-applications/omega/handler_libetonyek.cc
+++ b/xapian-applications/omega/handler_libetonyek.cc
@@ -1,0 +1,233 @@
+/** @file handler_libetonyek.cc
+ * @brief Extract text and metadata from Apple documents using libtonyek.
+ */
+/* Copyright (C) 2019 Bruno Baruffaldi
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+#include <config.h>
+#include "handler.h"
+#include "stringutils.h"
+
+#include <memory>
+
+#include <librevenge-generators/librevenge-generators.h>
+#include <librevenge-stream/librevenge-stream.h>
+#include <libetonyek/libetonyek.h>
+
+#define PARSE_FIELD(START, END, FIELD, OUT) \
+   parse_metadata_field((START), (END), (FIELD), (CONST_STRLEN(FIELD)), (OUT))
+
+using std::shared_ptr;
+using libetonyek::EtonyekDocument;
+using namespace librevenge;
+using namespace std;
+
+static void
+parse_metadata_field(const char* start,
+		     const char* end,
+		     const char* field,
+		     size_t len,
+		     string& out)
+{
+    if (size_t(end - start) > len && memcmp(start, field, len) == 0) {
+	start += len;
+	while (start != end && isspace(*start)) start++;
+	if (start != end && (end[-1] != '\r' || --end != start)) {
+	    if (!out.empty())
+		out.push_back(' ');
+	    out.append(start, end - start);
+	}
+    }
+}
+
+static void
+parse_metadata(const char* data,
+	       size_t len,
+	       string& author,
+	       string& title,
+	       string& keywords)
+{
+    const char* p = data;
+    const char* end = p + len;
+
+    while (p != end) {
+	const char* start = p;
+	p = static_cast<const char*>(memchr(p, '\n', end - start));
+	const char* eol;
+	if (p)
+	    eol = p++;
+	else
+	    p = eol = end;
+	if ((end - start) > 5 && memcmp(start, "meta:", 5) == 0) {
+	    start += 5;
+	    switch (*start) {
+		case 'i': {
+		    if (author.empty())
+			PARSE_FIELD(start, eol, "initial-creator", author);
+		    break;
+		}
+		case 'k': {
+		    PARSE_FIELD(start, eol, "keyword", keywords);
+		    break;
+		}
+	    }
+	} else if ((end - start) > 3 && memcmp(start, "dc:", 3) == 0) {
+	    start += 3;
+	    switch (*start) {
+		case 'c': {
+		    if (!author.empty())
+			author.clear();
+		    PARSE_FIELD(start, eol, "creator", author);
+		    break;
+		}
+		case 's': {
+		    PARSE_FIELD(start, eol, "subject", keywords);
+		    break;
+		}
+		case 't': {
+		    PARSE_FIELD(start, eol, "title", title);
+		    break;
+		}
+	    }
+	} else if ((end - start) > 8 && memcmp(start, "dcterms:", 8) == 0) {
+	    start += 8;
+	    PARSE_FIELD(start, eol, "available", keywords);
+	}
+    }
+}
+
+static void
+clear_text(string& str, const char* text)
+{
+    if (text) {
+	for (int i = 0; text[i] != '\0'; ++i)
+	    if (!isspace(text[i]) || (i && !isspace(text[i - 1])))
+		str.push_back(text[i]);
+	str.push_back('\n');
+    }
+}
+
+static bool
+extract_key(string& dump, RVNGInputStream* input, string& error)
+{
+    RVNGStringVector content;
+    RVNGTextPresentationGenerator document(content);
+    if (!EtonyekDocument::parse(input, &document)) {
+	error = "Libetonyek Error: Fail to extract text";
+	return false;
+    }
+    // Extract text if possible
+    unsigned size = content.size();
+    for (unsigned i = 0; i < size; ++i)
+	clear_text(dump, content[i].cstr());
+    return true;
+}
+
+static bool
+extract_numbers(string& dump, RVNGInputStream* input, string& error)
+{
+    RVNGStringVector content;
+    RVNGTextSpreadsheetGenerator document(content);
+
+    if (!EtonyekDocument::parse(input, &document)) {
+	error = "Libetonyek Error: Fail to extract text";
+	return false;
+    }
+    // Extract text if possible
+    unsigned size = content.size();
+    for (unsigned i = 0; i < size; ++i)
+	clear_text(dump, content[i].cstr());
+    return true;
+}
+
+static bool
+extract_pages(string& dump,
+	      string& title,
+	      string& author,
+	      string& keywords,
+	      string& error,
+	      RVNGInputStream* input)
+{
+    RVNGString text_dump, data_dump;
+    bool succeed = false;
+
+    // Extract text if possible
+    RVNGTextTextGenerator content(text_dump, false);
+    if (EtonyekDocument::parse(input, &content)) {
+	clear_text(dump, text_dump.cstr());
+	succeed = true;
+    } else {
+	 error = "Libetonyek Error: Fail to extract text";
+    }
+    // Extract metadata if possible
+    RVNGTextTextGenerator data(data_dump, true);
+    if (EtonyekDocument::parse(input, &data)) {
+	const char* metadata = data_dump.cstr();
+	size_t len = data_dump.size();
+	parse_metadata(metadata, len, author, title, keywords);
+	succeed = true;
+    } else {
+	if (!error.empty())
+	    error += " and metadata";
+	else
+	    error = "Libetonyek Error: Fail to extract metadata";
+    }
+    return succeed;
+}
+
+bool
+extract(const string& filename,
+	string& dump,
+	string& title,
+	string& keyword,
+	string& author,
+	string& pages,
+	string& error)
+{
+    try {
+	unique_ptr<RVNGInputStream> input;
+
+	if (RVNGDirectoryStream::isDirectory(filename.c_str()))
+	    input.reset(new RVNGDirectoryStream(filename.c_str()));
+	else
+	    input.reset(new RVNGFileStream(filename.c_str()));
+
+	EtonyekDocument::Type type = EtonyekDocument::TYPE_UNKNOWN;
+	auto confidence = EtonyekDocument::isSupported(input.get(), &type);
+
+	if (confidence == EtonyekDocument::CONFIDENCE_NONE) {
+	    error = "Libetonyek Error: The format couldn't be detected";
+	    return false;
+	}
+
+	switch (type) {
+	    case EtonyekDocument::TYPE_PAGES:
+		return extract_pages(dump, title, author,
+				     keyword, error, input.get());
+	    case EtonyekDocument::TYPE_NUMBERS:
+		return extract_numbers(dump, input.get(), error);
+	    case EtonyekDocument::TYPE_KEYNOTE:
+		return extract_key(dump, input.get(), error);
+	    default:
+		error = "Libetonyek Error: The format is not supported";
+	}
+	(void)pages;
+    } catch (...) {
+	error = "Libetonyek threw an exception";
+    }
+    return false;
+}

--- a/xapian-applications/omega/handler_libetonyek.cc
+++ b/xapian-applications/omega/handler_libetonyek.cc
@@ -31,7 +31,6 @@
 #define PARSE_FIELD(START, END, FIELD, OUT) \
    parse_metadata_field((START), (END), (FIELD), (CONST_STRLEN(FIELD)), (OUT))
 
-using std::shared_ptr;
 using libetonyek::EtonyekDocument;
 using namespace librevenge;
 using namespace std;
@@ -180,6 +179,7 @@ extract_pages(string& dump,
 	size_t len = data_dump.size();
 	parse_metadata(metadata, len, author, title, keywords);
 	succeed = true;
+	error.clear();
     } else {
 	if (!error.empty())
 	    error += " and metadata";

--- a/xapian-applications/omega/handler_libetonyek.cc
+++ b/xapian-applications/omega/handler_libetonyek.cc
@@ -171,7 +171,7 @@ extract_pages(string& dump,
 	clear_text(dump, text_dump.cstr());
 	succeed = true;
     } else {
-	 error = "Libetonyek Error: Fail to extract text";
+	error = "Libetonyek Error: Fail to extract text";
     }
     // Extract metadata if possible
     RVNGTextTextGenerator data(data_dump, true);

--- a/xapian-applications/omega/handler_libetonyek.cc
+++ b/xapian-applications/omega/handler_libetonyek.cc
@@ -179,13 +179,16 @@ extract_pages(string& dump,
 	size_t len = data_dump.size();
 	parse_metadata(metadata, len, author, title, keywords);
 	succeed = true;
-	error.clear();
     } else {
 	if (!error.empty())
 	    error += " and metadata";
 	else
 	    error = "Libetonyek Error: Fail to extract metadata";
     }
+
+    if (succeed)
+	error.clear();
+
     return succeed;
 }
 

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -166,6 +166,12 @@ index_add_default_libraries()
     index_library("application/x-tcr-ebook", omindex_ebook);
     index_library("application/x-qioo-ebook", omindex_ebook);
 #endif
+#if defined HAVE_LIBETONYEK
+    Worker* omindex_idocs = new Worker("omindex_idocs");
+    index_library("application/vnd.apple.keynote", omindex_idocs);
+    index_library("application/vnd.apple.pages", omindex_idocs);
+    index_library("application/vnd.apple.numbers", omindex_idocs);
+#endif
 }
 
 void

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -154,17 +154,17 @@ void
 index_add_default_libraries()
 {
 #if defined HAVE_POPPLER
-    Worker* omindex_pdf = new Worker("omindex_pdf");
-    index_library("application/pdf", omindex_pdf);
+    Worker* omindex_poppler = new Worker("omindex_poppler");
+    index_library("application/pdf", omindex_poppler);
 #endif
 #if defined HAVE_LIBEBOOK
-    Worker* omindex_ebook = new Worker("omindex_ebook");
-    index_library("application/vnd.palm", omindex_ebook);
-    index_library("application/x-fictionbook+xml", omindex_ebook);
-    index_library("application/x-zip-compressed-fb2", omindex_ebook);
-    index_library("application/x-sony-bbeb", omindex_ebook);
-    index_library("application/x-tcr-ebook", omindex_ebook);
-    index_library("application/x-qioo-ebook", omindex_ebook);
+    Worker* omindex_libebook = new Worker("omindex_libebook");
+    index_library("application/vnd.palm", omindex_libebook);
+    index_library("application/x-fictionbook+xml", omindex_libebook);
+    index_library("application/x-zip-compressed-fb2", omindex_libebook);
+    index_library("application/x-sony-bbeb", omindex_libebook);
+    index_library("application/x-tcr-ebook", omindex_libebook);
+    index_library("application/x-qioo-ebook", omindex_libebook);
 #endif
 #if defined HAVE_LIBETONYEK
     Worker* omindex_libetonyek = new Worker("omindex_libetonyek");

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -167,10 +167,10 @@ index_add_default_libraries()
     index_library("application/x-qioo-ebook", omindex_ebook);
 #endif
 #if defined HAVE_LIBETONYEK
-    Worker* omindex_idocs = new Worker("omindex_idocs");
-    index_library("application/vnd.apple.keynote", omindex_idocs);
-    index_library("application/vnd.apple.pages", omindex_idocs);
-    index_library("application/vnd.apple.numbers", omindex_idocs);
+    Worker* omindex_libetonyek = new Worker("omindex_libetonyek");
+    index_library("application/vnd.apple.keynote", omindex_libetonyek);
+    index_library("application/vnd.apple.pages", omindex_libetonyek);
+    index_library("application/vnd.apple.numbers", omindex_libetonyek);
 #endif
 }
 


### PR DESCRIPTION
At the moment, Omega uses pages2txt and similar filters to extract
information from iWork documents. We can replace them with libetonyek.