### PR TITLE
Enum parameters for Tf-idf weight

### DIFF
--- a/xapian-bindings/ruby/ruby.i
+++ b/xapian-bindings/ruby/ruby.i
@@ -112,9 +112,9 @@
 %rename("weight") get_weight;
 
 // Name of constants should start wth upper_case
-%rename("Wdfn_type") wdfn_type;
-%rename("Idfn_type") idfn_type;
-%rename("Wtn_type") wtn_type;
+%rename("Wdf_norm") wdf_norm;
+%rename("Idf_norm") idf_norm;
+%rename("Wt_norm") wt_norm;
 
 // These are 'dangerous' methods; i.e. they can cause a segfault if used
 // improperly.  We prefix with _dangerous_ so that Ruby users will not use them

--- a/xapian-bindings/ruby/ruby.i
+++ b/xapian-bindings/ruby/ruby.i
@@ -111,6 +111,11 @@
 %rename("wdf") get_wdf;
 %rename("weight") get_weight;
 
+// Name of constants should start wth upper_case
+%rename("Wdfn_type") wdfn_type;
+%rename("Idfn_type") idfn_type;
+%rename("Wtn_type") wtn_type;
+
 // These are 'dangerous' methods; i.e. they can cause a segfault if used
 // improperly.  We prefix with _dangerous_ so that Ruby users will not use them
 // inadvertently.

--- a/xapian-bindings/ruby/ruby.i
+++ b/xapian-bindings/ruby/ruby.i
@@ -111,7 +111,7 @@
 %rename("wdf") get_wdf;
 %rename("weight") get_weight;
 
-// Name of constants should start wth upper_case
+// Name of constants should start with upper case
 %rename("Wdf_norm") wdf_norm;
 %rename("Idf_norm") idf_norm;
 %rename("Wt_norm") wt_norm;

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -613,8 +613,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /** Construct a TfIdfWeight using the default normalizations ("ntn"). */
     TfIdfWeight()
-	: normalizations("ntn"), wdf_norm(WDF_NORM::NONE), idf_norm(IDF_NORM::TFIDF),
-	  wt_norm(WT_NORM::NONE), param_slope(0.2), param_delta(1.0)
+	: normalizations("ntn"), wdf_norm(WDF_NORM::NONE),
+	  idf_norm(IDF_NORM::TFIDF), wt_norm(WT_NORM::NONE),
+	  param_slope(0.2), param_delta(1.0)
     {
 	need_stat(TERMFREQ);
 	need_stat(WDF);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -467,51 +467,44 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
        during serialise(), the value may get truncated by static_cast<> and
        the desired result will not be achieved. */
   public:
-    /* The WDF_NORM works like so:
-     *
-     *    NONE: None.		wdfn=wdf
-     *    BOOLEAN: Boolean	wdfn=1 if term in document else wdfn=0
-     *    SQUARE: Square	wdfn=wdf*wdf
-     *    LOG: Logarithmic	wdfn=1+log<sub>e</sub>(wdf)
-     *    PIVOTED: Pivoted	wdfn=(1+log(1+log(wdf)))*
-     *				(1/(1-slope+(slope*doclen/avg_len)))+delta
-     *    LOG_AVERAGE: Log average wdfn=(1+log(wdf))/
-     *				   (1+log(doclen/unique_terms))
-     */
+    /** Wdf normalizations. */
     enum class WDF_NORM: int {
+    /*  NONE: None.  wdfn=wdf */
 	NONE = 1,
+    /*  BOOLEAN: Boolean  wdfn=1 if term in document else wdfn=0 */
 	BOOLEAN = 2,
+    /*  SQUARE: Square  wdfn=wdf*wdf */
 	SQUARE = 3,
+    /*  LOG: Logarithmic  wdfn=1+log<sub>e</sub>(wdf) */
 	LOG = 4,
+    /*  PIVOTED: Pivoted  wdfn=(1+log(1+log(wdf)))*
+     *			       (1/(1-slope+(slope*doclen/avg_len)))+delta */
 	PIVOTED = 5,
+    /*  LOG_AVERAGE: Log average  wdfn=(1+log(wdf))/(1+log(doclen/unique_terms)) */
 	LOG_AVERAGE = 6
     };
 
-    /* The IDF_NORM works like so:
-     *
-     *    NONE: None		idfn=1
-     *    TFIDF: TfIdf		idfn=log(N/Termfreq) where N is the number of
-     *    documents in collection and Termfreq is the number of documents
-     *    which are indexed by the term t.
-     *    PROB: Prob		idfn=log((N-Termfreq)/Termfreq)
-     *    FREQ: Freq		idfn=1/Termfreq
-     *    SQUARE: Squared	idfn=log(N/Termfreq)^2
-     *    PIVOTED: Pivoted	idfn=log((N+1)/Termfreq)
-     */
+    /** Idf normalizations. */
     enum class IDF_NORM: int {
+    /*  NONE: None  idfn=1 */
 	NONE = 1,
+    /*  TFIDF: TfIdf  idfn=log(N/Termfreq) where N is the number of documents
+     *  in collection and Termfreq is the number of documents which are
+     *  indexed by the term t. */
 	TFIDF = 2,
+    /*  SQUARE: Squared	 idfn=log(N/Termfreq)^2 */
 	SQUARE = 3,
+    /*  FREQ: Freq  idfn=1/Termfreq */
 	FREQ = 4,
+    /*  PROB: Prob  idfn=log((N-Termfreq)/Termfreq) */
 	PROB = 5,
+    /*  PIVOTED: Pivoted  idfn=log((N+1)/Termfreq) */
 	PIVOTED = 6
     };
 
-    /* The WT_NORM works like so:
-     *
-     *    NONE: None	wtn=tfn*idfn
-     */
+    /** Weight normalizations. */
     enum class WT_NORM: int {
+    /*  NONE: None  wtn=tfn*idfn */
 	NONE = 1
     };
   private:
@@ -546,6 +539,10 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
   public:
     /** Construct a TfIdfWeight
+     *
+     *  @param normalizations	A three character string indicating the
+     *				normalizations to be used for the tf(wdf), idf
+     *				and document weight.  (default: "ntn")
      *
      * The @a normalizations string works like so:
      *
@@ -587,6 +584,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /** Construct a TfIdfWeight
      *
+     *  @param normalizations	A three character string indicating the
+     *				normalizations to be used for the tf(wdf), idf
+     *				and document weight.  (default: "ntn")
      *	@param slope		Extra parameter for "Pivoted" tf normalization.  (default: 0.2)
      *	@param delta		Extra parameter for "Pivoted" tf normalization.  (default: 1.0)
      *

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -577,6 +577,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /* When additional normalizations are implemented in the future, the additional statistics for them
        should be accessed by these functions. */
+    wdf_norm decode_wdf_norm(char c);
+    idf_norm decode_idf_norm(char c);
+    wt_norm decode_wt_norm(char c);
     double get_wdfn(Xapian::termcount wdf,
 		    Xapian::termcount len,
 		    Xapian::termcount uniqterms,
@@ -627,7 +630,8 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      * Implementing support for more normalizations of each type would require
      * extending the backend to track more statistics.
      */
-    explicit TfIdfWeight(const std::string &normalizations);
+    explicit TfIdfWeight(const std::string &normalizations)
+	: TfIdfWeight(normalizations, 0.2, 1.0) {}
 
     /** Construct a TfIdfWeight
      *
@@ -683,7 +687,11 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      * Implementing support for more normalizations of each type would require
      * extending the backend to track more statistics.
      */
-    TfIdfWeight(wdf_norm wdf_norm_, idf_norm idf_norm_, wt_norm wt_norm_);
+    TfIdfWeight(wdf_norm wdf_normalization,
+		idf_norm idf_normalization,
+		wt_norm wt_normalization)
+	: TfIdfWeight(wdf_normalization, idf_normalization,
+		      wt_normalization, 0.2, 1.0) {}
 
     /** Construct a TfIdfWeight
      *

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -480,7 +480,8 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     /*  PIVOTED: Pivoted  wdfn=(1+log(1+log(wdf)))*
      *			       (1/(1-slope+(slope*doclen/avg_len)))+delta */
 	PIVOTED = 5,
-    /*  LOG_AVERAGE: Log average  wdfn=(1+log(wdf))/(1+log(doclen/unique_terms)) */
+    /*  LOG_AVERAGE: Log average  wdfn=(1+log(wdf))/
+     *				       (1+log(doclen/unique_terms)) */
 	LOG_AVERAGE = 6
     };
 

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -463,12 +463,8 @@ class XAPIAN_VISIBILITY_DEFAULT BoolWeight : public Weight {
 
 /// Xapian::Weight subclass implementing the tf-idf weighting scheme.
 class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
-    /* Three character string indicating the normalizations for tf(wdf), idf and
-       tfidf weight. */
-    std::string normalizations;
-
-    /* These three enum class should use integers only upto 256 . Otherwise
-       during serialise(), the value may get truncated by static_cast() and
+    /* These three enum classes should use integers only up to 255. Otherwise
+       during serialise(), the value may get truncated by static_cast<> and
        the desired result will not be achieved. */
   public:
     enum class WDF_NORM: int {
@@ -616,9 +612,8 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /** Construct a TfIdfWeight using the default normalizations ("ntn"). */
     TfIdfWeight()
-	: normalizations("ntn"), wdf_norm(WDF_NORM::NONE),
-	  idf_norm(IDF_NORM::TFIDF), wt_norm(WT_NORM::NONE),
-	  param_slope(0.2), param_delta(1.0)
+	: wdf_norm(WDF_NORM::NONE), idf_norm(IDF_NORM::TFIDF),
+	  wt_norm(WT_NORM::NONE), param_slope(0.2), param_delta(1.0)
     {
 	need_stat(TERMFREQ);
 	need_stat(WDF);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -468,7 +468,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
        the desired result will not be achieved. */
   public:
     /** Wdf normalizations. */
-    enum class WDF_NORM : int {
+    enum class wdfn_type : int {
 	/** None
 	 *
 	 *  wdfn=wdf
@@ -509,7 +509,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     };
 
     /** Idf normalizations. */
-    enum class IDF_NORM : int {
+    enum class idfn_type : int {
 	/** None
 	 *
 	 *  idfn=1
@@ -550,7 +550,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     };
 
     /** Weight normalizations. */
-    enum class WT_NORM : int {
+    enum class wtn_type : int {
 	/** None
 	 *
 	 *  wtn=tfn*idfn
@@ -559,11 +559,11 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     };
   private:
     /// The parameter for normalization for the wdf.
-    WDF_NORM wdf_norm;
+    wdfn_type wdf_norm;
     /// The parameter for normalization for the idf.
-    IDF_NORM idf_norm;
+    idfn_type idf_norm;
     /// The parameter for normalization for the document weight.
-    WT_NORM wt_norm;
+    wtn_type wt_norm;
 
     /// The factor to multiply with the weight.
     double wqf_factor;
@@ -583,9 +583,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     double get_wdfn(Xapian::termcount wdf,
 		    Xapian::termcount len,
 		    Xapian::termcount uniqterms,
-		    WDF_NORM wdf_norm_) const;
-    double get_idfn(IDF_NORM idf_norm_) const;
-    double get_wtn(double wt, WT_NORM wt_norm_) const;
+		    wdfn_type wdf_norm_) const;
+    double get_idfn(idfn_type idf_norm_) const;
+    double get_wtn(double wt, wtn_type wt_norm_) const;
 
   public:
     /** Construct a TfIdfWeight
@@ -686,7 +686,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      * Implementing support for more normalizations of each type would require
      * extending the backend to track more statistics.
      */
-    TfIdfWeight(WDF_NORM wdf_norm, IDF_NORM idf_norm, WT_NORM wt_norm);
+    TfIdfWeight(wdfn_type wdf_norm, idfn_type idf_norm, wtn_type wt_norm);
 
     /** Construct a TfIdfWeight
      *
@@ -701,13 +701,13 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      * Implementing support for more normalizations of each type would require
      * extending the backend to track more statistics.
      */
-    TfIdfWeight(WDF_NORM wdf_norm, IDF_NORM idf_norm,
-		WT_NORM wt_norm, double slope, double delta);
+    TfIdfWeight(wdfn_type wdf_norm, idfn_type idf_norm,
+		wtn_type wt_norm, double slope, double delta);
 
     /** Construct a TfIdfWeight using the default normalizations ("ntn"). */
     TfIdfWeight()
-	: wdf_norm(WDF_NORM::NONE), idf_norm(IDF_NORM::TFIDF),
-	  wt_norm(WT_NORM::NONE), param_slope(0.2), param_delta(1.0)
+	: wdf_norm(wdfn_type::NONE), idf_norm(idfn_type::TFIDF),
+	  wt_norm(wtn_type::NONE), param_slope(0.2), param_delta(1.0)
     {
 	need_stat(TERMFREQ);
 	need_stat(WDF);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -630,7 +630,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      * Implementing support for more normalizations of each type would require
      * extending the backend to track more statistics.
      */
-    explicit TfIdfWeight(const std::string &normalizations)
+    explicit TfIdfWeight(const std::string& normalizations)
 	: TfIdfWeight(normalizations, 0.2, 1.0) {}
 
     /** Construct a TfIdfWeight

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -467,6 +467,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
        tfidf weight. */
     std::string normalizations;
 
+    /* These three enum class should use integers only upto 256 . Otherwise
+       during serialise(), the value may get truncated by static_cast() and
+       the desired result will not be achieved. */
   public:
     enum class WDF_NORM: int {
 	NONE = 1,

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -463,12 +463,9 @@ class XAPIAN_VISIBILITY_DEFAULT BoolWeight : public Weight {
 
 /// Xapian::Weight subclass implementing the tf-idf weighting scheme.
 class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
-    /* These three enum classes should use integers only up to 255. Otherwise
-       during serialise(), the value may get truncated by static_cast<> and
-       the desired result will not be achieved. */
   public:
     /** Wdf normalizations. */
-    enum class wdfn_type : int {
+    enum class wdf_norm : unsigned char {
 	/** None
 	 *
 	 *  wdfn=wdf
@@ -509,7 +506,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     };
 
     /** Idf normalizations. */
-    enum class idfn_type : int {
+    enum class idf_norm : unsigned char {
 	/** None
 	 *
 	 *  idfn=1
@@ -550,7 +547,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     };
 
     /** Weight normalizations. */
-    enum class wtn_type : int {
+    enum class wt_norm : unsigned char {
 	/** None
 	 *
 	 *  wtn=tfn*idfn
@@ -559,11 +556,11 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     };
   private:
     /// The parameter for normalization for the wdf.
-    wdfn_type wdf_norm;
+    wdf_norm wdf_norm_;
     /// The parameter for normalization for the idf.
-    idfn_type idf_norm;
+    idf_norm idf_norm_;
     /// The parameter for normalization for the document weight.
-    wtn_type wt_norm;
+    wt_norm wt_norm_;
 
     /// The factor to multiply with the weight.
     double wqf_factor;
@@ -583,9 +580,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     double get_wdfn(Xapian::termcount wdf,
 		    Xapian::termcount len,
 		    Xapian::termcount uniqterms,
-		    wdfn_type wdf_norm_) const;
-    double get_idfn(idfn_type idf_norm_) const;
-    double get_wtn(double wt, wtn_type wt_norm_) const;
+		    wdf_norm wdf_normalization) const;
+    double get_idfn(idf_norm idf_normalization) const;
+    double get_wtn(double wt, wt_norm wt_normalization) const;
 
   public:
     /** Construct a TfIdfWeight
@@ -679,20 +676,20 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /** Construct a TfIdfWeight
      *
-     *	@param wdf_norm		The normalization for the wdf.
-     *	@param idf_norm		The normalization for the idf.
-     *	@param wt_norm		The normalization for the document weight.
+     *	@param wdf_norm_	The normalization for the wdf.
+     *	@param idf_norm_	The normalization for the idf.
+     *	@param wt_norm_		The normalization for the document weight.
      *
      * Implementing support for more normalizations of each type would require
      * extending the backend to track more statistics.
      */
-    TfIdfWeight(wdfn_type wdf_norm, idfn_type idf_norm, wtn_type wt_norm);
+    TfIdfWeight(wdf_norm wdf_norm_, idf_norm idf_norm_, wt_norm wt_norm_);
 
     /** Construct a TfIdfWeight
      *
-     *	@param wdf_norm		The normalization for the wdf.
-     *	@param idf_norm		The normalization for the idf.
-     *	@param wt_norm		The normalization for the document weight.
+     *	@param wdf_norm_	The normalization for the wdf.
+     *	@param idf_norm_	The normalization for the idf.
+     *	@param wt_norm_		The normalization for the document weight.
      *	@param slope		Extra parameter for "Pivoted" tf normalization.
      *				(default: 0.2)
      *	@param delta		Extra parameter for "Pivoted" tf normalization.
@@ -701,13 +698,13 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      * Implementing support for more normalizations of each type would require
      * extending the backend to track more statistics.
      */
-    TfIdfWeight(wdfn_type wdf_norm, idfn_type idf_norm,
-		wtn_type wt_norm, double slope, double delta);
+    TfIdfWeight(wdf_norm wdf_norm_, idf_norm idf_norm_,
+		wt_norm wt_norm_, double slope, double delta);
 
     /** Construct a TfIdfWeight using the default normalizations ("ntn"). */
     TfIdfWeight()
-	: wdf_norm(wdfn_type::NONE), idf_norm(idfn_type::TFIDF),
-	  wt_norm(wtn_type::NONE), param_slope(0.2), param_delta(1.0)
+	: wdf_norm_(wdf_norm::NONE), idf_norm_(idf_norm::TFIDF),
+	  wt_norm_(wt_norm::NONE), param_slope(0.2), param_delta(1.0)
     {
 	need_stat(TERMFREQ);
 	need_stat(WDF);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -467,6 +467,33 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
        tfidf weight. */
     std::string normalizations;
 
+  public:
+    enum class WDF_NORM: int {
+	NONE = 1,
+	BOOLEAN = 2,
+	SQUARE = 3,
+	LOG = 4,
+	PIVOTED = 5,
+	LOG_AVERAGE = 6
+    };
+
+    enum class IDF_NORM: int {
+	NONE = 1,
+	TFIDF = 2,
+	SQUARE = 3,
+	FREQ = 4,
+	PROB = 5,
+	PIVOTED = 6
+    };
+
+    enum class WT_NORM: int {
+	NONE = 1
+    };
+  private:
+    WDF_NORM wdf_norm;
+    IDF_NORM idf_norm;
+    WT_NORM wt_norm;
+
     /// The factor to multiply with the weight.
     double wqf_factor;
 
@@ -484,9 +511,10 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
        should be accessed by these functions. */
     double get_wdfn(Xapian::termcount wdf,
 		    Xapian::termcount len,
-		    Xapian::termcount uniqterms, char c) const;
-    double get_idfn(char c) const;
-    double get_wtn(double wt, char c) const;
+		    Xapian::termcount uniqterms,
+		    WDF_NORM wdf_norm_) const;
+    double get_idfn(IDF_NORM idf_norm_) const;
+    double get_wtn(double wt, WT_NORM wt_norm_) const;
 
   public:
     /** Construct a TfIdfWeight
@@ -578,9 +606,15 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      */
     TfIdfWeight(const std::string &normalizations, double slope, double delta);
 
+    TfIdfWeight(WDF_NORM wdf_norm, IDF_NORM idf_norm, WT_NORM wt_norm);
+
+    TfIdfWeight(WDF_NORM wdf_norm, IDF_NORM idf_norm,
+		WT_NORM wt_norm, double slope, double delta);
+
     /** Construct a TfIdfWeight using the default normalizations ("ntn"). */
     TfIdfWeight()
-	: normalizations("ntn"), param_slope(0.2), param_delta(1.0)
+	: normalizations("ntn"), wdf_norm(WDF_NORM::NONE), idf_norm(IDF_NORM::TFIDF),
+	  wt_norm(WT_NORM::NONE), param_slope(0.2), param_delta(1.0)
     {
 	need_stat(TERMFREQ);
 	need_stat(WDF);

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -467,6 +467,15 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
        during serialise(), the value may get truncated by static_cast<> and
        the desired result will not be achieved. */
   public:
+    /* The WDF_NORM works like so:
+     *
+     *    NONE: None.      wdfn=wdf
+     *    BOOLEAN: Boolean    wdfn=1 if term in document else wdfn=0
+     *    SQUARE: Square     wdfn=wdf*wdf
+     *    LOG: Logarithmic wdfn=1+log<sub>e</sub>(wdf)
+     *    PIVOTED: Pivoted     wdfn=(1+log(1+log(wdf)))*(1/(1-slope+(slope*doclen/avg_len)))+delta
+     *    LOG_AVERAGE: Log average wdfn=(1+log(wdf))/(1+log(doclen/unique_terms))
+     */
     enum class WDF_NORM: int {
 	NONE = 1,
 	BOOLEAN = 2,
@@ -476,6 +485,17 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 	LOG_AVERAGE = 6
     };
 
+    /* The IDF_NORM works like so:
+     *
+     *    NONE: None    idfn=1
+     *    TFIDF: TfIdf   idfn=log(N/Termfreq) where N is the number of
+     *    documents in collection and Termfreq is the number of documents
+     *    which are indexed by the term t.
+     *    PROB: Prob    idfn=log((N-Termfreq)/Termfreq)
+     *    FREQ: Freq    idfn=1/Termfreq
+     *    SQUARE: Squared idfn=log(N/Termfreq)^2
+     *    PIVOTED: Pivoted idfn=log((N+1)/Termfreq)
+     */
     enum class IDF_NORM: int {
 	NONE = 1,
 	TFIDF = 2,
@@ -485,12 +505,19 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 	PIVOTED = 6
     };
 
+    /* The WT_NORM works like so:
+     *
+     *    NONE: None wtn=tfn*idfn
+     */
     enum class WT_NORM: int {
 	NONE = 1
     };
   private:
+    /// The parameter for normalization for the wdf.
     WDF_NORM wdf_norm;
+    /// The parameter for normalization for the idf.
     IDF_NORM idf_norm;
+    /// The parameter for normalization for the document weight.
     WT_NORM wt_norm;
 
     /// The factor to multiply with the weight.
@@ -517,10 +544,6 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
   public:
     /** Construct a TfIdfWeight
-     *
-     *  @param normalizations	A three character string indicating the
-     *				normalizations to be used for the tf(wdf), idf
-     *				and document weight.  (default: "ntn")
      *
      * The @a normalizations string works like so:
      *
@@ -562,9 +585,6 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /** Construct a TfIdfWeight
      *
-     *  @param normalizations	A three character string indicating the
-     *				normalizations to be used for the tf(wdf), idf
-     *				and document weight.  (default: "ntn")
      *	@param slope		Extra parameter for "Pivoted" tf normalization.  (default: 0.2)
      *	@param delta		Extra parameter for "Pivoted" tf normalization.  (default: 1.0)
      *
@@ -605,8 +625,28 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      */
     TfIdfWeight(const std::string &normalizations, double slope, double delta);
 
+    /** Construct a TfIdfWeight
+     *
+     *	@param wdf_norm		The normalization for the wdf.
+     *	@param idf_norm		The normalization for the idf.
+     *	@param wt_norm		The normalization for the document weight.
+     *
+     * Implementing support for more normalizations of each type would require
+     * extending the backend to track more statistics.
+     */
     TfIdfWeight(WDF_NORM wdf_norm, IDF_NORM idf_norm, WT_NORM wt_norm);
 
+    /** Construct a TfIdfWeight
+     *
+     *	@param wdf_norm		The normalization for the wdf.
+     *	@param idf_norm		The normalization for the idf.
+     *	@param wt_norm		The normalization for the document weight.
+     *	@param slope		Extra parameter for "Pivoted" tf normalization.  (default: 0.2)
+     *	@param delta		Extra parameter for "Pivoted" tf normalization.  (default: 1.0)
+     *
+     * Implementing support for more normalizations of each type would require
+     * extending the backend to track more statistics.
+     */
     TfIdfWeight(WDF_NORM wdf_norm, IDF_NORM idf_norm,
 		WT_NORM wt_norm, double slope, double delta);
 

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -577,9 +577,9 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /* When additional normalizations are implemented in the future, the additional statistics for them
        should be accessed by these functions. */
-    wdf_norm decode_wdf_norm(char c);
-    idf_norm decode_idf_norm(char c);
-    wt_norm decode_wt_norm(char c);
+    wdf_norm decode_wdf_norm(const std::string& normalizations);
+    idf_norm decode_idf_norm(const std::string& normalizations);
+    wt_norm decode_wt_norm(const std::string& normalizations);
     double get_wdfn(Xapian::termcount wdf,
 		    Xapian::termcount len,
 		    Xapian::termcount uniqterms,

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -469,12 +469,14 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
   public:
     /* The WDF_NORM works like so:
      *
-     *    NONE: None.      wdfn=wdf
-     *    BOOLEAN: Boolean    wdfn=1 if term in document else wdfn=0
-     *    SQUARE: Square     wdfn=wdf*wdf
-     *    LOG: Logarithmic wdfn=1+log<sub>e</sub>(wdf)
-     *    PIVOTED: Pivoted     wdfn=(1+log(1+log(wdf)))*(1/(1-slope+(slope*doclen/avg_len)))+delta
-     *    LOG_AVERAGE: Log average wdfn=(1+log(wdf))/(1+log(doclen/unique_terms))
+     *    NONE: None.		wdfn=wdf
+     *    BOOLEAN: Boolean	wdfn=1 if term in document else wdfn=0
+     *    SQUARE: Square	wdfn=wdf*wdf
+     *    LOG: Logarithmic	wdfn=1+log<sub>e</sub>(wdf)
+     *    PIVOTED: Pivoted	wdfn=(1+log(1+log(wdf)))*
+     *				(1/(1-slope+(slope*doclen/avg_len)))+delta
+     *    LOG_AVERAGE: Log average wdfn=(1+log(wdf))/
+     *				   (1+log(doclen/unique_terms))
      */
     enum class WDF_NORM: int {
 	NONE = 1,
@@ -487,14 +489,14 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /* The IDF_NORM works like so:
      *
-     *    NONE: None    idfn=1
-     *    TFIDF: TfIdf   idfn=log(N/Termfreq) where N is the number of
+     *    NONE: None		idfn=1
+     *    TFIDF: TfIdf		idfn=log(N/Termfreq) where N is the number of
      *    documents in collection and Termfreq is the number of documents
      *    which are indexed by the term t.
-     *    PROB: Prob    idfn=log((N-Termfreq)/Termfreq)
-     *    FREQ: Freq    idfn=1/Termfreq
-     *    SQUARE: Squared idfn=log(N/Termfreq)^2
-     *    PIVOTED: Pivoted idfn=log((N+1)/Termfreq)
+     *    PROB: Prob		idfn=log((N-Termfreq)/Termfreq)
+     *    FREQ: Freq		idfn=1/Termfreq
+     *    SQUARE: Squared	idfn=log(N/Termfreq)^2
+     *    PIVOTED: Pivoted	idfn=log((N+1)/Termfreq)
      */
     enum class IDF_NORM: int {
 	NONE = 1,
@@ -507,7 +509,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     /* The WT_NORM works like so:
      *
-     *    NONE: None wtn=tfn*idfn
+     *    NONE: None	wtn=tfn*idfn
      */
     enum class WT_NORM: int {
 	NONE = 1
@@ -641,8 +643,10 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      *	@param wdf_norm		The normalization for the wdf.
      *	@param idf_norm		The normalization for the idf.
      *	@param wt_norm		The normalization for the document weight.
-     *	@param slope		Extra parameter for "Pivoted" tf normalization.  (default: 0.2)
-     *	@param delta		Extra parameter for "Pivoted" tf normalization.  (default: 1.0)
+     *	@param slope		Extra parameter for "Pivoted" tf normalization.
+     *				(default: 0.2)
+     *	@param delta		Extra parameter for "Pivoted" tf normalization.
+     *				(default: 1.0)
      *
      * Implementing support for more normalizations of each type would require
      * extending the backend to track more statistics.

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -468,44 +468,93 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
        the desired result will not be achieved. */
   public:
     /** Wdf normalizations. */
-    enum class WDF_NORM: int {
-    /*  NONE: None.  wdfn=wdf */
+    enum class WDF_NORM : int {
+	/** None
+	 *
+	 *  wdfn=wdf
+	 */
 	NONE = 1,
-    /*  BOOLEAN: Boolean  wdfn=1 if term in document else wdfn=0 */
+
+	/** Boolean
+	 *
+	 *  wdfn=1 if term in document else wdfn=0
+	 */
 	BOOLEAN = 2,
-    /*  SQUARE: Square  wdfn=wdf*wdf */
+
+	/** Square
+	 *
+	 *  wdfn=wdf*wdf
+	 */
 	SQUARE = 3,
-    /*  LOG: Logarithmic  wdfn=1+log<sub>e</sub>(wdf) */
+
+	/** Logarithmic
+	 *
+	 *  wdfn=1+log<sub>e</sub>(wdf)
+	 */
 	LOG = 4,
-    /*  PIVOTED: Pivoted  wdfn=(1+log(1+log(wdf)))*
-     *			       (1/(1-slope+(slope*doclen/avg_len)))+delta */
+
+	/** Pivoted
+	 *
+	 *  wdfn=(1+log(1+log(wdf)))*
+	 *	 (1/(1-slope+(slope*doclen/avg_len)))+delta
+	 */
 	PIVOTED = 5,
-    /*  LOG_AVERAGE: Log average  wdfn=(1+log(wdf))/
-     *				       (1+log(doclen/unique_terms)) */
+
+	/** Log average
+	 *
+	 *  wdfn=(1+log(wdf))/
+	 *	 (1+log(doclen/unique_terms))
+	 */
 	LOG_AVERAGE = 6
     };
 
     /** Idf normalizations. */
-    enum class IDF_NORM: int {
-    /*  NONE: None  idfn=1 */
+    enum class IDF_NORM : int {
+	/** None
+	 *
+	 *  idfn=1
+	 */
 	NONE = 1,
-    /*  TFIDF: TfIdf  idfn=log(N/Termfreq) where N is the number of documents
-     *  in collection and Termfreq is the number of documents which are
-     *  indexed by the term t. */
+
+	/** TfIdf
+	 *
+	 *  idfn=log(N/Termfreq) where N is the number of documents
+	 *  in collection and Termfreq is the number of documents which are
+	 *  indexed by the term t.
+	 */
 	TFIDF = 2,
-    /*  SQUARE: Squared	 idfn=log(N/Termfreq)^2 */
+
+	/** Square
+	 *
+	 *  idfn=log(N/Termfreq)^2
+	 */
 	SQUARE = 3,
-    /*  FREQ: Freq  idfn=1/Termfreq */
+
+	/** Frequency
+	 *
+	 *  idfn=1/Termfreq
+	 */
 	FREQ = 4,
-    /*  PROB: Prob  idfn=log((N-Termfreq)/Termfreq) */
+
+	/** Probability
+	 *
+	 *  idfn=log((N-Termfreq)/Termfreq)
+	 */
 	PROB = 5,
-    /*  PIVOTED: Pivoted  idfn=log((N+1)/Termfreq) */
+
+	/** Pivoted
+	 *
+	 *  idfn=log((N+1)/Termfreq)
+	 */
 	PIVOTED = 6
     };
 
     /** Weight normalizations. */
-    enum class WT_NORM: int {
-    /*  NONE: None  wtn=tfn*idfn */
+    enum class WT_NORM : int {
+	/** None
+	 *
+	 *  wtn=tfn*idfn
+	 */
 	NONE = 1
     };
   private:

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -963,7 +963,7 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     TEST_EQUAL_DOUBLE(mset[0].get_weight(), 1 + log(8.0));
     TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1.0);
 
-    // Check for SQUARE, NONE , NONE.
+    // Check for SQUARE, NONE, NONE.
     enquire.set_query(Xapian::Query("paragraph"));
     enquire.set_weighting_scheme(
 	Xapian::TfIdfWeight(
@@ -978,7 +978,7 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 
     // Check for NONE, TFIDF, NONE when termfreq=N
     enquire.set_query(Xapian::Query("this"));
-    // N=termfreq and so idfn=0 for "t"
+    // N=termfreq and so idfn=0 for TFIDF
     enquire.set_weighting_scheme(
 	Xapian::TfIdfWeight(
 	    Xapian::TfIdfWeight::wdf_norm::NONE,
@@ -993,7 +993,7 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 
     // Check for NONE, PROB, NONE and for both branches of PROB
     enquire.set_query(Xapian::Query("this"));
-    // N=termfreq and so idfn=0 for "p"
+    // N=termfreq and so idfn=0 for PROB
     enquire.set_weighting_scheme(
 	Xapian::TfIdfWeight(
 	    Xapian::TfIdfWeight::wdf_norm::NONE,
@@ -1007,7 +1007,11 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     }
 
     enquire.set_query(Xapian::Query("word"));
-    enquire.set_weighting_scheme(Xapian::TfIdfWeight("npn"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::PROB,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     mset_expect_order(mset, 2, 4);

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -814,7 +814,11 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 
     // check for "nsn" when termfreq != N
     enquire.set_query(query);
-    enquire.set_weighting_scheme(Xapian::TfIdfWeight("nsn"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::SQUARE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     mset_expect_order(mset, 2, 4);
@@ -822,7 +826,11 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 
     // Check for "bnn" and for both branches of 'b'.
     enquire.set_query(Xapian::Query("test"));
-    enquire.set_weighting_scheme(Xapian::TfIdfWeight("bnn"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::BOOLEAN,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 1);
     mset_expect_order(mset, 1);
@@ -830,7 +838,11 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 
     // Check for "lnn" and for both branches of 'l'.
     enquire.set_query(Xapian::Query("word"));
-    enquire.set_weighting_scheme(Xapian::TfIdfWeight("lnn"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::LOG,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     mset_expect_order(mset, 2, 4);

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -814,11 +814,7 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 
     // check for "nsn" when termfreq != N
     enquire.set_query(query);
-    enquire.set_weighting_scheme(
-	Xapian::TfIdfWeight(
-	    Xapian::TfIdfWeight::wdf_norm::NONE,
-	    Xapian::TfIdfWeight::idf_norm::SQUARE,
-	    Xapian::TfIdfWeight::wt_norm::NONE));
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("nsn"));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     mset_expect_order(mset, 2, 4);
@@ -826,11 +822,7 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 
     // Check for "bnn" and for both branches of 'b'.
     enquire.set_query(Xapian::Query("test"));
-    enquire.set_weighting_scheme(
-	Xapian::TfIdfWeight(
-	    Xapian::TfIdfWeight::wdf_norm::BOOLEAN,
-	    Xapian::TfIdfWeight::idf_norm::NONE,
-	    Xapian::TfIdfWeight::wt_norm::NONE));
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("bnn"));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 1);
     mset_expect_order(mset, 1);
@@ -838,11 +830,7 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
 
     // Check for "lnn" and for both branches of 'l'.
     enquire.set_query(Xapian::Query("word"));
-    enquire.set_weighting_scheme(
-	Xapian::TfIdfWeight(
-	    Xapian::TfIdfWeight::wdf_norm::LOG,
-	    Xapian::TfIdfWeight::idf_norm::NONE,
-	    Xapian::TfIdfWeight::wt_norm::NONE));
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("lnn"));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     mset_expect_order(mset, 2, 4);
@@ -894,6 +882,152 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     mset_expect_order(mset, 2, 4);
     TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8 * log((6.0 - 2) / 2));
     TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1 * log((6.0 - 2) / 2));
+
+    // Check for NONE, TFIDF, NONE when termfreq != N
+    enquire.set_query(query);
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::TFIDF,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    // doc 2 should have higher weight than 4 as only tf(wdf) will dominate.
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8.0 * log(6.0 / 2));
+
+    // Check that wqf is taken into account.
+    enquire.set_query(Xapian::Query("word", 2));
+    mset2 = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset2.size(), 2);
+    // wqf is 2, so weights should be doubled.
+    TEST_EQUAL_DOUBLE(mset[0].get_weight() * 2, mset2[0].get_weight());
+    TEST_EQUAL_DOUBLE(mset[1].get_weight() * 2, mset2[1].get_weight());
+
+    // Test with OP_SCALE_WEIGHT.
+    enquire.set_query(Xapian::Query(Xapian::Query::OP_SCALE_WEIGHT,
+				    query, 15.0));
+    mset2 = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset2.size(), 2);
+    // doc 2 should have higher weight than 4 as only tf(wdf) will dominate.
+    mset_expect_order(mset2, 2, 4);
+    TEST_NOT_EQUAL_DOUBLE(mset[0].get_weight(), 0.0);
+    TEST_EQUAL_DOUBLE(15 * mset[0].get_weight(), mset2[0].get_weight());
+
+    // check for NONE, FREQ, NONE when termfreq != N
+    enquire.set_query(query);
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::FREQ,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8.0 / 2);
+
+    // check for NONE, SQUARE, NONE when termfreq != N
+    enquire.set_query(query);
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::SQUARE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8.0 * pow(log(6.0 / 2), 2.0));
+
+    // Check for BOOLEAN, NONE, NONE and for both branches of BOOLEAN.
+    enquire.set_query(Xapian::Query("test"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::BOOLEAN,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 1);
+    mset_expect_order(mset, 1);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 1.0);
+
+    // Check for LOG, NONE, NONE and for both branches of LOG.
+    enquire.set_query(Xapian::Query("word"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::LOG,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 1 + log(8.0));
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1.0);
+
+    // Check for SQUARE, NONE , NONE.
+    enquire.set_query(Xapian::Query("paragraph"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::SQUARE,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE)); // idf=1 and tfn=tf*tf
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 5);
+    mset_expect_order(mset, 2, 1, 4, 3, 5);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 9.0);
+    TEST_EQUAL_DOUBLE(mset[4].get_weight(), 1.0);
+
+    // Check for NONE, TFIDF, NONE when termfreq=N
+    enquire.set_query(Xapian::Query("this"));
+    // N=termfreq and so idfn=0 for "t"
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::TFIDF,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 6);
+    mset_expect_order(mset, 1, 2, 3, 4, 5, 6);
+    for (int i = 0; i < 6; ++i) {
+	TEST_EQUAL_DOUBLE(mset[i].get_weight(), 0.0);
+    }
+
+    // Check for NONE, PROB, NONE and for both branches of PROB
+    enquire.set_query(Xapian::Query("this"));
+    // N=termfreq and so idfn=0 for "p"
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::PROB,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 6);
+    mset_expect_order(mset, 1, 2, 3, 4, 5, 6);
+    for (int i = 0; i < 6; ++i) {
+	TEST_EQUAL_DOUBLE(mset[i].get_weight(), 0.0);
+    }
+
+    enquire.set_query(Xapian::Query("word"));
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("npn"));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8 * log((6.0 - 2) / 2));
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1 * log((6.0 - 2) / 2));
+
+    // Check for LOG_AVERAGE, NONE, NONE.
+    enquire.set_query(Xapian::Query("word"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::LOG_AVERAGE,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(),
+		      (1 + log(8.0)) / (1 + log(81.0 / 56.0)));
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(),
+		      (1 + log(1.0)) / (1 + log(31.0 / 26.0)));
 }
 
 // Feature tests for pivoted normalization functions.
@@ -932,6 +1066,51 @@ DEFINE_TESTCASE(tfidfweight4, backend) {
     // check for "Ptn" which represents "Pxx"
     enquire.set_query(Xapian::Query("word"));
     enquire.set_weighting_scheme(Xapian::TfIdfWeight("Ptn", 0.2, 1.0));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    // Expect doc 2 with query "word" to have higher weight than doc 4.
+    mset_expect_order(mset, 2, 4);
+
+    // Check for PIVOTED, PIVOTED, NONE normalization string.
+    enquire.set_query(query);
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::PIVOTED,
+	    Xapian::TfIdfWeight::idf_norm::PIVOTED,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 5);
+    // Shorter docs should ranker higher if wqf is equal among all the docs.
+    TEST_REL(mset[0].get_weight(),>,mset[1].get_weight());
+    TEST_REL(mset[2].get_weight(),>,mset[3].get_weight());
+
+    // Check that wqf is taken into account.
+    enquire.set_query(Xapian::Query("paragraph", 2));
+    mset2 = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset2.size(), 5);
+    // wqf is 2, so weights should be doubled.
+    TEST_EQUAL_DOUBLE(mset[0].get_weight() * 2, mset2[0].get_weight());
+    TEST_EQUAL_DOUBLE(mset[1].get_weight() * 2, mset2[1].get_weight());
+
+    // check for NONE, PIVOTED, NONE
+    enquire.set_query(Xapian::Query("word"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::PIVOTED,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    // Expect doc 2 with query "word" to have higher weight than doc 4.
+    mset_expect_order(mset, 2, 4);
+
+    // check for PIVOTED, TFIDF, NONE
+    enquire.set_query(Xapian::Query("word"));
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::PIVOTED,
+	    Xapian::TfIdfWeight::idf_norm::TFIDF,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     // Expect doc 2 with query "word" to have higher weight than doc 4.

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -36,10 +36,10 @@ using namespace std;
 
 namespace Xapian {
 
-TfIdfWeight::TfIdfWeight(const std::string &normals)
+TfIdfWeight::TfIdfWeight(const std::string& normals)
     : TfIdfWeight::TfIdfWeight(normals, 0.2, 1.0) {}
 
-TfIdfWeight::TfIdfWeight(const std::string &normals, double slope, double delta)
+TfIdfWeight::TfIdfWeight(const std::string& normals, double slope, double delta)
     : normalizations(normals), param_slope(slope), param_delta(delta)
 {
     if (normalizations.length() != 3 ||

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -272,9 +272,10 @@ TfIdfWeight::get_wdfn(Xapian::termcount wdf, Xapian::termcount doclen,
 	    double den = 1 + log(wdf_avg);
 	    return num / den;
 	}
-	default:
-	    return wdf;
+	case wdf_norm::NONE:
+	    break;
     }
+    return wdf;
 }
 
 double
@@ -299,9 +300,10 @@ TfIdfWeight::get_idfn(idf_norm idf_normalization) const
 	    return pow(log(N / termfreq), 2.0);
 	case idf_norm::PIVOTED:
 	    return log((N + 1) / termfreq);
-	default:
-	    return (log(N / termfreq));
+	case idf_norm::TFIDF:
+	    break;
     }
+    return (log(N / termfreq));
 }
 
 double

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -37,66 +37,7 @@ using namespace std;
 namespace Xapian {
 
 TfIdfWeight::TfIdfWeight(const std::string &normals)
-    : normalizations(normals), param_slope(0.2), param_delta(1.0)
-{
-    if (normalizations.length() != 3 ||
-	!strchr("nbslPL", normalizations[0]) ||
-	!strchr("ntpfsP", normalizations[1]) ||
-	!strchr("n", normalizations[2]))
-	throw Xapian::InvalidArgumentError("Normalization string is invalid");
-    if (normalizations[1] != 'n') {
-	need_stat(TERMFREQ);
-	need_stat(COLLECTION_SIZE);
-    }
-    need_stat(WDF);
-    need_stat(WDF_MAX);
-    need_stat(WQF);
-    if (normalizations[0] == 'L') {
-	need_stat(DOC_LENGTH);
-	need_stat(DOC_LENGTH_MIN);
-	need_stat(DOC_LENGTH_MAX);
-	need_stat(UNIQUE_TERMS);
-    }
-    switch (normalizations[0]) {
-	case 'b':
-	    wdf_norm = WDF_NORM::BOOLEAN;
-	    break;
-	case 's':
-	    wdf_norm = WDF_NORM::SQUARE;
-	    break;
-	case 'l':
-	    wdf_norm = WDF_NORM::LOG;
-	    break;
-	case 'P':
-	    wdf_norm = WDF_NORM::PIVOTED;
-	    break;
-	case 'L':
-	    wdf_norm = WDF_NORM::LOG_AVERAGE;
-	    break;
-	default:
-	    wdf_norm = WDF_NORM::NONE;
-    }
-    switch (normalizations[1]) {
-	case 'n':
-	    idf_norm = IDF_NORM::NONE;
-	    break;
-	case 's':
-	    idf_norm = IDF_NORM::SQUARE;
-	    break;
-	case 'f':
-	    idf_norm = IDF_NORM::FREQ;
-	    break;
-	case 'P':
-	    idf_norm = IDF_NORM::PIVOTED;
-	    break;
-	case 'p':
-	    idf_norm = IDF_NORM::PROB;
-	    break;
-	default:
-	    idf_norm = IDF_NORM::TFIDF;
-    }
-    wt_norm = WT_NORM::NONE;
-}
+    : TfIdfWeight::TfIdfWeight(normals, 0.2, 1.0) {}
 
 TfIdfWeight::TfIdfWeight(const std::string &normals, double slope, double delta)
     : normalizations(normals), param_slope(slope), param_delta(delta)
@@ -172,58 +113,13 @@ TfIdfWeight::TfIdfWeight(const std::string &normals, double slope, double delta)
 TfIdfWeight::TfIdfWeight(WDF_NORM wdf_norm_,
 			 IDF_NORM idf_norm_,
 			 WT_NORM wt_norm_)
-    : wdf_norm(wdf_norm_), idf_norm(idf_norm_), wt_norm(wt_norm_),
-      param_slope(0.2), param_delta(1.0)
-{
-    if (!((wdf_norm == WDF_NORM::NONE) || (wdf_norm == WDF_NORM::BOOLEAN) ||
-	(wdf_norm == WDF_NORM::LOG_AVERAGE) || (wdf_norm == WDF_NORM::LOG) ||
-	(wdf_norm == WDF_NORM::PIVOTED) || (wdf_norm == WDF_NORM::SQUARE)))
-	throw Xapian::InvalidArgumentError("WDF_NORM is invalid");
-    if (!((idf_norm == IDF_NORM::NONE) || (idf_norm == IDF_NORM::TFIDF) ||
-	(idf_norm == IDF_NORM::SQUARE) || (idf_norm == IDF_NORM::FREQ) ||
-	(idf_norm == IDF_NORM::PIVOTED) || (idf_norm == IDF_NORM::PROB)))
-	throw Xapian::InvalidArgumentError("IDF_NORM is invalid");
-    if (!(wt_norm == WT_NORM::NONE))
-	throw Xapian::InvalidArgumentError("WT_NORM is invalid");
-    if (param_slope <= 0)
-	throw Xapian::InvalidArgumentError("Parameter slope is invalid");
-    if (param_delta <= 0)
-	throw Xapian::InvalidArgumentError("Parameter delta is invalid");
-    if (idf_norm != IDF_NORM::NONE) {
-	need_stat(TERMFREQ);
-	need_stat(COLLECTION_SIZE);
-    }
-    need_stat(WDF);
-    need_stat(WDF_MAX);
-    need_stat(WQF);
-    if (wdf_norm == WDF_NORM::PIVOTED || idf_norm == IDF_NORM::PIVOTED) {
-	need_stat(AVERAGE_LENGTH);
-	need_stat(DOC_LENGTH);
-	need_stat(DOC_LENGTH_MIN);
-    }
-    if (wdf_norm == WDF_NORM::LOG_AVERAGE) {
-	need_stat(DOC_LENGTH);
-	need_stat(DOC_LENGTH_MIN);
-	need_stat(DOC_LENGTH_MAX);
-	need_stat(UNIQUE_TERMS);
-    }
-}
+    : TfIdfWeight::TfIdfWeight(wdf_norm_, idf_norm_, wt_norm_, 0.2, 1.0) {}
 
 TfIdfWeight::TfIdfWeight(WDF_NORM wdf_norm_, IDF_NORM idf_norm_,
 			 WT_NORM wt_norm_, double slope, double delta)
     : wdf_norm(wdf_norm_), idf_norm(idf_norm_), wt_norm(wt_norm_),
       param_slope(slope), param_delta(delta)
 {
-    if (!((wdf_norm == WDF_NORM::NONE) || (wdf_norm == WDF_NORM::BOOLEAN) ||
-	(wdf_norm == WDF_NORM::LOG_AVERAGE) || (wdf_norm == WDF_NORM::LOG) ||
-	(wdf_norm == WDF_NORM::PIVOTED) || (wdf_norm == WDF_NORM::SQUARE)))
-	throw Xapian::InvalidArgumentError("WDF_NORM is invalid");
-    if (!((idf_norm == IDF_NORM::NONE) || (idf_norm == IDF_NORM::TFIDF) ||
-	(idf_norm == IDF_NORM::SQUARE) || (idf_norm == IDF_NORM::FREQ) ||
-	(idf_norm == IDF_NORM::PIVOTED) || (idf_norm == IDF_NORM::PROB)))
-	throw Xapian::InvalidArgumentError("IDF_NORM is invalid");
-    if (!(wt_norm == WT_NORM::NONE))
-	throw Xapian::InvalidArgumentError("WT_NORM is invalid");
     if (param_slope <= 0)
 	throw Xapian::InvalidArgumentError("Parameter slope is invalid");
     if (param_delta <= 0)
@@ -372,7 +268,6 @@ TfIdfWeight::get_wdfn(Xapian::termcount wdf, Xapian::termcount doclen,
 	    return num / den;
 	}
 	default:
-	    AssertEq(wdf_norm_, WDF_NORM::NONE);
 	    return wdf;
     }
 }
@@ -400,7 +295,6 @@ TfIdfWeight::get_idfn(IDF_NORM idf_norm_) const
 	case IDF_NORM::PIVOTED:
 	    return log((N + 1) / termfreq);
 	default:
-	    AssertEq(idf_norm_, IDF_NORM::TFIDF);
 	    return (log(N / termfreq));
     }
 }
@@ -409,7 +303,6 @@ double
 TfIdfWeight::get_wtn(double wt, WT_NORM wt_norm_) const
 {
     (void)wt_norm_;
-    AssertEq(wt_norm_, WT_NORM::NONE);
     return wt;
 }
 

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -37,9 +37,11 @@ using namespace std;
 namespace Xapian {
 
 TfIdfWeight::wdf_norm
-TfIdfWeight::decode_wdf_norm(char c)
+TfIdfWeight::decode_wdf_norm(const string& normalizations)
 {
-    switch (c) {
+    if (normalizations.length() != 3)
+	throw Xapian::InvalidArgumentError("Normalization string is invalid");
+    switch (normalizations[0]) {
 	case 'b':
 	    return wdf_norm::BOOLEAN;
 	case 's':
@@ -52,16 +54,16 @@ TfIdfWeight::decode_wdf_norm(char c)
 	    return wdf_norm::LOG_AVERAGE;
 	case 'n':
 	    return wdf_norm::NONE;
-	default:
-	    throw Xapian::InvalidArgumentError
-		  ("Normalization string is invalid");
     }
+    throw Xapian::InvalidArgumentError("Normalization string is invalid");
 }
 
 TfIdfWeight::idf_norm
-TfIdfWeight::decode_idf_norm(char c)
+TfIdfWeight::decode_idf_norm(const string& normalizations)
 {
-    switch (c) {
+    if (normalizations.length() != 3)
+	throw Xapian::InvalidArgumentError("Normalization string is invalid");
+    switch (normalizations[1]) {
 	case 'n':
 	    return idf_norm::NONE;
 	case 's':
@@ -74,29 +76,27 @@ TfIdfWeight::decode_idf_norm(char c)
 	    return idf_norm::PROB;
 	case 't':
 	    return idf_norm::TFIDF;
-	default:
-	    throw Xapian::InvalidArgumentError
-		  ("Normalization string is invalid");
     }
+    throw Xapian::InvalidArgumentError("Normalization string is invalid");
 }
 
 TfIdfWeight::wt_norm
-TfIdfWeight::decode_wt_norm(char c)
+TfIdfWeight::decode_wt_norm(const string& normalizations)
 {
-    switch (c) {
+    if (normalizations.length() != 3)
+	throw Xapian::InvalidArgumentError("Normalization string is invalid");
+    switch (normalizations[2]) {
 	case 'n':
 	    return wt_norm::NONE;
-	default:
-	    throw Xapian::InvalidArgumentError
-		  ("Normalization string is invalid");
     }
+    throw Xapian::InvalidArgumentError("Normalization string is invalid");
 }
 
 TfIdfWeight::TfIdfWeight(const std::string& normals,
 			 double slope, double delta)
-    : TfIdfWeight::TfIdfWeight(decode_wdf_norm(normals[0]),
-			       decode_idf_norm(normals[1]),
-			       decode_wt_norm(normals[2]),
+    : TfIdfWeight::TfIdfWeight(decode_wdf_norm(normals),
+			       decode_idf_norm(normals),
+			       decode_wt_norm(normals),
 			       slope, delta) {}
 
 TfIdfWeight::TfIdfWeight(wdf_norm wdf_normalization,
@@ -182,7 +182,7 @@ TfIdfWeight::unserialise(const string & s) const
     double delta = unserialise_double(&ptr, end);
     if (rare(end - ptr != 3))
 	throw Xapian::SerialisationError
-	      ("Extra data in TfIdfWeight::unserialise()");
+	      ("Incorrect data in TfIdfWeight::unserialise()");
     wdf_norm wdf_normalization = static_cast<wdf_norm>(*(ptr)++);
     idf_norm idf_normalization = static_cast<idf_norm>(*(ptr)++);
     wt_norm wt_normalization = static_cast<wt_norm>(*(ptr)++);

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -40,36 +40,36 @@ TfIdfWeight::TfIdfWeight(const std::string& normals)
     : TfIdfWeight::TfIdfWeight(normals, 0.2, 1.0) {}
 
 TfIdfWeight::TfIdfWeight(const std::string& normals, double slope, double delta)
-    : normalizations(normals), param_slope(slope), param_delta(delta)
+    : param_slope(slope), param_delta(delta)
 {
-    if (normalizations.length() != 3 ||
-	!strchr("nbslPL", normalizations[0]) ||
-	!strchr("ntpfsP", normalizations[1]) ||
-	!strchr("n", normalizations[2]))
+    if (normals.length() != 3 ||
+	!strchr("nbslPL", normals[0]) ||
+	!strchr("ntpfsP", normals[1]) ||
+	!strchr("n", normals[2]))
 	throw Xapian::InvalidArgumentError("Normalization string is invalid");
     if (param_slope <= 0)
 	throw Xapian::InvalidArgumentError("Parameter slope is invalid");
     if (param_delta <= 0)
 	throw Xapian::InvalidArgumentError("Parameter delta is invalid");
-    if (normalizations[1] != 'n') {
+    if (normals[1] != 'n') {
 	need_stat(TERMFREQ);
 	need_stat(COLLECTION_SIZE);
     }
     need_stat(WDF);
     need_stat(WDF_MAX);
     need_stat(WQF);
-    if (normalizations[0] == 'P' || normalizations[1] == 'P') {
+    if (normals[0] == 'P' || normals[1] == 'P') {
 	need_stat(AVERAGE_LENGTH);
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
     }
-    if (normalizations[0] == 'L') {
+    if (normals[0] == 'L') {
 	need_stat(DOC_LENGTH);
 	need_stat(DOC_LENGTH_MIN);
 	need_stat(DOC_LENGTH_MAX);
 	need_stat(UNIQUE_TERMS);
     }
-    switch (normalizations[0]) {
+    switch (normals[0]) {
 	case 'b':
 	    wdf_norm = WDF_NORM::BOOLEAN;
 	    break;
@@ -88,7 +88,7 @@ TfIdfWeight::TfIdfWeight(const std::string& normals, double slope, double delta)
 	default:
 	    wdf_norm = WDF_NORM::NONE;
     }
-    switch (normalizations[1]) {
+    switch (normals[1]) {
 	case 'n':
 	    idf_norm = IDF_NORM::NONE;
 	    break;

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -57,6 +57,45 @@ TfIdfWeight::TfIdfWeight(const std::string &normals)
 	need_stat(DOC_LENGTH_MAX);
 	need_stat(UNIQUE_TERMS);
     }
+    switch (normalizations[0]) {
+	case 'b':
+	    wdf_norm = WDF_NORM::BOOLEAN;
+	    break;
+	case 's':
+	    wdf_norm = WDF_NORM::SQUARE;
+	    break;
+	case 'l':
+	    wdf_norm = WDF_NORM::LOG;
+	    break;
+	case 'P':
+	    wdf_norm = WDF_NORM::PIVOTED;
+	    break;
+	case 'L':
+	    wdf_norm = WDF_NORM::LOG_AVERAGE;
+	    break;
+	default:
+	    wdf_norm = WDF_NORM::NONE;
+    }
+    switch (normalizations[1]) {
+	case 'n':
+	    idf_norm = IDF_NORM::NONE;
+	    break;
+	case 's':
+	    idf_norm = IDF_NORM::SQUARE;
+	    break;
+	case 'f':
+	    idf_norm = IDF_NORM::FREQ;
+	    break;
+	case 'P':
+	    idf_norm = IDF_NORM::PIVOTED;
+	    break;
+	case 'p':
+	    idf_norm = IDF_NORM::PROB;
+	    break;
+	default:
+	    idf_norm = IDF_NORM::TFIDF;
+    }
+    wt_norm = WT_NORM::NONE;
 }
 
 TfIdfWeight::TfIdfWeight(const std::string &normals, double slope, double delta)
@@ -89,12 +128,131 @@ TfIdfWeight::TfIdfWeight(const std::string &normals, double slope, double delta)
 	need_stat(DOC_LENGTH_MAX);
 	need_stat(UNIQUE_TERMS);
     }
+    switch (normalizations[0]) {
+	case 'b':
+	    wdf_norm = WDF_NORM::BOOLEAN;
+	    break;
+	case 's':
+	    wdf_norm = WDF_NORM::SQUARE;
+	    break;
+	case 'l':
+	    wdf_norm = WDF_NORM::LOG;
+	    break;
+	case 'P':
+	    wdf_norm = WDF_NORM::PIVOTED;
+	    break;
+	case 'L':
+	    wdf_norm = WDF_NORM::LOG_AVERAGE;
+	    break;
+	default:
+	    wdf_norm = WDF_NORM::NONE;
+    }
+    switch (normalizations[1]) {
+	case 'n':
+	    idf_norm = IDF_NORM::NONE;
+	    break;
+	case 's':
+	    idf_norm = IDF_NORM::SQUARE;
+	    break;
+	case 'f':
+	    idf_norm = IDF_NORM::FREQ;
+	    break;
+	case 'P':
+	    idf_norm = IDF_NORM::PIVOTED;
+	    break;
+	case 'p':
+	    idf_norm = IDF_NORM::PROB;
+	    break;
+	default:
+	    idf_norm = IDF_NORM::TFIDF;
+    }
+    wt_norm = WT_NORM::NONE;
+}
+
+TfIdfWeight::TfIdfWeight(WDF_NORM wdf_norm_,
+			 IDF_NORM idf_norm_,
+			 WT_NORM wt_norm_)
+    : wdf_norm(wdf_norm_), idf_norm(idf_norm_), wt_norm(wt_norm_),
+      param_slope(0.2), param_delta(1.0)
+{
+    if (!((wdf_norm == WDF_NORM::NONE) || (wdf_norm == WDF_NORM::BOOLEAN) ||
+	(wdf_norm == WDF_NORM::LOG_AVERAGE) || (wdf_norm == WDF_NORM::LOG) ||
+	(wdf_norm == WDF_NORM::PIVOTED) || (wdf_norm == WDF_NORM::SQUARE)))
+	throw Xapian::InvalidArgumentError("WDF_NORM is invalid");
+    if (!((idf_norm == IDF_NORM::NONE) || (idf_norm == IDF_NORM::TFIDF) ||
+	(idf_norm == IDF_NORM::SQUARE) || (idf_norm == IDF_NORM::FREQ) ||
+	(idf_norm == IDF_NORM::PIVOTED) || (idf_norm == IDF_NORM::PROB)))
+	throw Xapian::InvalidArgumentError("IDF_NORM is invalid");
+    if (!(wt_norm == WT_NORM::NONE))
+	throw Xapian::InvalidArgumentError("WT_NORM is invalid");
+    if (param_slope <= 0)
+	throw Xapian::InvalidArgumentError("Parameter slope is invalid");
+    if (param_delta <= 0)
+	throw Xapian::InvalidArgumentError("Parameter delta is invalid");
+    if (idf_norm != IDF_NORM::NONE) {
+	need_stat(TERMFREQ);
+	need_stat(COLLECTION_SIZE);
+    }
+    need_stat(WDF);
+    need_stat(WDF_MAX);
+    need_stat(WQF);
+    if (wdf_norm == WDF_NORM::PIVOTED || idf_norm == IDF_NORM::PIVOTED) {
+	need_stat(AVERAGE_LENGTH);
+	need_stat(DOC_LENGTH);
+	need_stat(DOC_LENGTH_MIN);
+    }
+    if (wdf_norm == WDF_NORM::LOG_AVERAGE) {
+	need_stat(DOC_LENGTH);
+	need_stat(DOC_LENGTH_MIN);
+	need_stat(DOC_LENGTH_MAX);
+	need_stat(UNIQUE_TERMS);
+    }
+}
+
+TfIdfWeight::TfIdfWeight(WDF_NORM wdf_norm_, IDF_NORM idf_norm_,
+			 WT_NORM wt_norm_, double slope, double delta)
+    : wdf_norm(wdf_norm_), idf_norm(idf_norm_), wt_norm(wt_norm_),
+      param_slope(slope), param_delta(delta)
+{
+    if (!((wdf_norm == WDF_NORM::NONE) || (wdf_norm == WDF_NORM::BOOLEAN) ||
+	(wdf_norm == WDF_NORM::LOG_AVERAGE) || (wdf_norm == WDF_NORM::LOG) ||
+	(wdf_norm == WDF_NORM::PIVOTED) || (wdf_norm == WDF_NORM::SQUARE)))
+	throw Xapian::InvalidArgumentError("WDF_NORM is invalid");
+    if (!((idf_norm == IDF_NORM::NONE) || (idf_norm == IDF_NORM::TFIDF) ||
+	(idf_norm == IDF_NORM::SQUARE) || (idf_norm == IDF_NORM::FREQ) ||
+	(idf_norm == IDF_NORM::PIVOTED) || (idf_norm == IDF_NORM::PROB)))
+	throw Xapian::InvalidArgumentError("IDF_NORM is invalid");
+    if (!(wt_norm == WT_NORM::NONE))
+	throw Xapian::InvalidArgumentError("WT_NORM is invalid");
+    if (param_slope <= 0)
+	throw Xapian::InvalidArgumentError("Parameter slope is invalid");
+    if (param_delta <= 0)
+	throw Xapian::InvalidArgumentError("Parameter delta is invalid");
+    if (idf_norm != IDF_NORM::NONE) {
+	need_stat(TERMFREQ);
+	need_stat(COLLECTION_SIZE);
+    }
+    need_stat(WDF);
+    need_stat(WDF_MAX);
+    need_stat(WQF);
+    if (wdf_norm == WDF_NORM::PIVOTED || idf_norm == IDF_NORM::PIVOTED) {
+	need_stat(AVERAGE_LENGTH);
+	need_stat(DOC_LENGTH);
+	need_stat(DOC_LENGTH_MIN);
+    }
+    if (wdf_norm == WDF_NORM::LOG_AVERAGE) {
+	need_stat(DOC_LENGTH);
+	need_stat(DOC_LENGTH_MIN);
+	need_stat(DOC_LENGTH_MAX);
+	need_stat(UNIQUE_TERMS);
+    }
 }
 
 TfIdfWeight *
 TfIdfWeight::clone() const
 {
-    return new TfIdfWeight(normalizations, param_slope, param_delta);
+    return new TfIdfWeight(wdf_norm, idf_norm, wt_norm,
+			   param_slope, param_delta);
 }
 
 void
@@ -107,7 +265,7 @@ TfIdfWeight::init(double factor_)
     }
 
     wqf_factor = get_wqf() * factor_;
-    idfn = get_idfn(normalizations[1]);
+    idfn = get_idfn(idf_norm);
 }
 
 string
@@ -127,7 +285,9 @@ TfIdfWeight::serialise() const
 {
     string result = serialise_double(param_slope);
     result += serialise_double(param_delta);
-    result += normalizations;
+    result += static_cast<unsigned char>(wdf_norm);
+    result += static_cast<unsigned char>(idf_norm);
+    result += static_cast<unsigned char>(wt_norm);
     return result;
 }
 
@@ -138,19 +298,20 @@ TfIdfWeight::unserialise(const string & s) const
     const char *end = ptr + s.size();
     double slope = unserialise_double(&ptr, end);
     double delta = unserialise_double(&ptr, end);
-    string normals(ptr, end);
-    ptr += 3;
+    WDF_NORM wdf_norm_ = static_cast<WDF_NORM>(*(ptr)++);
+    IDF_NORM idf_norm_ = static_cast<IDF_NORM>(*(ptr)++);
+    WT_NORM wt_norm_ = static_cast<WT_NORM>(*(ptr)++);
     if (rare(ptr != end))
 	throw Xapian::SerialisationError("Extra data in TfIdfWeight::unserialise()");
-    return new TfIdfWeight(normals, slope, delta);
+    return new TfIdfWeight(wdf_norm_, idf_norm_, wt_norm_, slope, delta);
 }
 
 double
 TfIdfWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount doclen,
 			 Xapian::termcount uniqterms) const
 {
-    double wdfn = get_wdfn(wdf, doclen, uniqterms, normalizations[0]);
-    return get_wtn(wdfn * idfn, normalizations[2]) * wqf_factor;
+    double wdfn = get_wdfn(wdf, doclen, uniqterms, wdf_norm);
+    return get_wtn(wdfn * idfn, wt_norm) * wqf_factor;
 }
 
 // An upper bound can be calculated simply on the basis of wdf_max as termfreq
@@ -160,8 +321,8 @@ TfIdfWeight::get_maxpart() const
 {
     Xapian::termcount wdf_max = get_wdf_upper_bound();
     Xapian::termcount len_min = get_doclength_lower_bound();
-    double wdfn = get_wdfn(wdf_max, len_min, len_min, normalizations[0]);
-    return get_wtn(wdfn * idfn, normalizations[2]) * wqf_factor;
+    double wdfn = get_wdfn(wdf_max, len_min, len_min, wdf_norm);
+    return get_wtn(wdfn * idfn, wt_norm) * wqf_factor;
 }
 
 // There is no extra per document component in the TfIdfWeighting scheme.
@@ -180,24 +341,24 @@ TfIdfWeight::get_maxextra() const
 // Return normalized wdf, idf and weight depending on the normalization string.
 double
 TfIdfWeight::get_wdfn(Xapian::termcount wdf, Xapian::termcount doclen,
-		      Xapian::termcount uniqterms, char c) const
+		      Xapian::termcount uniqterms, WDF_NORM wdf_norm_) const
 {
-    switch (c) {
-	case 'b':
+    switch (wdf_norm_) {
+	case WDF_NORM::BOOLEAN:
 	    if (wdf == 0) return 0;
 	    return 1.0;
-	case 's':
+	case WDF_NORM::SQUARE:
 	    return (wdf * wdf);
-	case 'l':
+	case WDF_NORM::LOG:
 	    if (wdf == 0) return 0;
 	    return (1 + log(double(wdf)));
-	case 'P': {
+	case WDF_NORM::PIVOTED: {
 	    if (wdf == 0) return 0;
 	    double normlen = doclen / get_average_length();
 	    double norm_factor = 1 / (1 - param_slope + (param_slope * normlen));
 	    return ((1 + log(1 + log(double(wdf)))) * norm_factor + param_delta);
 	}
-	case 'L': {
+	case WDF_NORM::LOG_AVERAGE: {
 	    if (wdf == 0) return 0;
 	    double uniqterm_double = uniqterms;
 	    double doclen_double = doclen;
@@ -211,42 +372,44 @@ TfIdfWeight::get_wdfn(Xapian::termcount wdf, Xapian::termcount doclen,
 	    return num / den;
 	}
 	default:
-	    AssertEq(c, 'n');
+	    AssertEq(wdf_norm_, WDF_NORM::NONE);
 	    return wdf;
     }
 }
 
 double
-TfIdfWeight::get_idfn(char c) const
+TfIdfWeight::get_idfn(IDF_NORM idf_norm_) const
 {
     Xapian::doccount termfreq = 1;
-    if (c != 'n') termfreq = get_termfreq();
+    if (idf_norm_ != IDF_NORM::NONE) termfreq = get_termfreq();
     double N = 1.0;
-    if (c != 'n' && c != 'f') N = get_collection_size();
-    switch (c) {
-	case 'n':
+    if ((idf_norm_ == IDF_NORM::PROB) || (idf_norm_ == IDF_NORM::SQUARE) ||
+	(idf_norm_ == IDF_NORM::TFIDF) || (idf_norm_ == IDF_NORM::PIVOTED))
+	N = get_collection_size();
+    switch (idf_norm_) {
+	case IDF_NORM::NONE:
 	    return 1.0;
-	case 'p':
+	case IDF_NORM::PROB:
 	    // All documents are indexed by the term
 	    if (N == termfreq) return 0;
 	    return log((N - termfreq) / termfreq);
-	case 'f':
+	case IDF_NORM::FREQ:
 	    return (1.0 / termfreq);
-	case 's':
+	case IDF_NORM::SQUARE:
 	    return pow(log(N / termfreq), 2.0);
-	case 'P':
+	case IDF_NORM::PIVOTED:
 	    return log((N + 1) / termfreq);
 	default:
-	    AssertEq(c, 't');
+	    AssertEq(idf_norm_, IDF_NORM::TFIDF);
 	    return (log(N / termfreq));
     }
 }
 
 double
-TfIdfWeight::get_wtn(double wt, char c) const
+TfIdfWeight::get_wtn(double wt, WT_NORM wt_norm_) const
 {
-    (void)c;
-    AssertEq(c, 'n');
+    (void)wt_norm_;
+    AssertEq(wt_norm_, WT_NORM::NONE);
     return wt;
 }
 


### PR DESCRIPTION
Now tfidf weight will also support 3 separate normalisation parameters besides the normalisation string .
This will help to implement normalizations that require more than 1 character to specify normalization.

