### PR TITLE
Update TfIdfWeight::create_from_parameters() 

### DIFF
--- a/xapian-core/weight/.gitignore
+++ b/xapian-core/weight/.gitignore
@@ -4,3 +4,5 @@
 /.deps
 /.libs
 /.dirstamp
+/wdf-norm-dispatch.h
+/idf-nor-dispatch.h

--- a/xapian-core/weight/.gitignore
+++ b/xapian-core/weight/.gitignore
@@ -5,4 +5,4 @@
 /.libs
 /.dirstamp
 /wdf-norm-dispatch.h
-/idf-nor-dispatch.h
+/idf-norm-dispatch.h

--- a/xapian-core/weight/Makefile.mk
+++ b/xapian-core/weight/Makefile.mk
@@ -2,10 +2,10 @@ noinst_HEADERS +=\
 	weight/weightinternal.h
 
 EXTRA_DIST +=\
-	weight/collate-wdf-norm\
 	weight/collate-idf-norm\
-	weight/wdf-norm-dispatch.h\
+	weight/collate-wdf-norm\
 	weight/idf-norm-dispatch.h\
+	weight/wdf-norm-dispatch.h\
 	weight/Makefile
 
 lib_src +=\
@@ -28,12 +28,12 @@ lib_src +=\
 	weight/weight.cc\
 	weight/weightinternal.cc
 
-weight/wdf-norm-dispatch.h: weight/collate-wdf-norm weight/Makefile.mk common/Tokeniseise.pm
-	$(PERL) -I'$(srcdir)/common' '$(srcdir)/weight/collate-wdf-norm' '$(srcdir)'
-
 weight/idf-norm-dispatch.h: weight/collate-idf-norm weight/Makefile.mk common/Tokeniseise.pm
 	$(PERL) -I'$(srcdir)/common' '$(srcdir)/weight/collate-idf-norm' '$(srcdir)'
 
+weight/wdf-norm-dispatch.h: weight/collate-wdf-norm weight/Makefile.mk common/Tokeniseise.pm
+	$(PERL) -I'$(srcdir)/common' '$(srcdir)/weight/collate-wdf-norm' '$(srcdir)'
+
 BUILT_SOURCES +=\
-	weight/wdf-norm-dispatch.h\
-	weight/idf-norm-dispatch.h
+	weight/idf-norm-dispatch.h\
+	weight/wdf-norm-dispatch.h

--- a/xapian-core/weight/Makefile.mk
+++ b/xapian-core/weight/Makefile.mk
@@ -2,6 +2,10 @@ noinst_HEADERS +=\
 	weight/weightinternal.h
 
 EXTRA_DIST +=\
+	weight/collate-wdf-norm\
+	weight/collate-idf-norm\
+	weight/wdf-norm-dispatch.h\
+	weight/idf-norm-dispatch.h\
 	weight/Makefile
 
 lib_src +=\
@@ -23,3 +27,13 @@ lib_src +=\
 	weight/tradweight.cc\
 	weight/weight.cc\
 	weight/weightinternal.cc
+
+weight/wdf-norm-dispatch.h: weight/collate-wdf-norm weight/Makefile.mk common/Tokeniseise.pm
+	$(PERL) -I'$(srcdir)/common' '$(srcdir)/weight/collate-wdf-norm' '$(srcdir)'
+
+weight/idf-norm-dispatch.h: weight/collate-idf-norm weight/Makefile.mk common/Tokeniseise.pm
+	$(PERL) -I'$(srcdir)/common' '$(srcdir)/weight/collate-idf-norm' '$(srcdir)'
+
+BUILT_SOURCES +=\
+	weight/wdf-norm-dispatch.h\
+	weight/idf-norm-dispatch.h

--- a/xapian-core/weight/collate-idf-norm
+++ b/xapian-core/weight/collate-idf-norm
@@ -23,15 +23,19 @@ EOF
 use Tokeniseise;
 
 my $hdr = Tokeniseise->new('weight/idf-norm-dispatch.h', 'Map string to idf normalisation code', $copyright, 'XAPIAN_INCLUDED_IDF_NORM_DISPATCH_H', 'idf_norm', 2, 'false');
-$hdr->add('NONE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::NONE)');
-$hdr->add('TFIDF', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::TFIDF)');
-$hdr->add('SQUARE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::SQUARE)');
-$hdr->add('FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::FREQ)');
-$hdr->add('PROB', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::PROB)');
-$hdr->add('PIVOTED', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::PIVOTED)');
-$hdr->add('GLOBAL_FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::GLOBAL_FREQ)');
-$hdr->add('LOG_GLOBAL_FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::LOG_GLOBAL_FREQ)');
-$hdr->add('INCREMENTED_GLOBAL_FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::INCREMENTED_GLOBAL_FREQ)');
-$hdr->add('SQRT_GLOBAL_FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::SQRT_GLOBAL_FREQ)');
+for my $enum (qw/
+    NONE
+    TFIDF
+    SQUARE
+    FREQ
+    PROB
+    PIVOTED
+    GLOBAL_FREQ
+    LOG_GLOBAL_FREQ
+    INCREMENTED_GLOBAL_FREQ
+    SQRT_GLOBAL_FREQ /)
+{
+    $hdr->add($enum, "static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::$enum)");
+}
 
 $hdr->write('false', 'idf_norm_tab');

--- a/xapian-core/weight/collate-idf-norm
+++ b/xapian-core/weight/collate-idf-norm
@@ -1,0 +1,37 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+my $copyright = <<'EOF';
+/* Copyright (C) 2020 Dipanshu Garg
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+EOF
+
+use Tokeniseise;
+
+my $hdr = Tokeniseise->new('weight/idf-norm-dispatch.h', 'Map string to idf normalisation code', $copyright, 'XAPIAN_INCLUDED_IDF_NORM_DISPATCH_H', 'idf_norm', 2, 'false');
+$hdr->add('NONE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::NONE)');
+$hdr->add('TFIDF', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::TFIDF)');
+$hdr->add('SQUARE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::SQUARE)');
+$hdr->add('FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::FREQ)');
+$hdr->add('PROB', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::PROB)');
+$hdr->add('PIVOTED', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::PIVOTED)');
+$hdr->add('GLOBAL_FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::GLOBAL_FREQ)');
+$hdr->add('LOG_GLOBAL_FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::LOG_GLOBAL_FREQ)');
+$hdr->add('INCREMENTED_GLOBAL_FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::INCREMENTED_GLOBAL_FREQ)');
+$hdr->add('SQRT_GLOBAL_FREQ', 'static_cast<unsigned char>(Xapian::TfIdfWeight::idf_norm::SQRT_GLOBAL_FREQ)');
+
+$hdr->write('false', 'idf_norm_tab');

--- a/xapian-core/weight/collate-wdf-norm
+++ b/xapian-core/weight/collate-wdf-norm
@@ -23,16 +23,20 @@ EOF
 use Tokeniseise;
 
 my $hdr = Tokeniseise->new('weight/wdf-norm-dispatch.h', 'Map string to wdf normalisation code', $copyright, 'XAPIAN_INCLUDED_WDF_NORM_DISPATCH_H', 'wdf_norm', 2, 'false');
-$hdr->add('NONE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::NONE)');
-$hdr->add('BOOLEAN', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::BOOLEAN)');
-$hdr->add('SQUARE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::SQUARE)');
-$hdr->add('LOG', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::LOG)');
-$hdr->add('PIVOTED', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::PIVOTED)');
-$hdr->add('LOG_AVERAGE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::LOG_AVERAGE)');
-$hdr->add('AUG_LOG', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::AUG_LOG)');
-$hdr->add('SQRT', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::SQRT)');
-$hdr->add('AUG_AVERAGE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::AUG_AVERAGE)');
-$hdr->add('MAX', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::MAX)');
-$hdr->add('AUG', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::AUG)');
+for my $enum (qw/
+    NONE
+    BOOLEAN
+    SQUARE
+    LOG
+    PIVOTED
+    LOG_AVERAGE
+    AUG_LOG
+    SQRT
+    AUG_AVERAGE
+    MAX
+    AUG /)
+{
+    $hdr->add($enum, "static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::$enum)");
+}
 
 $hdr->write('false', 'wdf_norm_tab');

--- a/xapian-core/weight/collate-wdf-norm
+++ b/xapian-core/weight/collate-wdf-norm
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+my $copyright = <<'EOF';
+/* Copyright (C) 2020 Dipanshu Garg
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+EOF
+
+use Tokeniseise;
+
+my $hdr = Tokeniseise->new('weight/wdf-norm-dispatch.h', 'Map string to wdf normalisation code', $copyright, 'XAPIAN_INCLUDED_WDF_NORM_DISPATCH_H', 'wdf_norm', 2, 'false');
+$hdr->add('NONE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::NONE)');
+$hdr->add('BOOLEAN', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::BOOLEAN)');
+$hdr->add('SQUARE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::SQUARE)');
+$hdr->add('LOG', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::LOG)');
+$hdr->add('PIVOTED', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::PIVOTED)');
+$hdr->add('LOG_AVERAGE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::LOG_AVERAGE)');
+$hdr->add('AUG_LOG', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::AUG_LOG)');
+$hdr->add('SQRT', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::SQRT)');
+$hdr->add('AUG_AVERAGE', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::AUG_AVERAGE)');
+$hdr->add('MAX', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::MAX)');
+$hdr->add('AUG', 'static_cast<unsigned char>(Xapian::TfIdfWeight::wdf_norm::AUG)');
+
+$hdr->write('false', 'wdf_norm_tab');

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -367,9 +367,9 @@ TfIdfWeight::create_from_parameters(const char * p) const
     if (*p == '\0')
 	return new Xapian::TfIdfWeight();
     string wdf_normalisation, idf_normalisation, wt_normalisation;
-    wdf_norm wdf_normalisation_;
-    idf_norm idf_normalisation_;
-    wt_norm wt_normalisation_;
+    wdf_norm wdf_normalisation_ = wdf_norm::NONE;
+    idf_norm idf_normalisation_ = idf_norm::TFIDF;
+    wt_norm wt_normalisation_ = wt_norm::NONE;
     if (!Xapian::Weight::Internal::param_name(&p, wdf_normalisation))
 	parameter_error("Parameter 1 (wdf_normalisation) is invalid");
     if (!Xapian::Weight::Internal::param_name(&p, idf_normalisation))

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -23,10 +23,10 @@
 #include <config.h>
 
 #include "xapian/weight.h"
-#include "weightinternal.h"
-#include "wdf-norm-dispatch.h"
 #include "idf-norm-dispatch.h"
 #include "keyword.h"
+#include "wdf-norm-dispatch.h"
+#include "weightinternal.h"
 #include <cmath>
 #include <cstring>
 
@@ -369,9 +369,6 @@ TfIdfWeight::create_from_parameters(const char * p) const
     if (*p == '\0')
 	return new Xapian::TfIdfWeight();
     string wdf_normalisation, idf_normalisation, wt_normalisation;
-    wdf_norm wdf_normalisation_ = wdf_norm::NONE;
-    idf_norm idf_normalisation_ = idf_norm::TFIDF;
-    wt_norm wt_normalisation_ = wt_norm::NONE;
     if (!Xapian::Weight::Internal::param_name(&p, wdf_normalisation))
 	parameter_error("Parameter 1 (wdf_normalisation) is invalid");
     if (!Xapian::Weight::Internal::param_name(&p, idf_normalisation))
@@ -386,19 +383,19 @@ TfIdfWeight::create_from_parameters(const char * p) const
     if (wdf_code < 0) {
 	parameter_error("Parameter 1 (wdf_normalisation) is invalid");
     }
-    wdf_normalisation_ = static_cast<wdf_norm>(wdf_code);
+    wdf_norm wdf_normalisation_ = static_cast<wdf_norm>(wdf_code);
 
     int idf_code = keyword(idf_norm_tab, idf_normalisation.data(),
 			   idf_normalisation.size());
     if (idf_code < 0) {
 	parameter_error("Parameter 2 (idf_normalisation) is invalid");
     }
-    idf_normalisation_ = static_cast<idf_norm>(idf_code);
+    idf_norm idf_normalisation_ = static_cast<idf_norm>(idf_code);
 
     if (wt_normalisation != "NONE") {
 	parameter_error("Parameter 3 (wt_normalisation) is invalid");
     }
-    wt_normalisation_ = wt_norm::NONE;
+    wt_norm wt_normalisation_ = wt_norm::NONE;
     return new Xapian::TfIdfWeight(wdf_normalisation_, idf_normalisation_,
 				   wt_normalisation_);
 }

--- a/xapian-core/weight/tfidfweight.cc
+++ b/xapian-core/weight/tfidfweight.cc
@@ -387,7 +387,9 @@ TfIdfWeight::create_from_parameters(const char * p) const
 	{ "LOG_AVERAGE", wdf_norm::LOG_AVERAGE },
 	{ "AUG_LOG", wdf_norm::AUG_LOG },
 	{ "SQRT", wdf_norm::SQRT },
-	{ "AUG_AVERAGE", wdf_norm::AUG_AVERAGE }
+	{ "AUG_AVERAGE", wdf_norm::AUG_AVERAGE },
+	{ "MAX", wdf_norm::MAX },
+	{ "AUG", wdf_norm::AUG }
     };
     map<string, idf_norm> idfnorm {
 	{ "NONE", idf_norm::NONE },

--- a/xapian-core/weight/weightinternal.h
+++ b/xapian-core/weight/weightinternal.h
@@ -254,7 +254,7 @@ class Weight::Internal {
 
     static bool param_name(const char** p, std::string& name) {
 	const char* q = *p;
-	while (*q != ' '){
+	while (*q != ' ') {
 	    if (*q == '\0') break;
 	    name += *(q)++;
 	}

--- a/xapian-core/weight/weightinternal.h
+++ b/xapian-core/weight/weightinternal.h
@@ -252,6 +252,18 @@ class Weight::Internal {
 	return true;
     }
 
+    static bool param_name(const char** p, std::string& name) {
+	const char* q = *p;
+	while (*q != ' '){
+	    if (*q == '\0') break;
+	    name += *(q)++;
+	}
+	if (q == *p) return false;
+	if (*q == ' ') q++;
+	*p = q;
+	return true;
+    }
+
     static void parameter_error(const char * msg,
 				const std::string & scheme) {
 	std::string m(msg);


### PR DESCRIPTION
We now use enums to specify normalisations. The parameters will be
specified as constant names.