### PR TITLE
Add tests for TfIdfWeight::create_from_parameters()

### DIFF
--- a/xapian-core/tests/api_weight.cc
+++ b/xapian-core/tests/api_weight.cc
@@ -750,6 +750,13 @@ DEFINE_TESTCASE(tfidfweight1, !backend) {
       given. */
     Xapian::TfIdfWeight weight2;
     TEST_EQUAL(weight2.serialise(), Xapian::TfIdfWeight("ntn").serialise());
+
+    TEST_EXCEPTION(Xapian::InvalidArgumentError,
+	Xapian::Weight::create("tfidf NONE FUN NONE"));
+
+    TEST_EXCEPTION(Xapian::InvalidArgumentError,
+	Xapian::Weight::create("tfidf NONE"));
+
 }
 
 // Test exception for junk after serialised weight.
@@ -1245,6 +1252,23 @@ DEFINE_TESTCASE(tfidfweight4, backend) {
     TEST_EQUAL(mset.size(), 2);
     // Expect doc 2 with query "word" to have higher weight than doc 4.
     mset_expect_order(mset, 2, 4);
+}
+
+// Check that create_from_parameters() creates the correct object.
+DEFINE_TESTCASE(tfidfweight5, !backend) {
+    auto wt_ptr = Xapian::Weight::create("tfidf NONE TFIDF NONE");
+    auto wt = Xapian::TfIdfWeight(Xapian::TfIdfWeight::wdf_norm::NONE,
+				  Xapian::TfIdfWeight::idf_norm::TFIDF,
+				  Xapian::TfIdfWeight::wt_norm::NONE);
+    TEST_EQUAL(wt_ptr->serialise(), wt.serialise());
+    delete wt_ptr;
+
+    auto wt_ptr2 = Xapian::Weight::create("tfidf SQRT PIVOTED NONE");
+    auto wt2 = Xapian::TfIdfWeight(Xapian::TfIdfWeight::wdf_norm::SQRT,
+				   Xapian::TfIdfWeight::idf_norm::PIVOTED,
+				   Xapian::TfIdfWeight::wt_norm::NONE);
+    TEST_EQUAL(wt_ptr2->serialise(), wt2.serialise());
+    delete wt_ptr2;
 }
 
 class CheckInitWeight : public Xapian::Weight {

--- a/xapian-core/weight/collate-idf-norm
+++ b/xapian-core/weight/collate-idf-norm
@@ -22,7 +22,7 @@ EOF
 
 use Tokeniseise;
 
-my $hdr = Tokeniseise->new('weight/idf-norm-dispatch.h', 'Map string to idf normalisation code', $copyright, 'XAPIAN_INCLUDED_IDF_NORM_DISPATCH_H', 'idf_norm', 2, 'false');
+my $hdr = Tokeniseise->new('weight/idf-norm-dispatch.h', 'Map string to idf normalisation code', $copyright, 'XAPIAN_INCLUDED_IDF_NORM_DISPATCH_H', 'idf_norm', 1, 'false');
 for my $enum (qw/
     NONE
     TFIDF

--- a/xapian-core/weight/collate-wdf-norm
+++ b/xapian-core/weight/collate-wdf-norm
@@ -22,7 +22,7 @@ EOF
 
 use Tokeniseise;
 
-my $hdr = Tokeniseise->new('weight/wdf-norm-dispatch.h', 'Map string to wdf normalisation code', $copyright, 'XAPIAN_INCLUDED_WDF_NORM_DISPATCH_H', 'wdf_norm', 2, 'false');
+my $hdr = Tokeniseise->new('weight/wdf-norm-dispatch.h', 'Map string to wdf normalisation code', $copyright, 'XAPIAN_INCLUDED_WDF_NORM_DISPATCH_H', 'wdf_norm', 1, 'false');
 for my $enum (qw/
     NONE
     BOOLEAN


### PR DESCRIPTION
Add tests to ensure that create_from_ parameters() works correctly.
Also, the wdf_norm and idf_norm tables aren't very large, so 1 byte
offset are sufficient.