### PR TITLE
Support more normalisations in TfIdfWeight

### DIFF
--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -514,7 +514,13 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 	 *
 	 *  wdfn=sqrt(wdf-0.5)+1 if(wdf>0), else wdfn=0
 	 */
-	SQRT = 8
+	SQRT = 8,
+
+	/** Augmented average term frequency
+	 *
+	 *  wdfn=0.9+0.1*(wdf/(doclen/unique_terms)) if(wdf>0), else wdfn=0
+	 */
+	AUG_AVERAGE = 9
     };
 
     /** Idf normalizations. */
@@ -567,7 +573,19 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 	 *
 	 *  idfn=log(Collfreq/Termfreq+1)
 	 */
-	LOG_GLOBAL_FREQ = 8
+	LOG_GLOBAL_FREQ = 8,
+
+	/** Incremented global frequency IDF
+	 *
+	 *  idfn=Collfreq/Termfreq+1
+	 */
+	INCREMENTED_GLOBAL_FREQ = 9,
+
+	/** Square root global frequency IDF
+	 *
+	 *  idfn=sqrt(Collfreq/Termfreq-0.9)
+	 */
+	SQRT_GLOBAL_FREQ = 10
     };
 
     /** Weight normalizations. */

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -1080,6 +1080,42 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     mset_expect_order(mset, 2, 4);
     TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8 * log(9.0 / 2 + 1));
     TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1 * log(9.0 / 2 + 1));
+
+    // Check for NONE, INCREMENTED_GLOBAL_FREQ, NONE.
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::INCREMENTED_GLOBAL_FREQ,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8 * (9.0 / 2 + 1));
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1 * (9.0 / 2 + 1));
+
+    // Check for NONE, SQRT_GLOBAL_FREQ, NONE.
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::NONE,
+	    Xapian::TfIdfWeight::idf_norm::SQRT_GLOBAL_FREQ,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8 * sqrt(9.0 / 2 - 0.9));
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1 * sqrt(9.0 / 2 - 0.9));
+
+    // Check for AUG_AVERAGE, NONE, NONE.
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::AUG_AVERAGE,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 0.9 + 0.1 * (8.0 / (81.0 / 56.0)));
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 0.9 + 0.1 * (1.0 / (31.0 / 26.0)));
 }
 
 // Feature tests for pivoted normalization functions.

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -273,7 +273,7 @@ TfIdfWeight::get_wdfn(Xapian::termcount wdf, Xapian::termcount doclen,
 	}
 	case wdf_norm::AUG_AVERAGE: {
 	    if (wdf == 0) return 0;
-	    return 0.9 + 0.1*(double(wdf) / (double(doclen) / uniqterms));
+	    return 0.9 + 0.1 * (double(wdf) / (double(doclen) / uniqterms));
 	}
 	case wdf_norm::NONE:
 	    break;


### PR DESCRIPTION
Add support for wdf normalisation "augmented average term frequency",
and IDF normalisations "incremented global frequency" and
"square root global frequency".