### PR TITLE
Headers missing to compile on msys with mingw.

### DIFF
--- a/xapian-core/net/progclient.h
+++ b/xapian-core/net/progclient.h
@@ -23,6 +23,10 @@
 
 #include <sys/types.h>
 
+#ifdef __WIN32__
+#include <winerror.h>
+#endif
+
 #include "backends/remote/remote-database.h"
 
 /** Implementation of RemoteDatabase using a spawned server.

--- a/xapian-core/net/remoteconnection.h
+++ b/xapian-core/net/remoteconnection.h
@@ -30,7 +30,7 @@
 
 #ifdef __WIN32__
 # include "safewinsock2.h"
-
+# include <winerror.h>
 # include <xapian/error.h>
 
 /** Class to initialise winsock and keep it initialised while we use it.


### PR DESCRIPTION
In msys with mingw-32bits (windows 10) I always have this problem and it is only solved by including this header in these files.
```
net/progclient.cc: In static member function 'static int ProgClient::run_program(const string&, const string&, void*&)':
net/progclient.cc:207:61: error: 'ERROR_PIPE_CONNECTED' was not declared in this scope
     if (!ConnectNamedPipe(hPipe, NULL) && GetLastError() != ERROR_PIPE_CONNECTED) {
                                                             ^~~~~~~~~~~~~~~~~~~~
make[2]: *** [net/progclient.lo] Error 1

net/remoteconnection.cc: In member function 'void RemoteConnection::shutdown()':
net/remoteconnection.cc:737:31: error: 'ERROR_IO_PENDING' was not declared in this scope
  if (!ok && GetLastError() == ERROR_IO_PENDING) {
```