### PR TITLE
#801  fix ,mono toolchain bug where it fails to parse a newer terminfo file format.

### DIFF
--- a/xapian-bindings/csharp/Makefile.am
+++ b/xapian-bindings/csharp/Makefile.am
@@ -92,10 +92,10 @@ $(ASSEMBLY).dll: $(XAPIAN_SWIG_CS_SRCS) AssemblyInfo.cs XapianSharp.snk
 ## this is the first time we're signing, the key in the file is used and
 ## then stored in the key container.  From then on, the key in the container
 ## is used.
-	$(CSC) -unsafe -target:library -out:$(ASSEMBLY).dll \
-	    -keyfile:XapianSharp.snk -keycontainer:"Xapian Signing Key" \
-	    `for f in $(XAPIAN_SWIG_CS_SRCS); do if test -f "$$f"; then echo $$f; else echo $(srcdir)/$$f ; fi ; done` \
-	    AssemblyInfo.cs
+	TERM= $(CSC) -unsafe -target:library -out:$(ASSEMBLY).dll \
+	          -keyfile:XapianSharp.snk -keycontainer:"Xapian Signing Key" \
+	          `for f in $(XAPIAN_SWIG_CS_SRCS); do if test -f "$$f"; then echo $$f; else echo $(srcdir)/$$f ; fi ; done` \
+	          AssemblyInfo.cs
 
 SWIG_GENERATED = xapian_wrap.cc xapian_wrap.h $(XAPIAN_SWIG_CS_SRCS)
 
@@ -127,7 +127,7 @@ install-data-local: $(ASSEMBLY).dll
 	$(GACUTIL) /i $(ASSEMBLY).dll /f $(GACUTIL_FLAGS)
 
 SmokeTest.exe: SmokeTest.cs $(ASSEMBLY).dll
-	$(CSC) -unsafe -target:exe -out:SmokeTest.exe `test -f SmokeTest.cs||echo '$(srcdir)/'`SmokeTest.cs -r:$(ASSEMBLY).dll
+	TERM= $(CSC) -unsafe -target:exe -out:SmokeTest.exe `test -f SmokeTest.cs||echo '$(srcdir)/'`SmokeTest.cs -r:$(ASSEMBLY).dll
 
 all-am: $(ASSEMBLY).dll
 

--- a/xapian-bindings/csharp/Makefile.am
+++ b/xapian-bindings/csharp/Makefile.am
@@ -93,9 +93,9 @@ $(ASSEMBLY).dll: $(XAPIAN_SWIG_CS_SRCS) AssemblyInfo.cs XapianSharp.snk
 ## then stored in the key container.  From then on, the key in the container
 ## is used.
 	TERM= $(CSC) -unsafe -target:library -out:$(ASSEMBLY).dll \
-	          -keyfile:XapianSharp.snk -keycontainer:"Xapian Signing Key" \
-	          `for f in $(XAPIAN_SWIG_CS_SRCS); do if test -f "$$f"; then echo $$f; else echo $(srcdir)/$$f ; fi ; done` \
-	          AssemblyInfo.cs
+	    -keyfile:XapianSharp.snk -keycontainer:"Xapian Signing Key" \
+	    `for f in $(XAPIAN_SWIG_CS_SRCS); do if test -f "$$f"; then echo $$f; else echo $(srcdir)/$$f ; fi ; done` \
+	    AssemblyInfo.cs
 
 SWIG_GENERATED = xapian_wrap.cc xapian_wrap.h $(XAPIAN_SWIG_CS_SRCS)
 
@@ -116,7 +116,7 @@ install-data-hook:
 uninstall-local:
 	eval `grep '^dlname=' $(lib_LTLIBRARIES)` ; \
 	  rm -f $(DESTDIR)$(libdir)/"$$dlname"
-	$(GACUTIL) /u $(ASSEMBLY) /f $(GACUTIL_FLAGS)
+	TERM= $(GACUTIL) /u $(ASSEMBLY) /f $(GACUTIL_FLAGS)
 
 AM_CXXFLAGS = @SWIG_CXXFLAGS@ $(XAPIAN_CXXFLAGS)
 _XapianSharp_la_LDFLAGS = -avoid-version -module $(NO_UNDEFINED)
@@ -124,7 +124,7 @@ _XapianSharp_la_SOURCES = xapian_wrap.cc
 _XapianSharp_la_LIBADD = $(XAPIAN_LIBS)
 
 install-data-local: $(ASSEMBLY).dll
-	$(GACUTIL) /i $(ASSEMBLY).dll /f $(GACUTIL_FLAGS)
+	TERM= $(GACUTIL) /i $(ASSEMBLY).dll /f $(GACUTIL_FLAGS)
 
 SmokeTest.exe: SmokeTest.cs $(ASSEMBLY).dll
 	TERM= $(CSC) -unsafe -target:exe -out:SmokeTest.exe `test -f SmokeTest.cs||echo '$(srcdir)/'`SmokeTest.cs -r:$(ASSEMBLY).dll


### PR DESCRIPTION
While Building c# on Ubuntu 18.10 ,an error occurrs which is resolved by setting terminal to an empty value.