### PR TITLE
Extract stat "wdfdocmax" for TfIdf Weight

### DIFF
--- a/xapian-core/api/database.cc
+++ b/xapian-core/api/database.cc
@@ -355,6 +355,15 @@ Database::get_unique_terms(Xapian::docid did) const
     return internal->get_unique_terms(did);
 }
 
+Xapian::termcount
+Database::get_wdfdocmax(Xapian::docid did) const
+{
+    if (did == 0)
+	docid_zero_invalid();
+
+    return internal->get_wdfdocmax(did);
+}
+
 Document
 Database::get_document(Xapian::docid did, unsigned flags) const
 {

--- a/xapian-core/api/postingiterator.cc
+++ b/xapian-core/api/postingiterator.cc
@@ -120,6 +120,14 @@ PostingIterator::get_unique_terms() const
     RETURN(internal->get_unique_terms());
 }
 
+Xapian::termcount
+PostingIterator::get_wdfdocmax() const
+{
+    LOGCALL(API, Xapian::termcount, "PostingIterator::get_wdfdocmax", NO_ARGS);
+    Assert(internal);
+    RETURN(internal->get_wdfdocmax());
+}
+
 #if 0 // FIXME: TermIterator supports this, so PostingIterator really ought to.
 Xapian::termcount
 PostingIterator::positionlist_count() const

--- a/xapian-core/api/postingiteratorinternal.h
+++ b/xapian-core/api/postingiteratorinternal.h
@@ -60,6 +60,10 @@ class PostingIterator::Internal {
 	return db.get_unique_terms(pl->get_docid());
     }
 
+    Xapian::termcount get_wdfdocmax() const {
+	return db.get_wdfdocmax(pl->get_docid());
+    }
+
     PositionList* open_position_list() const {
 	return pl->open_position_list();
     }

--- a/xapian-core/backends/databaseinternal.h
+++ b/xapian-core/backends/databaseinternal.h
@@ -146,6 +146,12 @@ class Database::Internal : public Xapian::Internal::intrusive_base {
      */
     virtual termcount get_unique_terms(docid did) const = 0;
 
+    /** Get the max wdf in document.
+     *
+     *  @param did  The document id of the document to return this value for.
+     */
+    virtual termcount get_wdfdocmax(docid did) const = 0;
+
     /** Returns frequencies for a term.
      *
      *  @param term		The term to get frequencies for

--- a/xapian-core/backends/empty_database.cc
+++ b/xapian-core/backends/empty_database.cc
@@ -182,6 +182,15 @@ EmptyDatabase::get_unique_terms(Xapian::docid did) const
     return 0;
 }
 
+Xapian::termcount
+EmptyDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    Assert(did != 0);
+    (void)did;
+    no_subdatabases();
+    return 0;
+}
+
 Xapian::Document::Internal*
 EmptyDatabase::open_document(Xapian::docid did, bool) const
 {

--- a/xapian-core/backends/empty_database.h
+++ b/xapian-core/backends/empty_database.h
@@ -75,6 +75,8 @@ class EmptyDatabase : public Xapian::Database::Internal {
 
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
 
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
+
     Xapian::Document::Internal* open_document(Xapian::docid did,
 					      bool lazy) const;
 

--- a/xapian-core/backends/glass/glass_database.cc
+++ b/xapian-core/backends/glass/glass_database.cc
@@ -748,6 +748,23 @@ GlassDatabase::get_unique_terms(Xapian::docid did) const
     RETURN(GlassTermList(ptrtothis, did).get_unique_terms());
 }
 
+Xapian::termcount
+GlassDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    LOGCALL(DB, Xapian::termcount, "GlassDatabase::get_wdfdocmax", did);
+    Assert(did != 0);
+    intrusive_ptr<const GlassDatabase> ptrtothis(this);
+    GlassTermList termlist(ptrtothis, did);
+    Xapian::termcount max_wdf = 0;
+    termlist.next();
+    while (!termlist.at_end()) {
+	Xapian::termcount current_wdf = termlist.get_wdf();
+	if (current_wdf > max_wdf) max_wdf = current_wdf;
+	termlist.next();
+    }
+    RETURN(max_wdf);
+}
+
 void
 GlassDatabase::get_freqs(const string & term,
 			 Xapian::doccount * termfreq_ptr,

--- a/xapian-core/backends/glass/glass_database.h
+++ b/xapian-core/backends/glass/glass_database.h
@@ -247,6 +247,7 @@ class GlassDatabase : public Xapian::Database::Internal {
     Xapian::totallength get_total_length() const;
     Xapian::termcount get_doclength(Xapian::docid did) const;
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
     void get_freqs(const string & term,
 		   Xapian::doccount * termfreq_ptr,
 		   Xapian::termcount * collfreq_ptr) const;

--- a/xapian-core/backends/honey/honey_database.cc
+++ b/xapian-core/backends/honey/honey_database.cc
@@ -164,6 +164,22 @@ HoneyDatabase::get_unique_terms(Xapian::docid did) const
     return HoneyTermList(this, did).get_unique_terms();
 }
 
+Xapian::termcount
+HoneyDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    Assert(did != 0);
+    HoneyTermList termlist(this, did);
+    Xapian::termcount max_wdf = 0;
+    termlist.next();
+    while (!termlist.at_end()) {
+	Xapian::termcount current_wdf = termlist.get_wdf();
+	if (current_wdf > max_wdf) max_wdf = current_wdf;
+	termlist.next();
+    }
+    return max_wdf;
+
+}
+
 void
 HoneyDatabase::get_freqs(const string& term,
 			 Xapian::doccount* termfreq_ptr,

--- a/xapian-core/backends/honey/honey_database.cc
+++ b/xapian-core/backends/honey/honey_database.cc
@@ -177,7 +177,6 @@ HoneyDatabase::get_wdfdocmax(Xapian::docid did) const
 	termlist.next();
     }
     return max_wdf;
-
 }
 
 void

--- a/xapian-core/backends/honey/honey_database.h
+++ b/xapian-core/backends/honey/honey_database.h
@@ -111,6 +111,9 @@ class HoneyDatabase : public Xapian::Database::Internal {
      */
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
 
+    // Return the max_wdf in the document
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
+
     /** Returns frequencies for a term.
      *
      *  @param term		The term to get frequencies for

--- a/xapian-core/backends/inmemory/inmemory_database.cc
+++ b/xapian-core/backends/inmemory/inmemory_database.cc
@@ -154,6 +154,12 @@ InMemoryPostList::get_description() const
     return term + ":" + str(termfreq);
 }
 
+Xapian::termcount
+InMemoryPostList::get_wdfdocmax() const
+{
+   return db->get_wdfdocmax(get_docid());
+}
+
 PositionList *
 InMemoryPostList::read_position_list()
 {
@@ -560,6 +566,20 @@ InMemoryDatabase::get_unique_terms(Xapian::docid did) const
     // unique_terms <= doclen.
     Xapian::termcount terms = termlists[did - 1].terms.size();
     return std::min(terms, Xapian::termcount(doclengths[did - 1]));
+}
+
+Xapian::termcount
+InMemoryDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    if (closed) InMemoryDatabase::throw_database_closed();
+    if (did == 0 || did > termlists.size() || !termlists[did - 1].is_valid)
+	throw Xapian::DocNotFoundError(string("Docid ") + str(did) +
+				 string(" not found"));
+    Xapian::termcount max_wdf = 0;
+    for (auto&& i : termlists[did - 1].terms) {
+	if (i.wdf > max_wdf) max_wdf = i.wdf;
+    }
+    return max_wdf;
 }
 
 TermList *

--- a/xapian-core/backends/inmemory/inmemory_database.h
+++ b/xapian-core/backends/inmemory/inmemory_database.h
@@ -162,6 +162,8 @@ class InMemoryPostList : public LeafPostList {
 
     Xapian::docid get_docid() const;     // Gets current docid
     Xapian::termcount get_wdf() const;	   // Within Document Frequency
+    // Max wdf of terms in current document
+    Xapian::termcount get_wdfdocmax() const;
     PositionList * read_position_list();
     PositionList * open_position_list() const;
 
@@ -334,6 +336,7 @@ class InMemoryDatabase : public Xapian::Database::Internal {
     Xapian::totallength get_total_length() const;
     Xapian::termcount get_doclength(Xapian::docid did) const;
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
 
     void get_freqs(const string & term,
 		   Xapian::doccount * termfreq_ptr,

--- a/xapian-core/backends/leafpostlist.cc
+++ b/xapian-core/backends/leafpostlist.cc
@@ -55,10 +55,12 @@ LeafPostList::get_termfreq_est() const
 
 double
 LeafPostList::get_weight(Xapian::termcount doclen,
-			 Xapian::termcount unique_terms) const
+			 Xapian::termcount unique_terms,
+			 Xapian::termcount wdfdocmax) const
 {
     if (!weight) return 0;
-    double sumpart = weight->get_sumpart(get_wdf(), doclen, unique_terms);
+    double sumpart = weight->get_sumpart(get_wdf(), doclen,
+					 unique_terms, wdfdocmax);
     AssertRel(sumpart, <=, weight->get_maxpart());
     return sumpart;
 }

--- a/xapian-core/backends/leafpostlist.h
+++ b/xapian-core/backends/leafpostlist.h
@@ -100,7 +100,8 @@ class LeafPostList : public PostList {
     Xapian::doccount get_termfreq_est() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     double recalc_maxweight();
 

--- a/xapian-core/backends/multi/multi_database.cc
+++ b/xapian-core/backends/multi/multi_database.cc
@@ -346,6 +346,17 @@ MultiDatabase::get_unique_terms(Xapian::docid did) const
     return shard->get_unique_terms(shard_did);
 }
 
+Xapian::termcount
+MultiDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    Assert(did != 0);
+
+    auto n_shards = shards.size();
+    auto shard = shards[shard_number(did, n_shards)];
+    auto shard_did = shard_docid(did, n_shards);
+    return shard->get_wdfdocmax(shard_did);
+}
+
 Xapian::Document::Internal*
 MultiDatabase::open_document(Xapian::docid did, bool lazy) const
 {

--- a/xapian-core/backends/multi/multi_database.h
+++ b/xapian-core/backends/multi/multi_database.h
@@ -109,6 +109,8 @@ class MultiDatabase : public Xapian::Database::Internal {
 
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
 
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
+
     Xapian::Document::Internal* open_document(Xapian::docid did,
 					      bool lazy) const;
 

--- a/xapian-core/backends/multi/multi_postlist.cc
+++ b/xapian-core/backends/multi/multi_postlist.cc
@@ -81,6 +81,7 @@ MultiPostList::get_wdf() const
 
 double
 MultiPostList::get_weight(Xapian::termcount,
+			  Xapian::termcount,
 			  Xapian::termcount) const
 {
     // MultiPostList is only used by PostingIterator which should never call

--- a/xapian-core/backends/multi/multi_postlist.h
+++ b/xapian-core/backends/multi/multi_postlist.h
@@ -80,7 +80,8 @@ class MultiPostList : public PostList {
 
     /// Return the weight contribution for the current position.
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     /// Return true if the current position is past the last entry in this list.
     bool at_end() const;

--- a/xapian-core/backends/postlist.h
+++ b/xapian-core/backends/postlist.h
@@ -87,7 +87,8 @@ class PostList {
 
     /// Return the weight contribution for the current position.
     virtual double get_weight(Xapian::termcount doclen,
-			      Xapian::termcount unique_terms) const = 0;
+			      Xapian::termcount unique_terms,
+			      Xapian::termcount wdfdocmax) const = 0;
 
     /// Return true if the current position is past the last entry in this list.
     virtual bool at_end() const = 0;

--- a/xapian-core/backends/remote/remote-database.cc
+++ b/xapian-core/backends/remote/remote-database.cc
@@ -560,6 +560,24 @@ RemoteDatabase::get_unique_terms(Xapian::docid did) const
     return doclen;
 }
 
+Xapian::termcount
+RemoteDatabase::get_wdfdocmax(Xapian::docid did) const
+{
+    Assert(did != 0);
+    string message;
+    pack_uint_last(message, did);
+    send_message(MSG_WDFDOCMAX, message);
+
+    get_message(message, REPLY_WDFDOCMAX);
+    const char* p = message.c_str();
+    const char* p_end = p + message.size();
+    Xapian::termcount wdfdocmax;
+    if (!unpack_uint_last(&p, p_end, &wdfdocmax)) {
+	throw Xapian::NetworkError("Bad REPLY_WDFDOCMAX", context);
+    }
+    return wdfdocmax;
+}
+
 reply_type
 RemoteDatabase::get_message(string &result,
 			    reply_type required_type,

--- a/xapian-core/backends/remote/remote-database.h
+++ b/xapian-core/backends/remote/remote-database.h
@@ -262,6 +262,7 @@ class RemoteDatabase : public Xapian::Database::Internal {
 
     Xapian::termcount get_doclength(Xapian::docid did) const;
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
 
     /// Check if term exists.
     bool term_exists(const std::string& tname) const;

--- a/xapian-core/include/xapian/database.h
+++ b/xapian-core/include/xapian/database.h
@@ -425,6 +425,8 @@ class XAPIAN_VISIBILITY_DEFAULT Database {
      */
     Xapian::termcount get_unique_terms(Xapian::docid did) const;
 
+    Xapian::termcount get_wdfdocmax(Xapian::docid did) const;
+
     /** Send a keep-alive message.
      *
      *  For remote databases, this method sends a message to the server to

--- a/xapian-core/include/xapian/postingiterator.h
+++ b/xapian-core/include/xapian/postingiterator.h
@@ -96,6 +96,9 @@ class XAPIAN_VISIBILITY_DEFAULT PostingIterator {
     /// Return the number of unique terms in the current document.
     Xapian::termcount get_unique_terms() const;
 
+    /// Return the max_wdf in the current document.
+    Xapian::termcount get_wdfdocmax() const;
+
 #if 0 // FIXME: TermIterator supports this, so PostingIterator really ought to.
     /// Return the length of the position list for the current position.
     Xapian::termcount positionlist_count() const;

--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -69,7 +69,9 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
 	 *
 	 *  This gives the total number of term occurrences.
 	 */
-	TOTAL_LENGTH = 16384
+	TOTAL_LENGTH = 16384,
+	/// Maximum wdf in the current document.
+	WDF_DOC_MAX = 32768
     } stat_flags;
 
     /** Tell Xapian that your subclass will want a particular statistic.
@@ -237,10 +239,12 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
      *  @param doclen The document's length (unnormalised).
      *  @param uniqterms	Number of unique terms in the document (used
      *				for absolute smoothing).
+     *  @param wdfdocmax	Maximum wdf value in the document.
      */
     virtual double get_sumpart(Xapian::termcount wdf,
 			       Xapian::termcount doclen,
-			       Xapian::termcount uniqterms) const = 0;
+			       Xapian::termcount uniqterms,
+			       Xapian::termcount wdfdocmax) const = 0;
 
     /** Return an upper bound on what get_sumpart() can return for any document.
      *
@@ -365,6 +369,16 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
 	return stats_needed == 0 && short_name() == "bool";
     }
 
+    /** @private @internal Return true if the max WDF of document is needed.
+     *
+     *  If this method returns true, then the max WDF will be
+     *  fetched and passed to @a get_sumpart().  Otherwise 0 may be passed for
+     *  the max wdf.
+     */
+    bool get_sumpart_needs_wdfdocmax_() const {
+	return stats_needed & WDF_DOC_MAX;
+    }
+
   protected:
     /** Don't allow copying.
      *
@@ -451,7 +465,8 @@ class XAPIAN_VISIBILITY_DEFAULT BoolWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -625,6 +640,7 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     double get_wdfn(Xapian::termcount wdf,
 		    Xapian::termcount len,
 		    Xapian::termcount uniqterms,
+		    Xapian::termcount wdfdocmax,
 		    wdf_norm wdf_normalization) const;
     double get_idfn(idf_norm idf_normalization) const;
     double get_wtn(double wt, wt_norm wt_normalization) const;
@@ -771,7 +787,8 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -882,7 +899,8 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1004,7 +1022,8 @@ class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1068,7 +1087,8 @@ class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqueterms) const;
+		       Xapian::termcount uniqueterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1144,7 +1164,8 @@ class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1220,7 +1241,8 @@ class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1294,7 +1316,8 @@ class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1373,7 +1396,8 @@ class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1432,7 +1456,8 @@ class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1513,7 +1538,8 @@ class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1594,7 +1620,8 @@ class XAPIAN_VISIBILITY_DEFAULT PL2PlusWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1656,7 +1683,8 @@ class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -1763,7 +1791,8 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const;
@@ -1797,7 +1826,8 @@ class XAPIAN_VISIBILITY_DEFAULT CoordWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount, Xapian::termcount) const;
@@ -1841,7 +1871,8 @@ class XAPIAN_VISIBILITY_DEFAULT DiceCoeffWeight : public Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterm) const;
+		       Xapian::termcount uniqterm,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount, Xapian::termcount) const;

--- a/xapian-core/matcher/andmaybepostlist.cc
+++ b/xapian-core/matcher/andmaybepostlist.cc
@@ -55,11 +55,12 @@ AndMaybePostList::get_docid() const
 
 double
 AndMaybePostList::get_weight(Xapian::termcount doclen,
-			     Xapian::termcount unique_terms) const
+			     Xapian::termcount unique_terms,
+			     Xapian::termcount wdfdocmax) const
 {
-    auto res = pl->get_weight(doclen, unique_terms);
+    auto res = pl->get_weight(doclen, unique_terms, wdfdocmax);
     if (maybe_matches())
-	res += r->get_weight(doclen, unique_terms);
+	res += r->get_weight(doclen, unique_terms, wdfdocmax);
     return res;
 }
 

--- a/xapian-core/matcher/andmaybepostlist.h
+++ b/xapian-core/matcher/andmaybepostlist.h
@@ -83,7 +83,8 @@ class AndMaybePostList : public WrapperPostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     double recalc_maxweight();
 

--- a/xapian-core/matcher/boolorpostlist.cc
+++ b/xapian-core/matcher/boolorpostlist.cc
@@ -59,7 +59,9 @@ BoolOrPostList::get_docid() const
 }
 
 double
-BoolOrPostList::get_weight(Xapian::termcount, Xapian::termcount) const
+BoolOrPostList::get_weight(Xapian::termcount,
+			   Xapian::termcount,
+			   Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/matcher/boolorpostlist.h
+++ b/xapian-core/matcher/boolorpostlist.h
@@ -133,7 +133,8 @@ class BoolOrPostList : public PostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     bool at_end() const;
 

--- a/xapian-core/matcher/externalpostlist.cc
+++ b/xapian-core/matcher/externalpostlist.cc
@@ -85,6 +85,7 @@ ExternalPostList::get_docid() const
 
 double
 ExternalPostList::get_weight(Xapian::termcount,
+			     Xapian::termcount,
 			     Xapian::termcount) const
 {
     LOGCALL(MATCH, double, "ExternalPostList::get_weight", NO_ARGS);

--- a/xapian-core/matcher/externalpostlist.h
+++ b/xapian-core/matcher/externalpostlist.h
@@ -66,7 +66,10 @@ class ExternalPostList : public PostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
+
+    Xapian::termcount get_wdfdocmax() const;
 
     double recalc_maxweight();
 

--- a/xapian-core/matcher/extraweightpostlist.cc
+++ b/xapian-core/matcher/extraweightpostlist.cc
@@ -39,7 +39,7 @@ ExtraWeightPostList::get_weight(Xapian::termcount doclen,
      * at some point, and so that we got all the incompatible changes needed to
      * add support for the number of unique terms over with in one go.
      */
-    double sum_extra = weight->get_sumextra(doclen, unique_terms, wdfdocmax);
+    double sum_extra = weight->get_sumextra(doclen, unique_terms);
     AssertRel(sum_extra,<=,max_extra);
     return pl->get_weight(doclen, unique_terms, wdfdocmax) + sum_extra;
 }

--- a/xapian-core/matcher/extraweightpostlist.cc
+++ b/xapian-core/matcher/extraweightpostlist.cc
@@ -30,7 +30,8 @@ using namespace std;
 
 double
 ExtraWeightPostList::get_weight(Xapian::termcount doclen,
-				Xapian::termcount unique_terms) const
+				Xapian::termcount unique_terms,
+				Xapian ::termcount wdfdocmax) const
 {
     /* Weight::get_sumextra() takes two parameters (document length and number
      * of unique terms) but none of the currently implemented weighting schemes
@@ -38,9 +39,9 @@ ExtraWeightPostList::get_weight(Xapian::termcount doclen,
      * at some point, and so that we got all the incompatible changes needed to
      * add support for the number of unique terms over with in one go.
      */
-    double sum_extra = weight->get_sumextra(doclen, unique_terms);
+    double sum_extra = weight->get_sumextra(doclen, unique_terms, wdfdocmax);
     AssertRel(sum_extra,<=,max_extra);
-    return pl->get_weight(doclen, unique_terms) + sum_extra;
+    return pl->get_weight(doclen, unique_terms, wdfdocmax) + sum_extra;
 }
 
 double

--- a/xapian-core/matcher/extraweightpostlist.h
+++ b/xapian-core/matcher/extraweightpostlist.h
@@ -57,7 +57,8 @@ class ExtraWeightPostList : public WrapperPostList {
     }
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     double recalc_maxweight();
 

--- a/xapian-core/matcher/localsubmatch.cc
+++ b/xapian-core/matcher/localsubmatch.cc
@@ -86,7 +86,8 @@ class LazyWeight : public Xapian::Weight {
 
     double get_sumpart(Xapian::termcount wdf,
 		       Xapian::termcount doclen,
-		       Xapian::termcount uniqterms) const;
+		       Xapian::termcount uniqterms,
+		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
@@ -131,11 +132,13 @@ LazyWeight::unserialise(const string &) const
 double
 LazyWeight::get_sumpart(Xapian::termcount wdf,
 			Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const
 {
     (void)wdf;
     (void)doclen;
     (void)uniqterms;
+    (void)wdfdocmax;
     throw Xapian::InvalidOperationError("LazyWeight::get_sumpart()");
 }
 

--- a/xapian-core/matcher/maxpostlist.cc
+++ b/xapian-core/matcher/maxpostlist.cc
@@ -130,13 +130,16 @@ MaxPostList::get_docid() const
 
 double
 MaxPostList::get_weight(Xapian::termcount doclen,
-			Xapian::termcount unique_terms) const
+			Xapian::termcount unique_terms,
+			Xapian::termcount wdfdocmax) const
 {
     Assert(did);
     double res = 0.0;
     for (size_t i = 0; i < n_kids; ++i) {
 	if (plist[i]->get_docid() == did)
-	    res = max(res, plist[i]->get_weight(doclen, unique_terms));
+	    res = max(res, plist[i]->get_weight(doclen,
+						unique_terms,
+						wdfdocmax));
     }
     return res;
 }

--- a/xapian-core/matcher/maxpostlist.h
+++ b/xapian-core/matcher/maxpostlist.h
@@ -89,7 +89,8 @@ class MaxPostList : public PostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     bool at_end() const;
 

--- a/xapian-core/matcher/multiandpostlist.cc
+++ b/xapian-core/matcher/multiandpostlist.cc
@@ -150,12 +150,13 @@ MultiAndPostList::get_docid() const
 
 double
 MultiAndPostList::get_weight(Xapian::termcount doclen,
-			     Xapian::termcount unique_terms) const
+			     Xapian::termcount unique_terms,
+			     Xapian::termcount wdfdocmax) const
 {
     Assert(did);
     double result = 0;
     for (size_t i = 0; i < n_kids; ++i) {
-	result += plist[i]->get_weight(doclen, unique_terms);
+	result += plist[i]->get_weight(doclen, unique_terms, wdfdocmax);
     }
     return result;
 }

--- a/xapian-core/matcher/multiandpostlist.h
+++ b/xapian-core/matcher/multiandpostlist.h
@@ -166,7 +166,8 @@ class MultiAndPostList : public PostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     bool at_end() const;
 

--- a/xapian-core/matcher/multixorpostlist.cc
+++ b/xapian-core/matcher/multixorpostlist.cc
@@ -187,13 +187,14 @@ MultiXorPostList::get_docid() const
 
 double
 MultiXorPostList::get_weight(Xapian::termcount doclen,
-			     Xapian::termcount unique_terms) const
+			     Xapian::termcount unique_terms,
+			     Xapian::termcount wdfdocmax) const
 {
     Assert(did);
     double result = 0;
     for (size_t i = 0; i < n_kids; ++i) {
 	if (plist[i]->get_docid() == did)
-	    result += plist[i]->get_weight(doclen, unique_terms);
+	    result += plist[i]->get_weight(doclen, unique_terms, wdfdocmax);
     }
     return result;
 }

--- a/xapian-core/matcher/multixorpostlist.h
+++ b/xapian-core/matcher/multixorpostlist.h
@@ -88,7 +88,8 @@ class MultiXorPostList : public PostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     bool at_end() const;
 

--- a/xapian-core/matcher/orpostlist.cc
+++ b/xapian-core/matcher/orpostlist.cc
@@ -92,14 +92,15 @@ OrPostList::get_docid() const
 
 double
 OrPostList::get_weight(Xapian::termcount doclen,
-		       Xapian::termcount unique_terms) const
+		       Xapian::termcount unique_terms,
+		       Xapian::termcount wdfdocmax) const
 {
     if (r_did == 0 || l_did < r_did)
-	return l->get_weight(doclen, unique_terms);
+	return l->get_weight(doclen, unique_terms, wdfdocmax);
     if (l_did == 0 || l_did > r_did)
-	return r->get_weight(doclen, unique_terms);
-    return l->get_weight(doclen, unique_terms) +
-	   r->get_weight(doclen, unique_terms);
+	return r->get_weight(doclen, unique_terms, wdfdocmax);
+    return l->get_weight(doclen, unique_terms, wdfdocmax) +
+	   r->get_weight(doclen, unique_terms, wdfdocmax);
 }
 
 double

--- a/xapian-core/matcher/orpostlist.h
+++ b/xapian-core/matcher/orpostlist.h
@@ -90,7 +90,8 @@ class OrPostList : public PostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     bool at_end() const;
 

--- a/xapian-core/matcher/postlisttree.h
+++ b/xapian-core/matcher/postlisttree.h
@@ -34,6 +34,8 @@ class PostListTree {
 
     bool need_unique_terms;
 
+    bool need_wdfdocmax;
+
     double max_weight;
 
     /// The current shard.
@@ -67,6 +69,7 @@ class PostListTree {
 		 const Xapian::Weight& wtscheme)
 	: need_doclength(wtscheme.get_sumpart_needs_doclength_()),
 	  need_unique_terms(wtscheme.get_sumpart_needs_uniqueterms_()),
+	  need_wdfdocmax(wtscheme.get_sumpart_needs_wdfdocmax_()),
 	  vsdoc(vsdoc_),
 	  db(db_) {}
 
@@ -145,9 +148,9 @@ class PostListTree {
     }
 
     double get_weight() const {
-	Xapian::termcount doclen = 0, unique_terms = 0;
-	get_doc_stats(pl->get_docid(), doclen, unique_terms);
-	return pl->get_weight(doclen, unique_terms);
+	Xapian::termcount doclen = 0, unique_terms = 0, wdfdocmax = 0;
+	get_doc_stats(pl->get_docid(), doclen, unique_terms, wdfdocmax);
+	return pl->get_weight(doclen, unique_terms, wdfdocmax);
     }
 
     /// Return false if we're done.
@@ -195,14 +198,17 @@ class PostListTree {
 
     void get_doc_stats(Xapian::docid shard_did,
 		       Xapian::termcount& doclen,
-		       Xapian::termcount& unique_terms) const {
+		       Xapian::termcount& unique_terms,
+		       Xapian::termcount& wdfdocmax) const {
 	// Fetching the document length and number of unique terms is work we
 	// can avoid if the weighting scheme doesn't use them.
-	if (need_doclength || need_unique_terms) {
+	if (need_doclength || need_unique_terms || need_wdfdocmax) {
 	    if (need_doclength)
 		doclen = shard_db->get_doclength(shard_did);
 	    if (need_unique_terms)
 		unique_terms = shard_db->get_unique_terms(shard_did);
+	    if (need_wdfdocmax)
+		wdfdocmax = shard_db->get_wdfdocmax(shard_did);
 	}
     }
 

--- a/xapian-core/matcher/postlisttree.h
+++ b/xapian-core/matcher/postlisttree.h
@@ -147,6 +147,10 @@ class PostListTree {
 	return unshard(pl->get_docid(), current_shard, n_shards);
     }
 
+    Xapian::termcount get_doclength(Xapian::docid shard_did) const {
+	return shard_db->get_doclength(shard_did);
+    }
+
     double get_weight() const {
 	Xapian::termcount doclen = 0, unique_terms = 0, wdfdocmax = 0;
 	get_doc_stats(pl->get_docid(), doclen, unique_terms, wdfdocmax);

--- a/xapian-core/matcher/selectpostlist.cc
+++ b/xapian-core/matcher/selectpostlist.cc
@@ -41,8 +41,9 @@ SelectPostList::vet(double w_min)
     } else {
 	Xapian::termcount doclen = 0;
 	Xapian::termcount unique_terms = 0;
-	pltree->get_doc_stats(pl->get_docid(), doclen, unique_terms);
-	cached_weight = pl->get_weight(doclen, unique_terms);
+	Xapian::termcount wdfdocmax = 0;
+	pltree->get_doc_stats(pl->get_docid(), doclen, unique_terms, wdfdocmax);
+	cached_weight = pl->get_weight(doclen, unique_terms, wdfdocmax);
 	if (cached_weight < w_min)
 	    return false;
     }
@@ -51,11 +52,12 @@ SelectPostList::vet(double w_min)
 
 double
 SelectPostList::get_weight(Xapian::termcount doclen,
-			   Xapian::termcount unique_terms) const
+			   Xapian::termcount unique_terms,
+			   Xapian::termcount wdfdocmax) const
 {
     if (cached_weight >= 0)
 	return cached_weight;
-    return pl->get_weight(doclen, unique_terms);
+    return pl->get_weight(doclen, unique_terms, wdfdocmax);
 }
 
 bool

--- a/xapian-core/matcher/selectpostlist.h
+++ b/xapian-core/matcher/selectpostlist.h
@@ -47,7 +47,8 @@ class SelectPostList : public WrapperPostList {
 	: WrapperPostList(pl_), pltree(pltree_) {}
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     bool at_end() const;
 

--- a/xapian-core/matcher/synonympostlist.cc
+++ b/xapian-core/matcher/synonympostlist.cc
@@ -41,6 +41,7 @@ SynonymPostList::set_weight(const Xapian::Weight * wt_)
     delete wt;
     wt = wt_;
     want_wdf = wt->get_sumpart_needs_wdf_();
+    want_wdfdocmax = wt->get_sumpart_needs_wdfdocmax_();
 }
 
 PostList *
@@ -85,12 +86,15 @@ SynonymPostList::get_weight(Xapian::termcount doclen,
 	    // that this is true.  Note that this requires doclen to be fetched
 	    // even if the weight object doesn't want it.
 	    if (doclen == 0) {
-		Xapian::termcount dummy;
-		pltree->get_doc_stats(pl->get_docid(), doclen, dummy, dummy);
+		doclen = pltree->get_doclength(pl->get_docid());
 	    }
 	    if (wdf > doclen) wdf = doclen;
 	}
-	// Set wdfdocmax to doclen in case of a synonym.
+    }
+    if (want_wdfdocmax) {
+	if (doclen == 0) {
+	    doclen = pltree->get_doclength(pl->get_docid());
+	}
 	wdfdocmax = doclen;
     }
     RETURN(wt->get_sumpart(wdf, doclen, unique_terms, wdfdocmax));

--- a/xapian-core/matcher/synonympostlist.cc
+++ b/xapian-core/matcher/synonympostlist.cc
@@ -61,7 +61,8 @@ SynonymPostList::skip_to(Xapian::docid did, double w_min)
 
 double
 SynonymPostList::get_weight(Xapian::termcount doclen,
-			    Xapian::termcount unique_terms) const
+			    Xapian::termcount unique_terms,
+			    Xapian::termcount wdfdocmax) const
 {
     LOGCALL(MATCH, double, "SynonymPostList::get_weight", doclen | unique_terms);
     Xapian::termcount wdf = 0;
@@ -85,12 +86,12 @@ SynonymPostList::get_weight(Xapian::termcount doclen,
 	    // even if the weight object doesn't want it.
 	    if (doclen == 0) {
 		Xapian::termcount dummy;
-		pltree->get_doc_stats(pl->get_docid(), doclen, dummy);
+		pltree->get_doc_stats(pl->get_docid(), doclen, dummy, dummy);
 	    }
 	    if (wdf > doclen) wdf = doclen;
 	}
     }
-    RETURN(wt->get_sumpart(wdf, doclen, unique_terms));
+    RETURN(wt->get_sumpart(wdf, doclen, unique_terms, wdfdocmax));
 }
 
 double

--- a/xapian-core/matcher/synonympostlist.cc
+++ b/xapian-core/matcher/synonympostlist.cc
@@ -90,6 +90,8 @@ SynonymPostList::get_weight(Xapian::termcount doclen,
 	    }
 	    if (wdf > doclen) wdf = doclen;
 	}
+	// Set wdfdocmax to doclen in case of a synonym.
+	wdfdocmax = doclen;
     }
     RETURN(wt->get_sumpart(wdf, doclen, unique_terms, wdfdocmax));
 }

--- a/xapian-core/matcher/synonympostlist.h
+++ b/xapian-core/matcher/synonympostlist.h
@@ -81,7 +81,8 @@ class SynonymPostList : public WrapperPostList {
     PostList *skip_to(Xapian::docid did, double w_min);
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
     double recalc_maxweight();
 
     // Note - we don't need to implement get_termfreq_est_using_stats()

--- a/xapian-core/matcher/synonympostlist.h
+++ b/xapian-core/matcher/synonympostlist.h
@@ -44,6 +44,9 @@ class SynonymPostList : public WrapperPostList {
     /// Flag indicating whether the weighting object needs the wdf.
     bool want_wdf;
 
+    /// Flag indicating whether the weighting object needs the wdfdocmax.
+    bool want_wdfdocmax;
+
     /** Are the subquery's wdf contributions disjoint?
      *
      *  This is true is each wdf from the document contributes at most itself
@@ -64,7 +67,7 @@ class SynonymPostList : public WrapperPostList {
 		    PostListTree* pltree_,
 		    bool wdf_disjoint_)
 	: WrapperPostList(subtree), wt(NULL), want_wdf(false),
-	  wdf_disjoint(wdf_disjoint_),
+	  want_wdfdocmax(false), wdf_disjoint(wdf_disjoint_),
 	  pltree(pltree_),
 	  doclen_lower_bound(db->get_doclength_lower_bound()) { }
 

--- a/xapian-core/matcher/valuerangepostlist.cc
+++ b/xapian-core/matcher/valuerangepostlist.cc
@@ -157,7 +157,15 @@ ValueRangePostList::get_docid() const
 
 double
 ValueRangePostList::get_weight(Xapian::termcount,
+			       Xapian::termcount,
 			       Xapian::termcount) const
+{
+    Assert(db);
+    return 0;
+}
+
+Xapian::termcount
+ValueRangePostList::get_wdfdocmax() const
 {
     Assert(db);
     return 0;

--- a/xapian-core/matcher/valuerangepostlist.h
+++ b/xapian-core/matcher/valuerangepostlist.h
@@ -66,7 +66,10 @@ class ValueRangePostList : public PostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
+
+    Xapian::termcount get_wdfdocmax() const;
 
     double recalc_maxweight();
 

--- a/xapian-core/matcher/wrapperpostlist.cc
+++ b/xapian-core/matcher/wrapperpostlist.cc
@@ -55,9 +55,10 @@ WrapperPostList::get_docid() const
 
 double
 WrapperPostList::get_weight(Xapian::termcount doclen,
-			    Xapian::termcount unique_terms) const
+			    Xapian::termcount unique_terms,
+			    Xapian::termcount wdfdocmax) const
 {
-    return pl->get_weight(doclen, unique_terms);
+    return pl->get_weight(doclen, unique_terms, wdfdocmax);
 }
 
 bool

--- a/xapian-core/matcher/wrapperpostlist.h
+++ b/xapian-core/matcher/wrapperpostlist.h
@@ -56,7 +56,8 @@ class WrapperPostList : public PostList {
     Xapian::docid get_docid() const;
 
     double get_weight(Xapian::termcount doclen,
-		      Xapian::termcount unique_terms) const;
+		      Xapian::termcount unique_terms,
+		      Xapian::termcount wdfdocmax) const;
 
     bool at_end() const;
 

--- a/xapian-core/net/remote_protocol.rst
+++ b/xapian-core/net/remote_protocol.rst
@@ -131,6 +131,12 @@ Unique Terms
 -  ``MSG_UNIQUETERMS L<document id>``
 -  ``REPLY_UNIQUETERMS L<number of unique terms>``
 
+Max wdf
+-------
+
+-  ``MSG_WDFDOCMAX L<document id>``
+-  ``REPLY_WDFDOCMAX L<max wdf in the document>``
+
 Value Stats
 -----------
 

--- a/xapian-core/net/remoteprotocol.h
+++ b/xapian-core/net/remoteprotocol.h
@@ -97,6 +97,7 @@ enum message_type {
     MSG_METADATAKEYLIST,	// Iterator for metadata keys
     MSG_FREQS,			// Get termfreq and collfreq
     MSG_UNIQUETERMS,		// Get number of unique terms in doc
+    MSG_WDFDOCMAX,		// Get the max_wdf in doc
     MSG_POSITIONLISTCOUNT,	// Get PositionList length
     MSG_RECONSTRUCTTEXT,	// Reconstruct document text
     MSG_SYNONYMTERMLIST,	// Get synonyms for a term
@@ -132,6 +133,7 @@ enum reply_type {
     REPLY_METADATAKEYLIST,	// Iterator for metadata keys
     REPLY_FREQS,		// Get termfreq and collfreq
     REPLY_UNIQUETERMS,		// Get number of unique terms in doc
+    REPLY_WDFDOCMAX,		// Get the max_wdf in doc
     REPLY_POSITIONLISTCOUNT,	// Get PositionList length
     REPLY_REMOVESPELLING,	// Remove a spelling
     REPLY_TERMLISTHEADER,	// Header for get termlist

--- a/xapian-core/net/remoteserver.cc
+++ b/xapian-core/net/remoteserver.cc
@@ -249,6 +249,9 @@ RemoteServer::run()
 		case MSG_UNIQUETERMS:
 		    msg_uniqueterms(message);
 		    continue;
+		case MSG_WDFDOCMAX:
+		    msg_wdfdocmax(message);
+		    continue;
 		case MSG_POSITIONLISTCOUNT:
 		    msg_positionlistcount(message);
 		    continue;
@@ -782,6 +785,20 @@ RemoteServer::msg_uniqueterms(const string &message)
     string reply;
     pack_uint_last(reply, db->get_unique_terms(did));
     send_message(REPLY_UNIQUETERMS, reply);
+}
+
+void
+RemoteServer::msg_wdfdocmax(const string& message)
+{
+    const char* p = message.data();
+    const char* p_end = p + message.size();
+    Xapian::docid did;
+    if (!unpack_uint_last(&p, p_end, &did)) {
+	throw Xapian::NetworkError("Bad MSG_WDFDOCMAX");
+    }
+    string reply;
+    pack_uint_last(reply, db->get_wdfdocmax(did));
+    send_message(REPLY_WDFDOCMAX, reply);
 }
 
 void

--- a/xapian-core/net/remoteserver.h
+++ b/xapian-core/net/remoteserver.h
@@ -206,6 +206,10 @@ class XAPIAN_VISIBILITY_DEFAULT RemoteServer : private RemoteConnection {
     XAPIAN_VISIBILITY_INTERNAL
     void msg_uniqueterms(const std::string & message);
 
+    // get max_wdf
+    XAPIAN_VISIBILITY_INTERNAL
+    void msg_wdfdocmax(const std::string& message);
+
     // reconstruct document text
     XAPIAN_VISIBILITY_INTERNAL
     void msg_reconstructtext(const std::string& message);

--- a/xapian-core/tests/api_db.cc
+++ b/xapian-core/tests/api_db.cc
@@ -1713,7 +1713,10 @@ class MyWeight : public Xapian::Weight {
     std::string name() const { return "MyWeight"; }
     string serialise() const { return string(); }
     MyWeight * unserialise(const string &) const { return new MyWeight; }
-    double get_sumpart(Xapian::termcount, Xapian::termcount, Xapian::termcount) const {
+    double get_sumpart(Xapian::termcount,
+		       Xapian::termcount,
+		       Xapian::termcount,
+		       Xapian::termcount) const {
 	return scale_factor;
     }
     double get_maxpart() const { return scale_factor; }

--- a/xapian-core/tests/api_percentages.cc
+++ b/xapian-core/tests/api_percentages.cc
@@ -305,6 +305,7 @@ class ZWeight : public Xapian::Weight {
 
     double get_sumpart(Xapian::termcount,
 		       Xapian::termcount,
+		       Xapian::termcount,
 		       Xapian::termcount) const {
 	return 0.0;
     }

--- a/xapian-core/tests/api_serialise.cc
+++ b/xapian-core/tests/api_serialise.cc
@@ -401,7 +401,10 @@ class ExceptionalWeight : public Xapian::Weight {
 
     void init(double) { }
 
-    double get_sumpart(Xapian::termcount, Xapian::termcount, Xapian::termcount) const {
+    double get_sumpart(Xapian::termcount,
+		       Xapian::termcount,
+		       Xapian::termcount,
+		       Xapian::termcount) const {
 	return 0;
     }
     double get_maxpart() const { return 0; }

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -1396,6 +1396,7 @@ class CheckStatsWeight : public Xapian::Weight {
 	TEST_REL(uniqueterms,<=,doclen);
 	TEST_REL(wdf,<=,wdf_upper);
 	TEST_REL(wdfdocmax,>=,1);
+	TEST_REL(wdfdocmax,<=,doclen);
 	if (term2 != "_") {
 	    sum += wdf;
 	    sum_squares += wdf * wdf;

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -1229,7 +1229,7 @@ class CheckInitWeight : public Xapian::Weight {
     }
 
     double get_sumpart(Xapian::termcount, Xapian::termcount,
-		       Xapian::termcount) const {
+		       Xapian::termcount, Xapian::termcount) const {
 	return 1.0;
     }
 
@@ -1302,6 +1302,7 @@ class CheckStatsWeight : public Xapian::Weight {
 	need_stat(COLLECTION_FREQ);
 	need_stat(UNIQUE_TERMS);
 	need_stat(TOTAL_LENGTH);
+	need_stat(WDF_DOC_MAX);
     }
 
     CheckStatsWeight(const Xapian::Database & db_,
@@ -1330,7 +1331,7 @@ class CheckStatsWeight : public Xapian::Weight {
     }
 
     double get_sumpart(Xapian::termcount wdf, Xapian::termcount doclen,
-		       Xapian::termcount uniqueterms) const {
+		       Xapian::termcount uniqueterms, Xapian::termcount) const {
 	Xapian::doccount num_docs = db.get_doccount();
 	TEST_EQUAL(get_collection_size(), num_docs);
 	TEST_EQUAL(get_rset_size(), 0);

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -1692,7 +1692,7 @@ class CheckStatsWeight5 : public Xapian::Weight {
 };
 
 /// Check wdfdocmax is clamped to doclen even if wdf and doclen aren't wanted.
-DEFINE_TESTCASE(checkstatsweight5, backend && !remote) {
+DEFINE_TESTCASE(checkstatsweight5, backend && !multi && !remote) {
     Xapian::Database db = get_database("apitest_simpledata");
     Xapian::Enquire enquire(db);
     Xapian::Query q{Xapian::Query::OP_SYNONYM,

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -1392,11 +1392,14 @@ class CheckStatsWeight : public Xapian::Weight {
 	TEST_EQUAL(get_wqf(), 1);
 	TEST_REL(doclen,>=,len_lower);
 	TEST_REL(doclen,<=,len_upper);
-	TEST_REL(uniqueterms,>=,1);
+	if (doclen > 0) {
+	    TEST_REL(uniqueterms,>=,1);
+	    TEST_REL(wdfdocmax,>=,1);
+	}
 	TEST_REL(uniqueterms,<=,doclen);
 	TEST_REL(wdf,<=,wdf_upper);
-	TEST_REL(wdfdocmax,>=,1);
 	TEST_REL(wdfdocmax,<=,doclen);
+	TEST_REL(wdfdocmax,>=,wdf);
 	if (term2 != "_") {
 	    sum += wdf;
 	    sum_squares += wdf * wdf;

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -1330,8 +1330,10 @@ class CheckStatsWeight : public Xapian::Weight {
 	return res;
     }
 
-    double get_sumpart(Xapian::termcount wdf, Xapian::termcount doclen,
-		       Xapian::termcount uniqueterms, Xapian::termcount) const {
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqueterms,
+		       Xapian::termcount wdfdocmax) const {
 	Xapian::doccount num_docs = db.get_doccount();
 	TEST_EQUAL(get_collection_size(), num_docs);
 	TEST_EQUAL(get_rset_size(), 0);
@@ -1393,6 +1395,7 @@ class CheckStatsWeight : public Xapian::Weight {
 	TEST_REL(uniqueterms,>=,1);
 	TEST_REL(uniqueterms,<=,doclen);
 	TEST_REL(wdf,<=,wdf_upper);
+	TEST_REL(wdfdocmax,>=,1);
 	if (term2 != "_") {
 	    sum += wdf;
 	    sum_squares += wdf * wdf;

--- a/xapian-core/weight/bb2weight.cc
+++ b/xapian-core/weight/bb2weight.cc
@@ -148,7 +148,7 @@ BB2Weight::unserialise(const string & s) const
 
 double
 BB2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		       Xapian::termcount) const
+		       Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
 

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -119,7 +119,7 @@ BM25PlusWeight::unserialise(const string & s) const
 
 double
 BM25PlusWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			    Xapian::termcount) const
+			    Xapian::termcount, Xapian::termcount) const
 {
     LOGCALL(WTCALC, double, "BM25PlusWeight::get_sumpart", wdf | len);
     Xapian::doclength normlen = max(len * len_factor, param_min_normlen);

--- a/xapian-core/weight/bm25weight.cc
+++ b/xapian-core/weight/bm25weight.cc
@@ -169,7 +169,7 @@ BM25Weight::unserialise(const string & s) const
 
 double
 BM25Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     LOGCALL(WTCALC, double, "BM25Weight::get_sumpart", wdf | len);
     Xapian::doclength normlen = max(len * len_factor, param_min_normlen);

--- a/xapian-core/weight/boolweight.cc
+++ b/xapian-core/weight/boolweight.cc
@@ -69,7 +69,7 @@ BoolWeight::unserialise(const string& s) const
 
 double
 BoolWeight::get_sumpart(Xapian::termcount, Xapian::termcount,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/coordweight.cc
+++ b/xapian-core/weight/coordweight.cc
@@ -69,7 +69,7 @@ CoordWeight::unserialise(const string& s) const
 
 double
 CoordWeight::get_sumpart(Xapian::termcount, Xapian::termcount,
-			 Xapian::termcount) const
+			 Xapian::termcount, Xapian::termcount) const
 {
     return factor;
 }

--- a/xapian-core/weight/dicecoeffweight.cc
+++ b/xapian-core/weight/dicecoeffweight.cc
@@ -85,8 +85,10 @@ DiceCoeffWeight::unserialise(const string & s) const
 }
 
 double
-DiceCoeffWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount,
-			     Xapian::termcount uniqterms) const
+DiceCoeffWeight::get_sumpart(Xapian::termcount wdf,
+			     Xapian::termcount,
+			     Xapian::termcount uniqterms,
+			     Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
     return factor * 2.0 / (get_query_length() + uniqterms);

--- a/xapian-core/weight/dlhweight.cc
+++ b/xapian-core/weight/dlhweight.cc
@@ -181,7 +181,7 @@ DLHWeight::unserialise(const string& s) const
 
 double
 DLHWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		       Xapian::termcount) const
+		       Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0 || wdf == len) return 0.0;
 

--- a/xapian-core/weight/dphweight.cc
+++ b/xapian-core/weight/dphweight.cc
@@ -137,7 +137,7 @@ DPHWeight::unserialise(const string& s) const
 
 double
 DPHWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		       Xapian::termcount) const
+		       Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0 || wdf == len) return 0.0;
 

--- a/xapian-core/weight/ifb2weight.cc
+++ b/xapian-core/weight/ifb2weight.cc
@@ -122,7 +122,7 @@ IfB2Weight::unserialise(const string & s) const
 
 double
 IfB2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
     double wdfn = wdf;

--- a/xapian-core/weight/ineb2weight.cc
+++ b/xapian-core/weight/ineb2weight.cc
@@ -121,7 +121,7 @@ IneB2Weight::unserialise(const string & s) const
 
 double
 IneB2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			 Xapian::termcount) const
+			 Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
     double wdfn = wdf;

--- a/xapian-core/weight/inl2weight.cc
+++ b/xapian-core/weight/inl2weight.cc
@@ -119,7 +119,7 @@ InL2Weight::unserialise(const string & s) const
 
 double
 InL2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
     double wdfn = wdf;

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -161,7 +161,7 @@ LMWeight::unserialise(const string & s) const
 
 double
 LMWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		      Xapian::termcount uniqterm) const
+		      Xapian::termcount uniqterm, Xapian::termcount) const
 {
     // Within Document Frequency of the term in document being considered.
     double wdf_double = wdf;

--- a/xapian-core/weight/pl2plusweight.cc
+++ b/xapian-core/weight/pl2plusweight.cc
@@ -167,7 +167,7 @@ PL2PlusWeight::unserialise(const string & s) const
 
 double
 PL2PlusWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			   Xapian::termcount) const
+			   Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0 || mean < 1) return 0.0;
 

--- a/xapian-core/weight/pl2weight.cc
+++ b/xapian-core/weight/pl2weight.cc
@@ -157,7 +157,7 @@ PL2Weight::unserialise(const string & s) const
 
 double
 PL2Weight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-		       Xapian::termcount) const
+		       Xapian::termcount, Xapian::termcount) const
 {
     if (wdf == 0) return 0.0;
 

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -198,10 +198,12 @@ TfIdfWeight::unserialise(const string & s) const
 }
 
 double
-TfIdfWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount doclen,
-			 Xapian::termcount uniqterms) const
+TfIdfWeight::get_sumpart(Xapian::termcount wdf,
+			 Xapian::termcount doclen,
+			 Xapian::termcount uniqterms,
+			 Xapian::termcount wdfdocmax) const
 {
-    double wdfn = get_wdfn(wdf, doclen, uniqterms, wdf_norm_);
+    double wdfn = get_wdfn(wdf, doclen, uniqterms, wdfdocmax, wdf_norm_);
     return get_wtn(wdfn * idfn, wt_norm_) * wqf_factor;
 }
 
@@ -212,7 +214,7 @@ TfIdfWeight::get_maxpart() const
 {
     Xapian::termcount wdf_max = get_wdf_upper_bound();
     Xapian::termcount len_min = get_doclength_lower_bound();
-    double wdfn = get_wdfn(wdf_max, len_min, len_min, wdf_norm_);
+    double wdfn = get_wdfn(wdf_max, len_min, len_min, wdf_max, wdf_norm_);
     return get_wtn(wdfn * idfn, wt_norm_) * wqf_factor;
 }
 
@@ -233,6 +235,7 @@ TfIdfWeight::get_maxextra() const
 double
 TfIdfWeight::get_wdfn(Xapian::termcount wdf, Xapian::termcount doclen,
 		      Xapian::termcount uniqterms,
+		      Xapian::termcount wdfdocmax,
 		      wdf_norm wdf_normalization) const
 {
     switch (wdf_normalization) {

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -235,7 +235,7 @@ TfIdfWeight::get_maxextra() const
 double
 TfIdfWeight::get_wdfn(Xapian::termcount wdf, Xapian::termcount doclen,
 		      Xapian::termcount uniqterms,
-		      Xapian::termcount wdfdocmax,
+		      Xapian::termcount,
 		      wdf_norm wdf_normalization) const
 {
     switch (wdf_normalization) {

--- a/xapian-core/weight/tradweight.cc
+++ b/xapian-core/weight/tradweight.cc
@@ -155,7 +155,7 @@ TradWeight::unserialise(const string & s) const
 
 double
 TradWeight::get_sumpart(Xapian::termcount wdf, Xapian::termcount len,
-			Xapian::termcount) const
+			Xapian::termcount, Xapian::termcount) const
 {
     double wdf_double = wdf;
     return termweight * (wdf_double / (len * len_factor + wdf_double));


### PR DESCRIPTION
Some TfIdf normalisations require the max wdf in the document.
This change adds remote and honey backend support for wdfdocmax,
hence fixes one issue of  #744.