### PR TITLE
Support more normalisations for TfIdfWeight

### DIFF
--- a/xapian-core/include/xapian/weight.h
+++ b/xapian-core/include/xapian/weight.h
@@ -537,7 +537,19 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
 	 *
 	 *  wdfn=0.9+0.1*(wdf/(doclen/unique_terms)) if(wdf>0), else wdfn=0
 	 */
-	AUG_AVERAGE = 9
+	AUG_AVERAGE = 9,
+
+	/** Max wdf
+	 *
+	 *  wdfn=wdf/wdfdocmax
+	 */
+	MAX = 10,
+
+	/** Augmented max wdf
+	 *
+	 *  wdfn=0.5+0.5*wdf/wdfdocmax if(wdf>0), else wdfn=0
+	 */
+	AUG = 11
     };
 
     /** Idf normalizations. */
@@ -665,9 +677,8 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      *     @li 'l': Logarithmic wdfn=1+log<sub>e</sub>(wdf)
      *     @li 'P': Pivoted     wdfn=(1+log(1+log(wdf)))*(1/(1-slope+(slope*doclen/avg_len)))+delta
      *     @li 'L': Log average wdfn=(1+log(wdf))/(1+log(doclen/unique_terms))
-     *
-     *     The Max-wdf and Augmented Max wdf normalizations haven't yet been
-     *     implemented.
+     *     @li 'm': Max-wdf	wdfn=wdf/wdfdocmax
+     *     @li 'a': Augmented max-wdf  wdfn=0.5+0.5*wdf/wdfdocmax
      *
      * @li The second character indicates the normalization for the idf.  The
      *     following normalizations are currently supported:
@@ -711,9 +722,8 @@ class XAPIAN_VISIBILITY_DEFAULT TfIdfWeight : public Weight {
      *     @li 's': Square     wdfn=wdf*wdf
      *     @li 'l': Logarithmic wdfn=1+log<sub>e</sub>(wdf)
      *     @li 'P': Pivoted     wdfn=(1+log(1+log(wdf)))*(1/(1-slope+(slope*doclen/avg_len)))+delta
-     *
-     *     The Max-wdf and Augmented Max wdf normalizations haven't yet been
-     *     implemented.
+     *     @li 'm': Max-wdf	wdfn=wdf/wdfdocmax
+     *     @li 'a': Augmented max-wdf  wdfn=0.5+0.5*wdf/wdfdocmax
      *
      * @li The second character indicates the normalization for the idf.  The
      *     following normalizations are currently supported:

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -883,6 +883,24 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8 * log((6.0 - 2) / 2));
     TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1 * log((6.0 - 2) / 2));
 
+    // Check for "mnn".
+    enquire.set_query(Xapian::Query("word"));
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("mnn"));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8.0 / 8);
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1.0 / 4);
+
+    // Check for "ann".
+    enquire.set_query(Xapian::Query("word"));
+    enquire.set_weighting_scheme(Xapian::TfIdfWeight("ann"));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(),0.5 + 0.5 * 8.0 / 8);
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(),0.5 + 0.5 * 1.0 / 4);
+
     // Check for NONE, TFIDF, NONE when termfreq != N
     enquire.set_query(query);
     enquire.set_weighting_scheme(
@@ -1116,6 +1134,30 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     mset_expect_order(mset, 2, 4);
     TEST_EQUAL_DOUBLE(mset[0].get_weight(), 0.9 + 0.1 * (8.0 / (81.0 / 56.0)));
     TEST_EQUAL_DOUBLE(mset[1].get_weight(), 0.9 + 0.1 * (1.0 / (31.0 / 26.0)));
+
+    // Check for MAX, NONE, NONE.
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::MAX,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 8.0 / 8);
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 1.0 / 4);
+
+    // Check for AUG, NONE, NONE.
+    enquire.set_weighting_scheme(
+	Xapian::TfIdfWeight(
+	    Xapian::TfIdfWeight::wdf_norm::AUG,
+	    Xapian::TfIdfWeight::idf_norm::NONE,
+	    Xapian::TfIdfWeight::wt_norm::NONE));
+    mset = enquire.get_mset(0, 10);
+    TEST_EQUAL(mset.size(), 2);
+    mset_expect_order(mset, 2, 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(),0.5 + 0.5 * 8.0 / 8);
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(),0.5 + 0.5 * 1.0 / 4);
 }
 
 // Feature tests for pivoted normalization functions.

--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -898,8 +898,8 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     mset_expect_order(mset, 2, 4);
-    TEST_EQUAL_DOUBLE(mset[0].get_weight(),0.5 + 0.5 * 8.0 / 8);
-    TEST_EQUAL_DOUBLE(mset[1].get_weight(),0.5 + 0.5 * 1.0 / 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 0.5 + 0.5 * 8.0 / 8);
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 0.5 + 0.5 * 1.0 / 4);
 
     // Check for NONE, TFIDF, NONE when termfreq != N
     enquire.set_query(query);
@@ -1156,8 +1156,8 @@ DEFINE_TESTCASE(tfidfweight3, backend) {
     mset = enquire.get_mset(0, 10);
     TEST_EQUAL(mset.size(), 2);
     mset_expect_order(mset, 2, 4);
-    TEST_EQUAL_DOUBLE(mset[0].get_weight(),0.5 + 0.5 * 8.0 / 8);
-    TEST_EQUAL_DOUBLE(mset[1].get_weight(),0.5 + 0.5 * 1.0 / 4);
+    TEST_EQUAL_DOUBLE(mset[0].get_weight(), 0.5 + 0.5 * 8.0 / 8);
+    TEST_EQUAL_DOUBLE(mset[1].get_weight(), 0.5 + 0.5 * 1.0 / 4);
 }
 
 // Feature tests for pivoted normalization functions.


### PR DESCRIPTION
Add support for wdf normalisations "max-norm" and "aug-norm"
described by SMART.