### PR TITLE
ci: Use appveyor-retry on network commands

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -92,18 +92,18 @@ install:
         $env:CONFIGOPTS+=" --disable-backend-honey"
       }
   - if "%TOOLCHAIN%"=="mingw" bash -c "echo 'c:/mingw /mingw' >> /etc/fstab"
-  - if "%TOOLCHAIN%"=="mingw" bash -c 'appveyor-retry mingw-get install libz-dev'
-  - if "%TOOLCHAIN%"=="mingw64" bash -c 'appveyor-retry pacman -Sy --noconfirm zlib-devel'
+  - if "%TOOLCHAIN%"=="mingw" appveyor-retry bash -c 'mingw-get install libz-dev'
+  - if "%TOOLCHAIN%"=="mingw64" appveyor-retry bash -c 'pacman -Sy --noconfirm zlib-devel'
   # Install cygwin git and patch packages since those installed in the image
   # want the 32-bit cygwin1.dll which means they fail to work if the 64-bit
   # cygwin1.dll is first on PATH.
   - if "%TOOLCHAIN%-%Platform%"=="cygwin-x64" appveyor-retry C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P zlib-devel -P git -P patch
   - if "%TOOLCHAIN%-%Platform%"=="cygwin-x86" appveyor-retry C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P cygwin32-zlib -P cygwin32-gcc-core -P cygwin32-gcc-g++ -P git -P patch
-  - bash -c 'time ./bootstrap --fetch-url-command="appveyor-retry curl -L" xapian-core'
+  - bash -c 'time ./bootstrap --fetch-url-command="curl --retry 5 --retry-connrefused -L" xapian-core'
   - if defined VCVARS_BAT call %VCVARS_BAT%
   - if "%TOOLCHAIN%"=="msvc" mkdir zlib
   - if "%TOOLCHAIN%"=="msvc" cd zlib
-  - if "%TOOLCHAIN%"=="msvc" bash -c 'appveyor-retry curl -L https://github.com/xapian/xapian-dev-deps/releases/download/current/zlib-1.2.11.tar.gz|tar --strip-components=1 -zxf -'
+  - if "%TOOLCHAIN%"=="msvc" bash -c 'curl --retry 5 --retry-connrefused -L https://github.com/xapian/xapian-dev-deps/releases/download/current/zlib-1.2.11.tar.gz|tar --strip-components=1 -zxf -'
   # Don't build zlib with -MD as it seems this flag needs to be used
   # consistently across the build.
   - if "%TOOLCHAIN%"=="msvc" sed -i 's/\(^CFLAGS  *= *-nologo \)-MD /\1/' win32/Makefile.msc
@@ -113,7 +113,7 @@ install:
   - if "%TOOLCHAIN%"=="msvc" nmake -nologo -f win32\Makefile.msc
   - if "%TOOLCHAIN%"=="msvc" cd ..
   # Fetch pre-built unicode-data.cc to avoid having to get working tclsh.
-  - appveyor-retry curl https://oligarchy.co.uk/xapian/patches/unicode-data13.cc > xapian-core\unicode\unicode-data.cc
+  - curl --retry 5 --retry-connrefused https://oligarchy.co.uk/xapian/patches/unicode-data13.cc > xapian-core\unicode\unicode-data.cc
   - ps: >-
       if ($env:TOOLCHAIN -eq "msvc") {
         $env:CC="cl -nologo"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -92,18 +92,18 @@ install:
         $env:CONFIGOPTS+=" --disable-backend-honey"
       }
   - if "%TOOLCHAIN%"=="mingw" bash -c "echo 'c:/mingw /mingw' >> /etc/fstab"
-  - if "%TOOLCHAIN%"=="mingw" bash -c 'mingw-get install libz-dev'
-  - if "%TOOLCHAIN%"=="mingw64" bash -c 'pacman -Sy --noconfirm zlib-devel'
+  - if "%TOOLCHAIN%"=="mingw" bash -c 'appveyor-retry mingw-get install libz-dev'
+  - if "%TOOLCHAIN%"=="mingw64" bash -c 'appveyor-retry pacman -Sy --noconfirm zlib-devel'
   # Install cygwin git and patch packages since those installed in the image
   # want the 32-bit cygwin1.dll which means they fail to work if the 64-bit
   # cygwin1.dll is first on PATH.
-  - if "%TOOLCHAIN%-%Platform%"=="cygwin-x64" C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P zlib-devel -P git -P patch
-  - if "%TOOLCHAIN%-%Platform%"=="cygwin-x86" C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P cygwin32-zlib -P cygwin32-gcc-core -P cygwin32-gcc-g++ -P git -P patch
-  - bash -c 'time ./bootstrap --fetch-url-command="curl -L" xapian-core'
+  - if "%TOOLCHAIN%-%Platform%"=="cygwin-x64" appveyor-retry C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P zlib-devel -P git -P patch
+  - if "%TOOLCHAIN%-%Platform%"=="cygwin-x86" appveyor-retry C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P cygwin32-zlib -P cygwin32-gcc-core -P cygwin32-gcc-g++ -P git -P patch
+  - bash -c 'time ./bootstrap --fetch-url-command="appveyor-retry curl -L" xapian-core'
   - if defined VCVARS_BAT call %VCVARS_BAT%
   - if "%TOOLCHAIN%"=="msvc" mkdir zlib
   - if "%TOOLCHAIN%"=="msvc" cd zlib
-  - if "%TOOLCHAIN%"=="msvc" bash -c 'curl -L https://github.com/xapian/xapian-dev-deps/releases/download/current/zlib-1.2.11.tar.gz|tar --strip-components=1 -zxf -'
+  - if "%TOOLCHAIN%"=="msvc" bash -c 'appveyor-retry curl -L https://github.com/xapian/xapian-dev-deps/releases/download/current/zlib-1.2.11.tar.gz|tar --strip-components=1 -zxf -'
   # Don't build zlib with -MD as it seems this flag needs to be used
   # consistently across the build.
   - if "%TOOLCHAIN%"=="msvc" sed -i 's/\(^CFLAGS  *= *-nologo \)-MD /\1/' win32/Makefile.msc
@@ -113,7 +113,7 @@ install:
   - if "%TOOLCHAIN%"=="msvc" nmake -nologo -f win32\Makefile.msc
   - if "%TOOLCHAIN%"=="msvc" cd ..
   # Fetch pre-built unicode-data.cc to avoid having to get working tclsh.
-  - curl https://oligarchy.co.uk/xapian/patches/unicode-data13.cc > xapian-core\unicode\unicode-data.cc
+  - appveyor-retry curl https://oligarchy.co.uk/xapian/patches/unicode-data13.cc > xapian-core\unicode\unicode-data.cc
   - ps: >-
       if ($env:TOOLCHAIN -eq "msvc") {
         $env:CC="cl -nologo"


### PR DESCRIPTION
This will retry the command up to three times if it fails, which
should help to reduce the flakiness we sometimes see.