### PR TITLE
Add Thai, Lana Tai and Pali codepoints to codepoint_is_cjk() test

### DIFF
--- a/xapian-core/queryparser/cjk-tokenizer.cc
+++ b/xapian-core/queryparser/cjk-tokenizer.cc
@@ -53,6 +53,8 @@ CJK::codepoint_is_cjk(unsigned p)
     // Array containing the last value in each range of codepoints which
     // are either all CJK or all non-CJK.
     static const unsigned splits[] = {
+	// 0E00..0E7F; Thai, Lanna Tai, Pali
+	0x0E00 - 1, 0x0E7F,
 	// 1100..11FF; Hangul Jamo
 	0x1100 - 1, 0x11FF,
 	// 2E80..2EFF; CJK Radicals Supplement

--- a/xapian-core/tests/api_termgen.cc
+++ b/xapian-core/tests/api_termgen.cc
@@ -184,6 +184,9 @@ static const test test_simple[] = {
     // would split this differently as '申込み ！月額 円'
     { "", "申込み！月額円", "み[2] 円[4] 月額[3] 申込[1]" },
 
+    // Thai word segmentation
+    { "", "โดยตั้งใจ", "ตั้งใจ[2] โดย[1]" },
+
     // Test set_stemming_strategy():
     { "stem=en,none,!cjkwords",
 	  "Unstemmed words!", "unstemmed[1] words[2]" },


### PR DESCRIPTION
The Thai, Lana Tai and Pali codepoints currently are not detected by the CJK tokenizer, and text in these scripts are only word-segmented around spaces and punctuation.

This pull request fixes that.