### PR TITLE
Fix glass function readahead_key to not abort for overlong keys

### DIFF
--- a/xapian-core/backends/glass/glass_table.cc
+++ b/xapian-core/backends/glass/glass_table.cc
@@ -1430,6 +1430,10 @@ GlassTable::readahead_key(const string &key) const
     LOGCALL(DB, bool, "GlassTable::readahead_key", key);
     Assert(!key.empty());
 
+    // An overlong key cannot be found.
+    if (key.size() > GLASS_BTREE_MAX_KEY_LEN)
+	RETURN(false);
+
     // Three cases:
     //
     // handle == -1:  Lazy table in a multi-file database which isn't yet open.

--- a/xapian-core/tests/api_backend.cc
+++ b/xapian-core/tests/api_backend.cc
@@ -23,6 +23,7 @@
 #include <config.h>
 
 #include "api_backend.h"
+#include "backends/glass/glass_table.h"
 
 #include <xapian.h>
 
@@ -1863,4 +1864,14 @@ DEFINE_TESTCASE(positfrompostit1, positional) {
 	++p;
 	TEST_EQUAL(p, postit.positionlist_end());
     }
+}
+
+// Regression test for glass readahead_key throwing "Key too long" error
+DEFINE_TESTCASE(readaheadkeylong, glass) {
+	Xapian::Database db = get_database("apitest_simpledata");
+	std::string term(GLASS_BTREE_MAX_KEY_LEN + 1, 'x');
+	Xapian::Query q{term};
+	Xapian::Enquire enquire{db};
+	enquire.set_query(q);
+	enquire.get_mset(0, 10);
 }


### PR DESCRIPTION
Currently, a query may abort with an InvalidArgument error if one of
the terms exceed the maximum allowed length for glass btree keys.
However, this error is thrown only if the query triggers a readahead_key
call on the glass table.

This patch updates readahead_key to report overlong keys as not found,
rather than aborting the whole query.