### PR TITLE
Add Gmime to Omega

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
             - libe-book-dev
             - libetonyek-dev
             - libtesseract-dev
+            - libgmime-2.6-dev
       env: CPPFLAGS=-D_GLIBCXX_DEBUG
     - compiler: clang
       os: linux
@@ -58,6 +59,7 @@ matrix:
             - libe-book-dev
             - libetonyek-dev
             - libtesseract-dev
+            - libgmime-2.6-dev
       env: USE_CC=clang USE_CXX='clang++ -stdlib=libc++'
     - compiler: gcc
       os: linux
@@ -118,6 +120,7 @@ matrix:
           update: true
           packages:
             - doxygen
+            - gmime
             - graphviz
             - help2man
             - icu4c

--- a/xapian-applications/omega/Makefile.am
+++ b/xapian-applications/omega/Makefile.am
@@ -44,7 +44,7 @@ BUILT_SOURCES = extra/omegascript.vim my-html-tok.h mimemap.h namedents.h
 
 MAINTAINERCLEANFILES = my-html-tok.h mimemap.h mimemap.stamp namedents.h
 
-EXTRA_PROGRAMS = omindex_poppler omindex_libebook omindex_libetonyek omindex_tesseract
+EXTRA_PROGRAMS = omindex_poppler omindex_libebook omindex_libetonyek omindex_tesseract omindex_gmime
 
 EXTRA_DIST =\
 	clickmodel/testdata/test1.log\
@@ -192,6 +192,10 @@ omindex_libetonyek_CXXFLAGS = $(LIBETONYEK_CFLAGS) $(XAPIAN_CXXFLAGS)
 omindex_tesseract_SOURCES = assistant.cc worker_comms.cc handler_tesseract.cc
 omindex_tesseract_LDADD = $(TESSERACT_LIBS)
 omindex_tesseract_CXXFLAGS = $(TESSERACT_CFLAGS)
+
+omindex_gmime_SOURCES = assistant.cc worker_comms.cc myhtmlparse.cc datetime.cc htmlparse.cc common/keyword.cc handler_gmime.cc
+omindex_gmime_LDADD = $(GMIME_LIBS) libutf8convert.la
+omindex_gmime_CXXFLAGS = $(GMIME_CFLAGS) $(XAPIAN_CXXFLAGS)
 
 scriptindex_SOURCES = scriptindex.cc myhtmlparse.cc htmlparse.cc\
  common/getopt.cc common/str.cc commonhelp.cc utils.cc hashterm.cc loadfile.cc\

--- a/xapian-applications/omega/configure.ac
+++ b/xapian-applications/omega/configure.ac
@@ -276,6 +276,11 @@ PKG_CHECK_MODULES([TESSERACT], [tesseract, lept], [
      AC_DEFINE(HAVE_TESSERACT, 1, [Define HAVE_TESSERACT if the library is available])
      OMINDEX_MODULES="$OMINDEX_MODULES omindex_tesseract"],[ ])
 
+dnl check if gmime is available.
+PKG_CHECK_MODULES([GMIME], [gmime-2.6, glib-2.0], [
+     AC_DEFINE(HAVE_GMIME, 1, [Define HAVE_GMIME if the library is available])
+     OMINDEX_MODULES="$OMINDEX_MODULES omindex_gmime"],[ ])
+
 AC_SUBST([OMINDEX_MODULES])
 
 dnl Check that snprintf actually works as it's meant to.

--- a/xapian-applications/omega/docs/overview.rst
+++ b/xapian-applications/omega/docs/overview.rst
@@ -307,8 +307,8 @@ other filters too - see below):
 * Atom feeds (.atom)
 * MAFF (.maff) if unzip is available
 * MHTML (.mhtml, .mht) if perl with MIME::Tools is available
-* MIME email messages (.eml) and USENET articles if perl with MIME::Tools and
-  HTML::Parser is available
+* MIME email messages (.eml) and USENET articles if gmime 2.6 or perl with MIME::Tools and
+  HTML::Parser are available
 * vCard files (.vcf, .vcard) if perl with Text::vCard is available
 * FictionBook v.2 files (.fb2) if libe-book is available
 * QiOO (mobile format, for java-enabled cellphones) files (.jar) if libe-book is available

--- a/xapian-applications/omega/docs/overview.rst
+++ b/xapian-applications/omega/docs/overview.rst
@@ -308,7 +308,7 @@ other filters too - see below):
 * MAFF (.maff) if unzip is available
 * MHTML (.mhtml, .mht) if perl with MIME::Tools is available
 * MIME email messages (.eml) and USENET articles if gmime 2.6 or perl with MIME::Tools and
-  HTML::Parser are available
+  HTML::Parser is available
 * vCard files (.vcf, .vcard) if perl with Text::vCard is available
 * FictionBook v.2 files (.fb2) if libe-book is available
 * QiOO (mobile format, for java-enabled cellphones) files (.jar) if libe-book is available

--- a/xapian-applications/omega/handler_gmime.cc
+++ b/xapian-applications/omega/handler_gmime.cc
@@ -166,11 +166,7 @@ extract(const string& filename,
     author = g_mime_message_get_sender(message);
     title = g_mime_message_get_subject(message);
 
-    try {
-	parser_content(body, dump);
-    } catch (ReadError) {
-	dump.clear();
-    }
+    parser_content(body, dump);
 
     (void)pages;
     return true;

--- a/xapian-applications/omega/handler_gmime.cc
+++ b/xapian-applications/omega/handler_gmime.cc
@@ -1,0 +1,173 @@
+/** @file handler_gmime.cc
+ * @brief Extract text and metadata using gmime.
+ */
+/* Copyright (C) 2019 Bruno Baruffaldi
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+#include <config.h>
+#include "handler.h"
+
+#include "myhtmlparse.h"
+
+#include <glib.h>
+#include <gmime/gmime.h>
+
+using namespace std;
+
+const unsigned SIZE = 8192;
+
+static void
+extract_html(const string& text, string& charset, string& dump)
+{
+    MyHtmlParser parser;
+    if (charset.empty())
+	charset = "UTF-8";
+    try {
+	parser.ignore_metarobots();
+	parser.parse_html(text, charset, false);
+	dump += parser.dump;
+    } catch (const string& newcharset) {
+	parser.reset();
+	parser.ignore_metarobots();
+	parser.parse_html(text, newcharset, true);
+	dump += parser.dump;
+    } catch (...) {
+	return;
+    }
+}
+
+size_t decode(unsigned char* text, size_t len, GMimeContentEncoding encoding)
+{
+    unsigned char buffer[SIZE];
+    int state;
+    guint32 save;
+    switch (encoding) {
+	case GMIME_CONTENT_ENCODING_BASE64: {
+	    len = g_mime_encoding_base64_decode_step(text, len, buffer,
+						     &state, &save);
+	    memcpy(text, buffer, len);
+	    break;
+	}
+	case GMIME_CONTENT_ENCODING_UUENCODE: {
+	    len = g_mime_encoding_uudecode_step(text, len, buffer,
+						&state, &save);
+	    memcpy(text, buffer, len);
+	    break;
+	}
+	case GMIME_CONTENT_ENCODING_QUOTEDPRINTABLE: {
+	    len = g_mime_encoding_quoted_decode_step(text, len, buffer,
+						     &state, &save);
+	    memcpy(text, buffer, len);
+	    break;
+	}
+	default:
+	    break;
+    }
+    return len;
+}
+
+bool
+parser_content(GMimeObject* me, string& dump)
+{
+    GMimeContentType* ct = g_mime_object_get_content_type(me);
+    if (GMIME_IS_MULTIPART(me)) {
+	GMimeMultipart* mpart = (GMimeMultipart*)me;
+	string subtype = g_mime_content_type_get_media_subtype(ct);
+	int count = g_mime_multipart_get_count(mpart);
+	if (subtype == "alternative") {
+	    for (int i = 0; i < count; ++i) {
+		GMimeObject* part = g_mime_multipart_get_part(mpart, i);
+		if (parser_content(part, dump))
+		    return true;
+	    }
+	} else {
+	    bool ret = false;
+	    for (int i = 0; i < count; ++i) {
+		GMimeObject* part = g_mime_multipart_get_part(mpart, i);
+		ret |= parser_content(part, dump);
+	    }
+	    return ret;
+	}
+    } else if (GMIME_IS_PART(me)) {
+	GMimePart* part = (GMimePart*)me;
+	GMimeDataWrapper* content = g_mime_part_get_content_object(part);
+	string type = g_mime_content_type_get_media_type(ct);
+	string subtype = g_mime_content_type_get_media_subtype(ct);
+	string charset(g_mime_object_get_headers(me));
+	size_t start = charset.find("charset=");
+	if (start != string::npos) {
+	    start += 9;
+	    charset = charset.substr(start, charset.length() - start - 3);
+	    charset = g_mime_charset_canon_name(charset.c_str());
+	} else {
+	    charset.clear();
+	}
+	if (type == "text") {
+	    char* buffer = new char[SIZE];
+	    GMimeStream* sr = g_mime_data_wrapper_get_stream(content);
+	    size_t presz = 0, len = g_mime_stream_read(sr, buffer, SIZE);
+	    auto encoding = g_mime_part_get_content_encoding(part);
+	    len = decode((unsigned char*)buffer, len, encoding);
+	    if (subtype == "plain") {
+		if (!charset.empty() && charset != "UTF-8") {
+		    GMimeFilter* ch = g_mime_filter_charset_new(charset.c_str(),
+								"UTF-8");
+		    if (GMIME_IS_FILTER(ch)) {
+			g_mime_filter_complete(ch, buffer, len, presz, &buffer,
+						&len, &presz);
+		    }
+		}
+		dump += string(buffer, buffer + len);
+	    } else if (subtype == "html") {
+		extract_html((const char*)buffer, charset, dump);
+	    }
+	    delete [] buffer;
+	    return true;
+	}
+    }
+    return false;
+}
+
+bool
+extract(const string& filename,
+	string& dump,
+	string& title,
+	string& keywords,
+	string& author,
+	string& pages,
+	string& error)
+{
+    g_mime_init(0);
+
+    FILE* fd = fopen(filename.c_str(), "r");
+
+    if (fd == NULL) {
+	error = "Gmime Error: fail open " + filename;
+	return false;
+    }
+
+    GMimeStream* stream = g_mime_stream_file_new(fd);
+    GMimeParser* parser = g_mime_parser_new_with_stream(stream);
+    GMimeMessage* message = g_mime_parser_construct_message(parser);
+    GMimeObject* body = g_mime_message_get_body(message);
+    author = g_mime_message_get_sender(message);
+    title = g_mime_message_get_subject(message);
+
+    parser_content(body, dump);
+    (void)pages;
+    return true;
+}

--- a/xapian-applications/omega/handler_gmime.cc
+++ b/xapian-applications/omega/handler_gmime.cc
@@ -23,9 +23,7 @@
 
 #include "myhtmlparse.h"
 #include "utf8convert.h"
-#include <string.h>
 
-#include <glib.h>
 #include <gmime/gmime.h>
 
 using namespace std;
@@ -47,8 +45,6 @@ extract_html(const string& text, string& charset, string& dump)
 	parser.ignore_metarobots();
 	parser.parse_html(text, newcharset, true);
 	dump += parser.dump;
-    } catch (...) {
-	return;
     }
 }
 
@@ -86,7 +82,7 @@ parser_content(GMimeObject* me, string& dump)
 {
     GMimeContentType* ct = g_mime_object_get_content_type(me);
     if (GMIME_IS_MULTIPART(me)) {
-	GMimeMultipart* mpart = (GMimeMultipart*)me;
+	GMimeMultipart* mpart = reinterpret_cast<GMimeMultipart*>(me);
 	string subtype = g_mime_content_type_get_media_subtype(ct);
 	int count = g_mime_multipart_get_count(mpart);
 	if (subtype == "alternative") {
@@ -104,7 +100,7 @@ parser_content(GMimeObject* me, string& dump)
 	    return ret;
 	}
     } else if (GMIME_IS_PART(me)) {
-	GMimePart* part = (GMimePart*)me;
+	GMimePart* part = reinterpret_cast<GMimePart*>(me);
 	GMimeDataWrapper* content = g_mime_part_get_content_object(part);
 	string type = g_mime_content_type_get_media_type(ct);
 	string subtype = g_mime_content_type_get_media_subtype(ct);

--- a/xapian-applications/omega/handler_gmime.cc
+++ b/xapian-applications/omega/handler_gmime.cc
@@ -24,7 +24,9 @@
 #include "myhtmlparse.h"
 #include "utf8convert.h"
 
+#include <glib.h>
 #include <gmime/gmime.h>
+#include <string.h>
 
 using namespace std;
 

--- a/xapian-applications/omega/handler_gmime.cc
+++ b/xapian-applications/omega/handler_gmime.cc
@@ -22,6 +22,7 @@
 #include "handler.h"
 
 #include "myhtmlparse.h"
+#include <string.h>
 
 #include <glib.h>
 #include <gmime/gmime.h>

--- a/xapian-applications/omega/handler_gmime.cc
+++ b/xapian-applications/omega/handler_gmime.cc
@@ -166,7 +166,11 @@ extract(const string& filename,
     author = g_mime_message_get_sender(message);
     title = g_mime_message_get_subject(message);
 
-    parser_content(body, dump);
+    try {
+	parser_content(body, dump);
+    } catch (ReadError) {
+	dump.clear();
+    }
 
     (void)pages;
     return true;

--- a/xapian-applications/omega/handler_gmime.cc
+++ b/xapian-applications/omega/handler_gmime.cc
@@ -166,7 +166,12 @@ extract(const string& filename,
     author = g_mime_message_get_sender(message);
     title = g_mime_message_get_subject(message);
 
-    parser_content(body, dump);
+    try {
+	parser_content(body, dump);
+    } catch (...) {
+	dump.clear();
+    }
+
     (void)pages;
     return true;
 }

--- a/xapian-applications/omega/handler_gmime.cc
+++ b/xapian-applications/omega/handler_gmime.cc
@@ -166,11 +166,7 @@ extract(const string& filename,
     author = g_mime_message_get_sender(message);
     title = g_mime_message_get_subject(message);
 
-    try {
-	parser_content(body, dump);
-    } catch (...) {
-	dump.clear();
-    }
+    parser_content(body, dump);
 
     (void)pages;
     return true;

--- a/xapian-applications/omega/index_file.cc
+++ b/xapian-applications/omega/index_file.cc
@@ -184,6 +184,11 @@ index_add_default_libraries()
     index_library("image/x-portable-anymap", omindex_tesseract);
     index_library("image/x-portable-pixmap", omindex_tesseract);
 #endif
+#if defined HAVE_GMIME
+    Worker* omindex_gmime = new Worker("omindex_gmime");
+    index_library("message/rfc822", omindex_gmime);
+    index_library("message/news", omindex_gmime);
+#endif
 }
 
 void


### PR DESCRIPTION
At the moment, omindex uses a perl script to index eml files. However, 
we can use Gmime to handle this kind of files.