### PR TITLE
ruby: Don't print iterator sizes to stdout

### DIFF
--- a/xapian-bindings/ruby/xapian.rb
+++ b/xapian-bindings/ruby/xapian.rb
@@ -63,7 +63,6 @@ module Xapian
         retval.push(wrapper.call(item))
         item.next()
       end
-      puts retval.size()
       return retval
     end
   end # _safelyIterate


### PR DESCRIPTION
This was introduced in commit 4b6a37cd, presumably just some debugging
left in by mistake. It causes unwanted mess in the output of the
application using xapian bindings.