### PR TITLE
Pass wdfdocmax to get_sumextra()

### DIFF
--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -262,7 +262,8 @@ class XAPIAN_VISIBILITY_DEFAULT Weight {
      *  @param uniqterms The number of unique terms in the document.
      */
     virtual double get_sumextra(Xapian::termcount doclen,
-				Xapian::termcount uniqterms) const = 0;
+				Xapian::termcount uniqterms,
+				Xapian::termcount wdfdocmax) const = 0;
 
     /** Return an upper bound on what get_sumextra() can return for any
      *  document.
@@ -470,7 +471,8 @@ class XAPIAN_VISIBILITY_DEFAULT BoolWeight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     BoolWeight * create_from_parameters(const char * params) const;
@@ -792,7 +794,8 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     TfIdfWeight * create_from_parameters(const char * params) const;
@@ -904,7 +907,8 @@ class XAPIAN_VISIBILITY_DEFAULT BM25Weight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     BM25Weight * create_from_parameters(const char * params) const;
@@ -1027,7 +1031,8 @@ class XAPIAN_VISIBILITY_DEFAULT BM25PlusWeight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     BM25PlusWeight * create_from_parameters(const char * params) const;
@@ -1092,7 +1097,8 @@ class XAPIAN_VISIBILITY_DEFAULT TradWeight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     TradWeight * create_from_parameters(const char * params) const;
@@ -1169,7 +1175,8 @@ class XAPIAN_VISIBILITY_DEFAULT InL2Weight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     InL2Weight * create_from_parameters(const char * params) const;
@@ -1246,7 +1253,8 @@ class XAPIAN_VISIBILITY_DEFAULT IfB2Weight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     IfB2Weight * create_from_parameters(const char * params) const;
@@ -1321,7 +1329,8 @@ class XAPIAN_VISIBILITY_DEFAULT IneB2Weight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     IneB2Weight * create_from_parameters(const char * params) const;
@@ -1401,7 +1410,8 @@ class XAPIAN_VISIBILITY_DEFAULT BB2Weight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     BB2Weight * create_from_parameters(const char * params) const;
@@ -1461,7 +1471,8 @@ class XAPIAN_VISIBILITY_DEFAULT DLHWeight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     DLHWeight * create_from_parameters(const char * params) const;
@@ -1543,7 +1554,8 @@ class XAPIAN_VISIBILITY_DEFAULT PL2Weight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     PL2Weight * create_from_parameters(const char * params) const;
@@ -1625,7 +1637,8 @@ class XAPIAN_VISIBILITY_DEFAULT PL2PlusWeight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     PL2PlusWeight * create_from_parameters(const char * params) const;
@@ -1688,7 +1701,8 @@ class XAPIAN_VISIBILITY_DEFAULT DPHWeight : public Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 
     DPHWeight * create_from_parameters(const char * params) const;
@@ -1795,7 +1809,9 @@ class XAPIAN_VISIBILITY_DEFAULT LMWeight : public Weight {
 		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const;
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount,
+			Xapian::termcount) const;
     double get_maxextra() const;
 
     LMWeight * create_from_parameters(const char * params) const;
@@ -1830,7 +1846,9 @@ class XAPIAN_VISIBILITY_DEFAULT CoordWeight : public Weight {
 		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount, Xapian::termcount) const;
+    double get_sumextra(Xapian::termcount,
+			Xapian::termcount,
+			Xapian::termcount) const;
     double get_maxextra() const;
 
     CoordWeight * create_from_parameters(const char * params) const;
@@ -1875,7 +1893,9 @@ class XAPIAN_VISIBILITY_DEFAULT DiceCoeffWeight : public Weight {
 		       Xapian::termcount wdfdocmax) const;
     double get_maxpart() const;
 
-    double get_sumextra(Xapian::termcount, Xapian::termcount) const;
+    double get_sumextra(Xapian::termcount,
+			Xapian::termcount,
+			Xapian::termcount) const;
     double get_maxextra() const;
 
     DiceCoeffWeight * create_from_parameters(const char * params) const;

--- a/xapian-core/matcher/extraweightpostlist.cc
+++ b/xapian-core/matcher/extraweightpostlist.cc
@@ -33,11 +33,12 @@ ExtraWeightPostList::get_weight(Xapian::termcount doclen,
 				Xapian::termcount unique_terms,
 				Xapian ::termcount wdfdocmax) const
 {
-    /* Weight::get_sumextra() takes two parameters (document length and number
-     * of unique terms) but none of the currently implemented weighting schemes
-     * actually use the latter - it was added because it's likely to be wanted
-     * at some point, and so that we got all the incompatible changes needed to
-     * add support for the number of unique terms over with in one go.
+    /* Weight::get_sumextra() takes three parameters (document length, number of
+     * unique terms and the max wdf in the document) but none of the currently
+     * implemented weighting schemes actually use the max wdf - it was added
+     * because it's likely to be wanted at some point, and so that we got all
+     * the incompatible changes needed to add support for the max wdf over with
+     * in one go.
      */
     double sum_extra = weight->get_sumextra(doclen, unique_terms, wdfdocmax);
     AssertRel(sum_extra,<=,max_extra);

--- a/xapian-core/matcher/extraweightpostlist.cc
+++ b/xapian-core/matcher/extraweightpostlist.cc
@@ -34,11 +34,11 @@ ExtraWeightPostList::get_weight(Xapian::termcount doclen,
 				Xapian ::termcount wdfdocmax) const
 {
     /* Weight::get_sumextra() takes three parameters (document length, number of
-     * unique terms and the max wdf in the document) but none of the currently
-     * implemented weighting schemes actually use the max wdf - it was added
-     * because it's likely to be wanted at some point, and so that we got all
-     * the incompatible changes needed to add support for the max wdf over with
-     * in one go.
+     * unique terms and the max wdf in the document) but currently only doclen
+     * is actually used - unique_terms and wdfdocmax were added because they are
+     * likely to be wanted at some point, and so that we got all the
+     * incompatible changes needed to add support for the unique terms and max
+     * wdf over with in one go.
      */
     double sum_extra = weight->get_sumextra(doclen, unique_terms, wdfdocmax);
     AssertRel(sum_extra,<=,max_extra);

--- a/xapian-core/matcher/extraweightpostlist.cc
+++ b/xapian-core/matcher/extraweightpostlist.cc
@@ -39,7 +39,7 @@ ExtraWeightPostList::get_weight(Xapian::termcount doclen,
      * at some point, and so that we got all the incompatible changes needed to
      * add support for the number of unique terms over with in one go.
      */
-    double sum_extra = weight->get_sumextra(doclen, unique_terms);
+    double sum_extra = weight->get_sumextra(doclen, unique_terms, wdfdocmax);
     AssertRel(sum_extra,<=,max_extra);
     return pl->get_weight(doclen, unique_terms, wdfdocmax) + sum_extra;
 }

--- a/xapian-core/matcher/localsubmatch.cc
+++ b/xapian-core/matcher/localsubmatch.cc
@@ -91,7 +91,8 @@ class LazyWeight : public Xapian::Weight {
     double get_maxpart() const;
 
     double get_sumextra(Xapian::termcount doclen,
-			Xapian::termcount uniqterms) const;
+			Xapian::termcount uniqterms,
+			Xapian::termcount wdfdocmax) const;
     double get_maxextra() const;
 };
 
@@ -144,10 +145,12 @@ LazyWeight::get_sumpart(Xapian::termcount wdf,
 
 double
 LazyWeight::get_sumextra(Xapian::termcount doclen,
-			 Xapian::termcount uniqterms) const
+			 Xapian::termcount uniqterms,
+			 Xapian::termcount wdfdocmax) const
 {
     (void)doclen;
     (void)uniqterms;
+    (void)wdfdocmax;
     throw Xapian::InvalidOperationError("LazyWeight::get_sumextra()");
 }
 

--- a/xapian-core/tests/api_db.cc
+++ b/xapian-core/tests/api_db.cc
@@ -1721,7 +1721,11 @@ class MyWeight : public Xapian::Weight {
     }
     double get_maxpart() const { return scale_factor; }
 
-    double get_sumextra(Xapian::termcount, Xapian::termcount) const { return 0; }
+    double get_sumextra(Xapian::termcount,
+			Xapian::termcount,
+			Xapian::termcount) const {
+	return 0;
+    }
     double get_maxextra() const { return 0; }
 };
 

--- a/xapian-core/tests/api_percentages.cc
+++ b/xapian-core/tests/api_percentages.cc
@@ -315,6 +315,7 @@ class ZWeight : public Xapian::Weight {
     }
 
     double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount,
 			Xapian::termcount) const {
 	return 1.0 / doclen;
     }

--- a/xapian-core/tests/api_serialise.cc
+++ b/xapian-core/tests/api_serialise.cc
@@ -409,7 +409,11 @@ class ExceptionalWeight : public Xapian::Weight {
     }
     double get_maxpart() const { return 0; }
 
-    double get_sumextra(Xapian::termcount, Xapian::termcount) const { return 0; }
+    double get_sumextra(Xapian::termcount,
+			Xapian::termcount,
+			Xapian::termcount) const {
+	return 0;
+    }
     double get_maxextra() const { return 0; }
 };
 

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -1235,7 +1235,9 @@ class CheckInitWeight : public Xapian::Weight {
 
     double get_maxpart() const { return 1.0; }
 
-    double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const {
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount,
+			Xapian::termcount) const {
 	return 1.0 / doclen;
     }
 
@@ -1330,10 +1332,8 @@ class CheckStatsWeight : public Xapian::Weight {
 	return res;
     }
 
-    double get_sumpart(Xapian::termcount wdf,
-		       Xapian::termcount doclen,
-		       Xapian::termcount uniqueterms,
-		       Xapian::termcount wdfdocmax) const {
+    double get_sumpart(Xapian::termcount wdf, Xapian::termcount doclen,
+		       Xapian::termcount uniqueterms, Xapian::termcount) const {
 	Xapian::doccount num_docs = db.get_doccount();
 	TEST_EQUAL(get_collection_size(), num_docs);
 	TEST_EQUAL(get_rset_size(), 0);
@@ -1416,7 +1416,9 @@ class CheckStatsWeight : public Xapian::Weight {
 	return 1.0;
     }
 
-    double get_sumextra(Xapian::termcount doclen, Xapian::termcount) const {
+    double get_sumextra(Xapian::termcount doclen,
+			Xapian::termcount,
+			Xapian::termcount) const {
 	return 1.0 / doclen;
     }
 

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -1332,8 +1332,10 @@ class CheckStatsWeight : public Xapian::Weight {
 	return res;
     }
 
-    double get_sumpart(Xapian::termcount wdf, Xapian::termcount doclen,
-		       Xapian::termcount uniqueterms, Xapian::termcount) const {
+    double get_sumpart(Xapian::termcount wdf,
+		       Xapian::termcount doclen,
+		       Xapian::termcount uniqueterms,
+		       Xapian::termcount wdfdocmax) const {
 	Xapian::doccount num_docs = db.get_doccount();
 	TEST_EQUAL(get_collection_size(), num_docs);
 	TEST_EQUAL(get_rset_size(), 0);
@@ -1686,7 +1688,8 @@ class CheckStatsWeight5 : public Xapian::Weight {
 	return 1.0;
     }
 
-    double get_sumextra(Xapian::termcount, Xapian::termcount) const {
+    double get_sumextra(Xapian::termcount, Xapian::termcount,
+			Xapian::termcount) const {
 	return 0.0;
     }
 

--- a/xapian-core/weight/bb2weight.cc
+++ b/xapian-core/weight/bb2weight.cc
@@ -185,7 +185,9 @@ BB2Weight::get_maxpart() const
 }
 
 double
-BB2Weight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+BB2Weight::get_sumextra(Xapian::termcount,
+			Xapian::termcount,
+			Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/bm25plusweight.cc
+++ b/xapian-core/weight/bm25plusweight.cc
@@ -173,7 +173,9 @@ BM25PlusWeight::get_maxpart() const
  * 2 * param_k2 * query_length / (1 + normlen)
  */
 double
-BM25PlusWeight::get_sumextra(Xapian::termcount len, Xapian::termcount) const
+BM25PlusWeight::get_sumextra(Xapian::termcount len,
+			     Xapian::termcount,
+			     Xapian::termcount) const
 {
     LOGCALL(WTCALC, double, "BM25PlusWeight::get_sumextra", len);
     double num = (2.0 * param_k2 * get_query_length());

--- a/xapian-core/weight/bm25weight.cc
+++ b/xapian-core/weight/bm25weight.cc
@@ -217,7 +217,9 @@ BM25Weight::get_maxpart() const
  * 2 * param_k2 * query_length / (1 + normlen)
  */
 double
-BM25Weight::get_sumextra(Xapian::termcount len, Xapian::termcount) const
+BM25Weight::get_sumextra(Xapian::termcount len,
+			 Xapian::termcount,
+			 Xapian::termcount) const
 {
     LOGCALL(WTCALC, double, "BM25Weight::get_sumextra", len);
     double num = (2.0 * param_k2 * get_query_length());

--- a/xapian-core/weight/boolweight.cc
+++ b/xapian-core/weight/boolweight.cc
@@ -81,7 +81,9 @@ BoolWeight::get_maxpart() const
 }
 
 double
-BoolWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+BoolWeight::get_sumextra(Xapian::termcount,
+			 Xapian::termcount,
+			 Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/coordweight.cc
+++ b/xapian-core/weight/coordweight.cc
@@ -81,7 +81,9 @@ CoordWeight::get_maxpart() const
 }
 
 double
-CoordWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+CoordWeight::get_sumextra(Xapian::termcount,
+			  Xapian::termcount,
+			  Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/dicecoeffweight.cc
+++ b/xapian-core/weight/dicecoeffweight.cc
@@ -101,7 +101,9 @@ DiceCoeffWeight::get_maxpart() const
 }
 
 double
-DiceCoeffWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+DiceCoeffWeight::get_sumextra(Xapian::termcount,
+			      Xapian::termcount,
+			      Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/dlhweight.cc
+++ b/xapian-core/weight/dlhweight.cc
@@ -203,7 +203,9 @@ DLHWeight::get_maxpart() const
 }
 
 double
-DLHWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+DLHWeight::get_sumextra(Xapian::termcount,
+			Xapian::termcount,
+			Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/dphweight.cc
+++ b/xapian-core/weight/dphweight.cc
@@ -160,7 +160,9 @@ DPHWeight::get_maxpart() const
 }
 
 double
-DPHWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+DPHWeight::get_sumextra(Xapian::termcount,
+			Xapian::termcount,
+			Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/ifb2weight.cc
+++ b/xapian-core/weight/ifb2weight.cc
@@ -140,7 +140,9 @@ IfB2Weight::get_maxpart() const
 }
 
 double
-IfB2Weight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+IfB2Weight::get_sumextra(Xapian::termcount,
+			 Xapian::termcount,
+			 Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/ineb2weight.cc
+++ b/xapian-core/weight/ineb2weight.cc
@@ -140,7 +140,9 @@ IneB2Weight::get_maxpart() const
 }
 
 double
-IneB2Weight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+IneB2Weight::get_sumextra(Xapian::termcount,
+			  Xapian::termcount,
+			  Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/inl2weight.cc
+++ b/xapian-core/weight/inl2weight.cc
@@ -138,7 +138,9 @@ InL2Weight::get_maxpart() const
 }
 
 double
-InL2Weight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+InL2Weight::get_sumextra(Xapian::termcount,
+			 Xapian::termcount,
+			 Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/lmweight.cc
+++ b/xapian-core/weight/lmweight.cc
@@ -245,7 +245,9 @@ LMWeight::get_maxpart() const
  *	  |D| is total document length.
  */
 double
-LMWeight::get_sumextra(Xapian::termcount len, Xapian::termcount) const
+LMWeight::get_sumextra(Xapian::termcount len,
+		       Xapian::termcount,
+		       Xapian::termcount) const
 {
     if (select_smoothing == DIRICHLET_PLUS_SMOOTHING) {
 	double extra_weight = param_smoothing1 / (len + param_smoothing1);

--- a/xapian-core/weight/pl2plusweight.cc
+++ b/xapian-core/weight/pl2plusweight.cc
@@ -190,7 +190,9 @@ PL2PlusWeight::get_maxpart() const
 }
 
 double
-PL2PlusWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+PL2PlusWeight::get_sumextra(Xapian::termcount,
+			    Xapian::termcount,
+			    Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/pl2weight.cc
+++ b/xapian-core/weight/pl2weight.cc
@@ -176,7 +176,9 @@ PL2Weight::get_maxpart() const
 }
 
 double
-PL2Weight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+PL2Weight::get_sumextra(Xapian::termcount,
+			Xapian::termcount,
+			Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -214,8 +214,7 @@ TfIdfWeight::get_maxpart() const
 {
     Xapian::termcount wdf_max = get_wdf_upper_bound();
     Xapian::termcount len_min = get_doclength_lower_bound();
-    double wdfn = get_wdfn(wdf_max, len_min, len_min,
-			   wdf_max, wdf_norm_);
+    double wdfn = get_wdfn(wdf_max, len_min, len_min, wdf_max, wdf_norm_);
     return get_wtn(wdfn * idfn, wt_norm_) * wqf_factor;
 }
 

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -214,13 +214,16 @@ TfIdfWeight::get_maxpart() const
 {
     Xapian::termcount wdf_max = get_wdf_upper_bound();
     Xapian::termcount len_min = get_doclength_lower_bound();
-    double wdfn = get_wdfn(wdf_max, len_min, len_min, wdf_max, wdf_norm_);
+    double wdfn = get_wdfn(wdf_max, len_min, len_min,
+			   wdf_max, wdf_norm_);
     return get_wtn(wdfn * idfn, wt_norm_) * wqf_factor;
 }
 
 // There is no extra per document component in the TfIdfWeighting scheme.
 double
-TfIdfWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+TfIdfWeight::get_sumextra(Xapian::termcount,
+			  Xapian::termcount,
+			  Xapian::termcount) const
 {
     return 0;
 }

--- a/xapian-core/weight/tradweight.cc
+++ b/xapian-core/weight/tradweight.cc
@@ -171,7 +171,9 @@ TradWeight::get_maxpart() const
 }
 
 double
-TradWeight::get_sumextra(Xapian::termcount, Xapian::termcount) const
+TradWeight::get_sumextra(Xapian::termcount,
+			 Xapian::termcount,
+			 Xapian::termcount) const
 {
     return 0;
 }


### PR DESCRIPTION
Since we pass doclen and uniqterms to get_sumextra(), it makes
sense that we also pass wdfdocmax to it. This fixes the second
issue of #744. (the first was fixed by PR 309)