### PR TITLE
Add Tesseract to Omega

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
             - libpoppler-cpp-dev
             - libe-book-dev
             - libetonyek-dev
+            - libtesseract-dev
       env: CPPFLAGS=-D_GLIBCXX_DEBUG
     - compiler: clang
       os: linux
@@ -56,6 +57,7 @@ matrix:
             - libpoppler-cpp-dev
             - libe-book-dev
             - libetonyek-dev
+            - libtesseract-dev
       env: USE_CC=clang USE_CXX='clang++ -stdlib=libc++'
     - compiler: gcc
       os: linux
@@ -82,6 +84,7 @@ matrix:
             - tcl
             - libsvm-dev
             - libpoppler-cpp-dev
+            - libtesseract-dev
     - os: linux
       addons:
         apt:
@@ -130,6 +133,7 @@ matrix:
             - poppler
             - python
             - python2
+            - tesseract
       before_install:
         - travis_retry pip2 install sphinx docutils
         - travis_retry pip3 install sphinx

--- a/xapian-applications/omega/Makefile.am
+++ b/xapian-applications/omega/Makefile.am
@@ -44,7 +44,7 @@ BUILT_SOURCES = extra/omegascript.vim my-html-tok.h mimemap.h namedents.h
 
 MAINTAINERCLEANFILES = my-html-tok.h mimemap.h mimemap.stamp namedents.h
 
-EXTRA_PROGRAMS = omindex_poppler omindex_libebook omindex_libetonyek
+EXTRA_PROGRAMS = omindex_poppler omindex_libebook omindex_libetonyek omindex_tesseract
 
 EXTRA_DIST =\
 	clickmodel/testdata/test1.log\
@@ -188,6 +188,10 @@ omindex_libebook_CXXFLAGS = $(LIBEBOOK_CFLAGS) $(XAPIAN_CXXFLAGS)
 omindex_libetonyek_SOURCES = assistant.cc worker_comms.cc handler_libetonyek.cc
 omindex_libetonyek_LDADD = $(LIBETONYEK_LIBS)
 omindex_libetonyek_CXXFLAGS = $(LIBETONYEK_CFLAGS) $(XAPIAN_CXXFLAGS)
+
+omindex_tesseract_SOURCES = assistant.cc worker_comms.cc handler_tesseract.cc
+omindex_tesseract_LDADD = $(TESSERACT_LIBS)
+omindex_tesseract_CXXFLAGS = $(TESSERACT_CFLAGS)
 
 scriptindex_SOURCES = scriptindex.cc myhtmlparse.cc htmlparse.cc\
  common/getopt.cc common/str.cc commonhelp.cc utils.cc hashterm.cc loadfile.cc\

--- a/xapian-applications/omega/configure.ac
+++ b/xapian-applications/omega/configure.ac
@@ -271,6 +271,11 @@ PKG_CHECK_MODULES([LIBETONYEK], [libetonyek-0.1,librevenge-0.0,librevenge-genera
      AC_DEFINE(HAVE_LIBETONYEK, 1, [Define HAVE_LIBETONYEK if the library is available])
      OMINDEX_MODULES="$OMINDEX_MODULES omindex_libetonyek"],[ ])
 
+dnl check if libtesseract is available.
+PKG_CHECK_MODULES([TESSERACT], [tesseract, lept], [
+     AC_DEFINE(HAVE_TESSERACT, 1, [Define HAVE_TESSERACT if the library is available])
+     OMINDEX_MODULES="$OMINDEX_MODULES omindex_tesseract"],[ ])
+
 AC_SUBST([OMINDEX_MODULES])
 
 dnl Check that snprintf actually works as it's meant to.

--- a/xapian-applications/omega/docs/overview.rst
+++ b/xapian-applications/omega/docs/overview.rst
@@ -315,7 +315,8 @@ other filters too - see below):
 * TCR (simple compressed text format) files (.tcr) if libe-book is available
 * eReader files (.pdb) if libe-book is available
 * Sony eBook files (.lrf) if libe-book is available
-* Image files that contain text (.png, .jpg) if libtesseract-dev is available.
+* Image JPEG files that contain text (.png, .jpg, .jpeg, .jfif, .jpe, .webq, .tif, .tiff,
+  .pbm, .gif, .ppm, .pgm) if libtesseract-dev is available.
 
 If you have additional extensions that represent one of these types, you can
 add an additional MIME mapping using the ``--mime-type`` option.  For

--- a/xapian-applications/omega/docs/overview.rst
+++ b/xapian-applications/omega/docs/overview.rst
@@ -315,6 +315,7 @@ other filters too - see below):
 * TCR (simple compressed text format) files (.tcr) if libe-book is available
 * eReader files (.pdb) if libe-book is available
 * Sony eBook files (.lrf) if libe-book is available
+* Image files that contain text (.png, .jpg) if libtesseract-dev is available.
 
 If you have additional extensions that represent one of these types, you can
 add an additional MIME mapping using the ``--mime-type`` option.  For

--- a/xapian-applications/omega/docs/overview.rst
+++ b/xapian-applications/omega/docs/overview.rst
@@ -315,7 +315,7 @@ other filters too - see below):
 * TCR (simple compressed text format) files (.tcr) if libe-book is available
 * eReader files (.pdb) if libe-book is available
 * Sony eBook files (.lrf) if libe-book is available
-* Image JPEG files that contain text (.png, .jpg, .jpeg, .jfif, .jpe, .webq, .tif, .tiff,
+* Image files that contain text (.png, .jpg, .jpeg, .jfif, .jpe, .webp, .tif, .tiff,
   .pbm, .gif, .ppm, .pgm) if libtesseract-dev is available.
 
 If you have additional extensions that represent one of these types, you can

--- a/xapian-applications/omega/handler_tesseract.cc
+++ b/xapian-applications/omega/handler_tesseract.cc
@@ -29,20 +29,16 @@ using namespace tesseract;
 
 static TessBaseAPI* ocr = NULL;
 
-static bool
+static void
 clear_text(string& dump, const char* text)
 {
-    bool k = false;
     if (text) {
 	for (int i = 0; text[i] != '\0'; ++i) {
-	    if (!isspace(text[i]) || (i && !isspace(text[i - 1]))) {
+	    if (!isspace(text[i]) || (i && !isspace(text[i - 1])))
 		dump.push_back(text[i]);
-		k |= !isspace(text[i]);
-	    }
 	}
 	delete [] text;
     }
-    return k;
 }
 
 bool
@@ -65,22 +61,17 @@ extract(const string& filename,
     Pix* image = pixRead(filename.c_str());
 
     if (!image) {
-	error = "Tesseract Error: Error while openning the image";
+	error = "Tesseract Error: Error while opening the image";
 	return false;
     }
 
     ocr->SetImage(image);
 
     // Get OCR result
-    bool has_text = clear_text(dump, ocr->GetUTF8Text());
+    clear_text(dump, ocr->GetUTF8Text());
 
     // Destroy used object and release memory
     pixDestroy(&image);
-
-    if (!has_text) {
-	error = "Tesseract Error: The image does not content text";
-	return false;
-    }
 
     (void)title;
     (void)keywords;

--- a/xapian-applications/omega/handler_tesseract.cc
+++ b/xapian-applications/omega/handler_tesseract.cc
@@ -1,0 +1,85 @@
+/** @file handler_tesseract.cc
+ * @brief Extract text from Images using tesseract.
+ */
+/* Copyright (C) 2019 Bruno Baruffaldi
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+#include <config.h>
+#include "handler.h"
+
+#include <tesseract/baseapi.h>
+#include <leptonica/allheaders.h>
+
+using namespace std;
+using namespace tesseract;
+
+TessBaseAPI* ocr = NULL;
+
+static bool
+clear_text(string& dump, const char* text)
+{
+    bool k = false;
+    if (text) {
+	for (int i = 0; text[i] != '\0'; ++i) {
+	    if (!isspace(text[i]) || (i && !isspace(text[i - 1]))) {
+		dump.push_back(text[i]);
+		k |= isalnum(text[i]);
+	    }
+	}
+	delete [] text;
+    }
+    return k;
+}
+
+bool
+extract(const string& filename,
+	string& dump,
+	string& title,
+	string& keywords,
+	string& author,
+	string& pages,
+	string& error)
+{
+    // Create the ocr if necessary
+    if (!ocr) {
+	ocr = new TessBaseAPI();
+	if (ocr->Init(NULL, NULL))
+	    _Exit(1);
+	ocr->SetPageSegMode(PSM_AUTO_OSD);
+    }
+    // Open Image
+    Pix* image = pixRead(filename.c_str());
+    ocr->SetImage(image);
+
+    // Get OCR result
+    bool has_text = clear_text(dump, ocr->GetUTF8Text());
+
+    // Destroy used object and release memory
+    pixDestroy(&image);
+
+    if (!has_text) {
+	error = "Tesseract Error: The image does not content text\n";
+	return false;
+    }
+
+    (void)title;
+    (void)keywords;
+    (void)author;
+    (void)pages;
+
+    return true;
+}

--- a/xapian-applications/omega/handler_tesseract.cc
+++ b/xapian-applications/omega/handler_tesseract.cc
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace tesseract;
 
-TessBaseAPI* ocr = NULL;
+static TessBaseAPI* ocr = NULL;
 
 static bool
 clear_text(string& dump, const char* text)
@@ -37,7 +37,7 @@ clear_text(string& dump, const char* text)
 	for (int i = 0; text[i] != '\0'; ++i) {
 	    if (!isspace(text[i]) || (i && !isspace(text[i - 1]))) {
 		dump.push_back(text[i]);
-		k |= isalnum(text[i]);
+		k |= !isspace(text[i]);
 	    }
 	}
 	delete [] text;
@@ -63,6 +63,12 @@ extract(const string& filename,
     }
     // Open Image
     Pix* image = pixRead(filename.c_str());
+
+    if (!image) {
+	error = "Tesseract Error: Error while openning the image";
+	return false;
+    }
+
     ocr->SetImage(image);
 
     // Get OCR result
@@ -72,7 +78,7 @@ extract(const string& filename,
     pixDestroy(&image);
 
     if (!has_text) {
-	error = "Tesseract Error: The image does not content text\n";
+	error = "Tesseract Error: The image does not content text";
 	return false;
     }
 

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -172,6 +172,11 @@ index_add_default_libraries()
     index_library("application/vnd.apple.pages", omindex_libetonyek);
     index_library("application/vnd.apple.numbers", omindex_libetonyek);
 #endif
+#if defined HAVE_TESSERACT
+    Worker* omindex_tesseract = new Worker("omindex_tesseract");
+    index_library("image/jpeg", omindex_tesseract);
+    index_library("image/png", omindex_tesseract);
+#endif
 }
 
 void

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -176,6 +176,12 @@ index_add_default_libraries()
     Worker* omindex_tesseract = new Worker("omindex_tesseract");
     index_library("image/jpeg", omindex_tesseract);
     index_library("image/png", omindex_tesseract);
+    index_library("image/webp", omindex_tesseract);
+    index_library("image/tiff", omindex_tesseract);
+    index_library("image/x-pbm", omindex_tesseract);
+    index_library("image/gif", omindex_tesseract);
+    index_library("image/x-portable-pixmap", omindex_tesseract);
+    index_library("image/x-pgm", omindex_tesseract);
 #endif
 }
 

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -174,14 +174,15 @@ index_add_default_libraries()
 #endif
 #if defined HAVE_TESSERACT
     Worker* omindex_tesseract = new Worker("omindex_tesseract");
+    index_library("image/gif", omindex_tesseract);
     index_library("image/jpeg", omindex_tesseract);
     index_library("image/png", omindex_tesseract);
     index_library("image/webp", omindex_tesseract);
     index_library("image/tiff", omindex_tesseract);
-    index_library("image/x-pbm", omindex_tesseract);
-    index_library("image/gif", omindex_tesseract);
+    index_library("image/x-portable-bitmap", omindex_tesseract);
+    index_library("image/x-portable-graymap", omindex_tesseract);
+    index_library("image/x-portable-anymap", omindex_tesseract);
     index_library("image/x-portable-pixmap", omindex_tesseract);
-    index_library("image/x-pgm", omindex_tesseract);
 #endif
 }
 

--- a/xapian-applications/omega/mimemap.tokens
+++ b/xapian-applications/omega/mimemap.tokens
@@ -199,6 +199,20 @@ lrf		application/x-sony-bbeb
 tcr		application/x-tcr-ebook
 pdb		application/vnd.palm
 
+# Image files:
+gif		image/gif
+jfif		image/jpeg
+jpe		image/jpeg
+jpeg		image/jpeg
+jpg		image/jpeg
+pbm		image/x-pbm
+pgm		image/x-pgm
+png		image/png
+ppm		image/x-portable-pixmap
+tif		image/tiff
+tiff		image/tiff
+webq		image/webp
+
 # Extensions to quietly ignore:
 a		ignore
 adm		ignore

--- a/xapian-applications/omega/mimemap.tokens
+++ b/xapian-applications/omega/mimemap.tokens
@@ -205,13 +205,14 @@ jfif		image/jpeg
 jpe		image/jpeg
 jpeg		image/jpeg
 jpg		image/jpeg
-pbm		image/x-pbm
-pgm		image/x-pgm
+pbm		image/x-portable-bitmap
+pgm		image/x-portable-graymap
 png		image/png
+pnm		image/x-portable-anymap
 ppm		image/x-portable-pixmap
 tif		image/tiff
 tiff		image/tiff
-webq		image/webp
+webp		image/webp
 
 # Extensions to quietly ignore:
 a		ignore


### PR DESCRIPTION
Currently, omindex cannot handle image which contain text. It is 
possible to use an OCR(like tesseract) to extract text from images and 
index them.