### PR TITLE
Allow  command to fail with an option to run failover script

### DIFF
--- a/xapian-applications/omega/docs/omegascript.rst
+++ b/xapian-applications/omega/docs/omegascript.rst
@@ -1018,8 +1018,9 @@ $if{COND[,THEN[,ELSE]]}
 
         The ability to omit ``THEN`` was added in Omega 1.4.15.
 
-$include{FILE}
-	include another OmegaScript file
+$include{FILE,[FAILOVER_SCRIPT]}
+        include another OmegaScript file ``FILE``, runs optional
+        OmegaScript ``FAILOVER_SCRIPT`` on failure.
 
 $switch{EXPR,CASE1,VALUE1,[CASE2,VALUE2]...[,DEFAULT]}
         first evaluates ``EXPR``, and then evaluates ``CASE1``, ``CASE2``, ...

--- a/xapian-applications/omega/omegatest
+++ b/xapian-applications/omega/omegatest
@@ -1451,6 +1451,17 @@ printf '$hitlist{$list{$terms{T},|}/$field{tag1}|$field{tag2}|$field{tag3}}' > "
 testcase 'Tone/one|two|three' B=Tone
 testcase 'Tthree|Ttwo/one|two|three' B=Ttwo B=Tthree
 
+
+# Test failover script is run when the failover script is provided
+# and non-existent template file is passed in $include
+printf '$include{non_existant.template,$set{data,replacement_for_template}}$opt{data}' > "$TEST_TEMPLATE"
+testcase 'replacement_for_template' B=Tone
+
+# Test exception is thrown when non-existent template file is passed in
+# $include and optional failover script is not provided
+printf '$include{non_existant.template}$opt{data}' > "$TEST_TEMPLATE"
+testcase "Exception: Couldn't read format template 'non_existant.template' (No such file or directory)" B=Tone
+
 rm "$OMEGA_CONFIG_FILE" "$TEST_INDEXSCRIPT" "$TEST_TEMPLATE"
 rm -rf "$TEST_DB"
 if [ "$failed" = 0 ] ; then

--- a/xapian-applications/omega/query.cc
+++ b/xapian-applications/omega/query.cc
@@ -1125,7 +1125,7 @@ T(htmlstrip,	   1, 1, N, 0), // html strip tags string (s/<[^>]*>?//g)
 T(httpheader,	   2, 2, N, 0), // arbitrary HTTP header
 T(id,		   0, 0, N, 0), // docid of current doc
 T(if,		   1, 3, 1, 0), // conditional
-T(include,	   1, 1, 1, 0), // include another file
+T(include,	   1, 2, 1, 0), // include another file
 T(json,		   1, 1, N, 0), // JSON string escaping
 T(jsonarray,	   1, 2, 1, 0), // Format list as a JSON array
 T(jsonbool,	   1, 1, 1, 0), // Format list as a JSON bool
@@ -1789,7 +1789,15 @@ eval(const string &fmt, const vector<string> &param)
 		    value = eval(args[2], param);
 		break;
 	    case CMD_include:
-		value = eval_file(args[0]);
+		try {
+		    value = eval_file(args[0]);
+		} catch (...) {
+		    if (args.size() == 2) {
+			value = eval(args[1], param);
+		    } else {
+			throw;
+		    }
+		}
 		break;
 	    case CMD_json:
 		value = args[0];


### PR DESCRIPTION
Implement option for allow failure in $include command in Omega

This adds a change to allow include to run an optional failover script if the provided template is non-existant.