### PR TITLE
Remote backend errors testing 

### DIFF
--- a/xapian-core/include/xapian/dbfactory.h
+++ b/xapian-core/include/xapian/dbfactory.h
@@ -119,6 +119,8 @@ Database open(const std::string &program, const std::string &args, unsigned time
 XAPIAN_VISIBILITY_DEFAULT
 WritableDatabase open_writable(const std::string &program, const std::string &args, unsigned timeout = 0, int flags = 0);
 
+XAPIAN_VISIBILITY_DEFAULT
+bool kill_server(const std::string& uuid);
 }
 #endif
 

--- a/xapian-core/net/progclient.cc
+++ b/xapian-core/net/progclient.cc
@@ -257,6 +257,16 @@ ProgClient::~ProgClient()
 #endif
 }
 
+#ifndef __WIN32__
+    pid_t
+#else
+    HANDLE
+#endif
+ProgClient::get_child() const
+{
+    return child;
+}
+
 #ifdef DISABLE_GPL_LIBXAPIAN
 # error GPL source we cannot relicense included in libxapian
 #endif

--- a/xapian-core/net/progclient.h
+++ b/xapian-core/net/progclient.h
@@ -97,6 +97,13 @@ class ProgClient : public RemoteDatabase {
 
     /** Destructor. */
     ~ProgClient();
+
+#ifndef __WIN32__
+    pid_t
+#else
+    HANDLE
+#endif
+get_child() const;
 };
 
 #endif // XAPIAN_INCLUDED_PROGCLIENT_H

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -490,8 +490,11 @@ DEFINE_TESTCASE(closedb10, writable && metadata) {
 DEFINE_TESTCASE(closedb11, remote) {
 	Xapian::WritableDatabase db(get_writable_database());
 	kill_server(db.get_uuid());
-	TEST_EXCEPTION(Xapian::NetworkError, db.add_document(Xapian::Document()));
-    TEST_EXCEPTION(Xapian::NetworkError, db.get_doccount());
-    TEST_EXCEPTION(Xapian::NetworkError, db.commit());
+	TEST_EXCEPTION(Xapian::NetworkError,
+		db.add_document(Xapian::Document()));
+    TEST_EXCEPTION(Xapian::NetworkError,
+		db.get_doccount());
+    TEST_EXCEPTION(Xapian::NetworkError,
+		db.commit());
 	return true;
 }

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -484,6 +484,14 @@ DEFINE_TESTCASE(closedb10, writable && metadata) {
 		   db.get_metadata("bar"));
     TEST_EXCEPTION(Xapian::DatabaseClosedError,
 		   db.metadata_keys_begin());
+	return true;
+}
 
-    return true;
+DEFINE_TESTCASE(closedb11, remote) {
+	Xapian::WritableDatabase db(get_writable_database());
+	kill_server(db.get_uuid());
+	TEST_EXCEPTION(Xapian::NetworkError, db.add_document(Xapian::Document()));
+    TEST_EXCEPTION(Xapian::NetworkError, db.get_doccount());
+    TEST_EXCEPTION(Xapian::NetworkError, db.commit());
+	return true;
 }

--- a/xapian-core/tests/api_closedb.cc
+++ b/xapian-core/tests/api_closedb.cc
@@ -492,9 +492,9 @@ DEFINE_TESTCASE(closedb11, remote) {
 	kill_server(db.get_uuid());
 	TEST_EXCEPTION(Xapian::NetworkError,
 		db.add_document(Xapian::Document()));
-    TEST_EXCEPTION(Xapian::NetworkError,
+	TEST_EXCEPTION(Xapian::NetworkError,
 		db.get_doccount());
-    TEST_EXCEPTION(Xapian::NetworkError,
+	TEST_EXCEPTION(Xapian::NetworkError,
 		db.commit());
 	return true;
 }

--- a/xapian-core/tests/apitest.cc
+++ b/xapian-core/tests/apitest.cc
@@ -152,6 +152,12 @@ XFAIL_FOR_BACKEND(const std::string& backend_prefix,
     }
 }
 
+bool
+kill_server(const std::string& uuid)
+{
+    return backendmanager->kill_server(uuid);
+}
+
 class ApiTestRunner : public TestRunner
 {
   public:

--- a/xapian-core/tests/apitest.h
+++ b/xapian-core/tests/apitest.h
@@ -71,6 +71,8 @@ void skip_test_unless_backend(const std::string & backend_prefix);
 // allows backends like "multi_glass" to be covered by specifying "multi".
 void skip_test_for_backend(const std::string & backend_prefix);
 
+bool kill_server(const std::string& uuid);
+
 #define SKIP_TEST_UNLESS_BACKEND(B) skip_test_unless_backend(B)
 #define SKIP_TEST_FOR_BACKEND(B) skip_test_for_backend(B)
 

--- a/xapian-core/tests/harness/backendmanager.cc
+++ b/xapian-core/tests/harness/backendmanager.cc
@@ -302,6 +302,13 @@ BackendManager::clean_up()
 {
 }
 
+bool 
+BackendManager::kill_server(const std::string& uuid)
+{
+    throw Xapian::InvalidOperationError("kill_server called for " + uuid + ", but available only for remote servers");
+    return false;
+}
+
 const char *
 BackendManager::get_xapian_progsrv_command()
 {

--- a/xapian-core/tests/harness/backendmanager.cc
+++ b/xapian-core/tests/harness/backendmanager.cc
@@ -302,10 +302,11 @@ BackendManager::clean_up()
 {
 }
 
-bool 
+bool
 BackendManager::kill_server(const std::string& uuid)
 {
-    throw Xapian::InvalidOperationError("kill_server called for " + uuid + ", but available only for remote servers");
+    throw Xapian::InvalidOperationError("kill_server called for " +
+    uuid + ", but available only for remote servers");
     return false;
 }
 

--- a/xapian-core/tests/harness/backendmanager.h
+++ b/xapian-core/tests/harness/backendmanager.h
@@ -167,6 +167,8 @@ class BackendManager {
      */
     virtual void clean_up();
 
+    bool kill_server(const std::string& uuid);
+
     /// Get the command line required to run xapian-progsrv.
     static const char * get_xapian_progsrv_command();
 };

--- a/xapian-core/tests/harness/backendmanager.h
+++ b/xapian-core/tests/harness/backendmanager.h
@@ -167,7 +167,7 @@ class BackendManager {
      */
     virtual void clean_up();
 
-    bool kill_server(const std::string& uuid);
+    virtual bool kill_server(const std::string& uuid);
 
     /// Get the command line required to run xapian-progsrv.
     static const char * get_xapian_progsrv_command();

--- a/xapian-core/tests/harness/backendmanager_multi.cc
+++ b/xapian-core/tests/harness/backendmanager_multi.cc
@@ -248,3 +248,18 @@ BackendManagerMulti::get_writable_database_path_again()
 {
     return last_wdb_path;
 }
+
+bool
+BackendManagerMulti::kill_server(const std::string& uuid) {
+    bool result = false;
+    for (auto sub_manager : sub_managers) {
+	string prefix = "remote";
+	string dbtype = sub_manager->get_dbtype();
+	if (std::mismatch(prefix.begin(), prefix.end(), dbtype.begin(),
+	    dbtype.end()).first == prefix.end()) {
+	    auto sub_db_uuid = uuid.substr(uuid.find(":") + 1);
+	    result |= sub_manager->kill_server(sub_db_uuid);
+	}
+    }
+    return result;
+}

--- a/xapian-core/tests/harness/backendmanager_multi.h
+++ b/xapian-core/tests/harness/backendmanager_multi.h
@@ -77,6 +77,8 @@ class BackendManagerMulti : public BackendManager {
 
     /// Get the path of the last opened WritableDatabase.
     std::string get_writable_database_path_again();
+
+    bool kill_server(const std::string& uuid);
 };
 
 #endif // XAPIAN_INCLUDED_BACKENDMANAGER_MULTI_H

--- a/xapian-core/tests/harness/backendmanager_remoteprog.cc
+++ b/xapian-core/tests/harness/backendmanager_remoteprog.cc
@@ -128,3 +128,9 @@ BackendManagerRemoteProg::get_writable_database_again()
 #endif
     return Xapian::Remote::open_writable(XAPIAN_PROGSRV, args);
 }
+
+bool
+BackendManagerRemoteProg::kill_server(const std::string& uuid)
+{
+    return Xapian::Remote::kill_server(uuid);
+}

--- a/xapian-core/tests/harness/backendmanager_remoteprog.h
+++ b/xapian-core/tests/harness/backendmanager_remoteprog.h
@@ -71,6 +71,8 @@ class BackendManagerRemoteProg : public BackendManagerRemote {
 
     /// Create a WritableDatabase object for the last opened WritableDatabase.
     Xapian::WritableDatabase get_writable_database_again();
+
+    bool kill_server(const std::string& uuid);
 };
 
 #endif // XAPIAN_INCLUDED_BACKENDMANAGER_REMOTEPROG_H

--- a/xapian-core/tests/harness/backendmanager_remotetcp.cc
+++ b/xapian-core/tests/harness/backendmanager_remotetcp.cc
@@ -81,7 +81,7 @@ struct pid_fd {
 static pid_fd pid_to_fd[16];
 
 struct port_pididx {
-    int port;
+	int port;
 	unsigned pididx;
 };
 
@@ -216,12 +216,12 @@ try_next_port:
 
     // Find a slot to track the pid->fd mapping in.  If we can't find a slot
     // it just means we'll leak the fd, so don't worry about that too much.
-    unsigned pididx = 0;
+	unsigned pididx = 0;
 	for (unsigned i = 0; i < sizeof(pid_to_fd) / sizeof(pid_fd); ++i) {
 	if (pid_to_fd[i].pid == 0) {
 	    pid_to_fd[i].fd = tracked_fd;
 	    pid_to_fd[i].pid = child;
-	    pididx = i;
+		pididx = i;
 		break;
 	}
     }
@@ -374,9 +374,9 @@ BackendManagerRemoteTcp::get_writable_database(const string & name,
 					       const string & file)
 {
     string args = get_writable_database_args(name, file);
-    auto pp = launch_xapian_tcpsrv(args);
+	auto pp = launch_xapian_tcpsrv(args);
 	auto db = Xapian::Remote::open_writable(LOCALHOST, pp.port);
-    uuid_to_pididx[db.get_uuid()] = pp.pididx;
+	uuid_to_pididx[db.get_uuid()] = pp.pididx;
 	return db;
 }
 

--- a/xapian-core/tests/harness/backendmanager_remotetcp.cc
+++ b/xapian-core/tests/harness/backendmanager_remotetcp.cc
@@ -81,8 +81,8 @@ struct pid_fd {
 static pid_fd pid_to_fd[16];
 
 struct port_pididx {
-	int port;
-	unsigned pididx;
+    int port;
+    unsigned pididx;
 };
 
 extern "C" {
@@ -219,8 +219,8 @@ try_next_port:
 	unsigned pididx = 0;
 	for (unsigned i = 0; i < sizeof(pid_to_fd) / sizeof(pid_fd); ++i) {
 	if (pid_to_fd[i].pid == 0) {
-	    pid_to_fd[i].fd = tracked_fd;
-	    pid_to_fd[i].pid = child;
+		pid_to_fd[i].fd = tracked_fd;
+		pid_to_fd[i].pid = child;
 		pididx = i;
 		break;
 	}
@@ -431,11 +431,6 @@ BackendManagerRemoteTcp::kill_server(const std::string& uuid)
 		close(fd);
 		return true;
 	}
-	pid_to_fd[pididx].fd = 0;
-	pid_to_fd[pididx].pid = 0;
-	close(fd);
-	return true;
-}
 #endif
 	return false;
 }

--- a/xapian-core/tests/harness/backendmanager_remotetcp.h
+++ b/xapian-core/tests/harness/backendmanager_remotetcp.h
@@ -67,6 +67,8 @@ class BackendManagerRemoteTcp : public BackendManagerRemote {
     /// Create a WritableDatabase object for the last opened WritableDatabase.
     Xapian::WritableDatabase get_writable_database_again();
 
+    bool kill_server(const std::string& uuid);
+
     /// Called after each test, to perform any necessary cleanup.
     void clean_up();
 };


### PR DESCRIPTION
tests are not passing, because of backendmanager::kill_server calls instead of backendmanager_remotetcp::kill_server. there several problems: 

I have tried to make particular remote server killable, but noticed that it is not only backendmanager_remote class used in "remote" test cases. there are backendmanager_mutli used during test invoking with several db classes i guess.
I want to know is my logic correct of making changes in xapian-core/tests/harness/backendmanager_remotetcp.cc correct? and can you explain how backendmanager_multi used in "remote" tests?