### PR TITLE
xapian-bindings: Fix the build with slibtool

### DIFF
--- a/xapian-bindings/java/run-java-test
+++ b/xapian-bindings/java/run-java-test
@@ -1,11 +1,24 @@
 #!/bin/sh
 # To run `jdb` instead of `java` set JAVA=jdb
 # To run under gdb, set JAVA='gdb --args java'
+LIBTOOL="${LIBTOOL-../libtool}"
 arg=`echo "$1"|sed 's!.*/!!;s!\.class$!!'`
+
+# GNU libtool and slibtool have different and incompatible usage for --config.
+if ${LIBTOOL} --config > libtoolconfig.$$ 2>/dev/null; then
+	. ./libtoolconfig.$$
+else
+	objdir="built/libs"
+	rm -rf "$objdir"
+	mkdir -p "$objdir"
+	${LIBTOOL} --mode=install cp libxapian_jni.la "$objdir"
+fi
+rm -f libtoolconfig.$$
+
 # Use libtool's -dlopen option to ensure that libxapian_jni.so (or whatever)
 # is in the shared library path.
-${LIBTOOL-../libtool} --config > libtoolconfig.$$
-. ./libtoolconfig.$$
-rm -f libtoolconfig.$$
-${LIBTOOL-../libtool} -dlopen libxapian_jni.la --mode=execute \
+${LIBTOOL} -dlopen libxapian_jni.la --mode=execute \
   $OSX_SIP_HACK_ENV ${JAVA-java} -Djava.library.path="$objdir" -classpath built/xapian.jar${PATHSEP-:}. "$arg"
+rc=$?
+rm -rf built/libs
+exit $rc

--- a/xapian-bindings/perl/Makefile.am
+++ b/xapian-bindings/perl/Makefile.am
@@ -55,9 +55,14 @@ BUILT_SOURCES = Xapian.pm xapian_wrap.cc \
 
 auto/Xapian/Xapian$(PERL_SO): Xapian.la
 	@$(MKDIR_P) auto/Xapian
-	$(LIBTOOL) --config > libtoolconfig.tmp
+## GNU libtool and slibtool have different and incompatible usage for --config.
+	if $(LIBTOOL) --config > libtoolconfig.tmp 2>/dev/null; then \
 ## ksh requires a path on the sourced file.
-	. ./libtoolconfig.tmp; cp "$$objdir/Xapian$(PERL_SO)" auto/Xapian
+		. ./libtoolconfig.tmp; \
+		cp "$$objdir/Xapian$(PERL_SO)" auto/Xapian; \
+	else \
+		$(LIBTOOL) --mode=install cp $< $@; \
+	fi;
 	rm -f libtoolconfig.tmp
 
 EXTRA_DIST = perl.i except.i extra.i $(TESTS) \

--- a/xapian-bindings/python3/Makefile.am
+++ b/xapian-bindings/python3/Makefile.am
@@ -88,9 +88,14 @@ xapian/__pycache__/__init__.@PYTHON3_CACHE_OPT1_EXT@: xapian/__init__.py xapian/
 
 xapian/_xapian$(PYTHON3_EXT_SUFFIX): _xapian.la
 	$(MKDIR_P) xapian
-	$(LIBTOOL) --config > libtoolconfig.tmp
+## GNU libtool and slibtool have different and incompatible usage for --config.
+	if $(LIBTOOL) --config > libtoolconfig.tmp 2>/dev/null; then \
 ## ksh requires a path on the sourced file.
-	. ./libtoolconfig.tmp; cp $$objdir/_xapian$(PYTHON3_EXT_SUFFIX) xapian
+		. ./libtoolconfig.tmp; \
+		cp $$objdir/_xapian$(PYTHON3_EXT_SUFFIX) xapian; \
+	else \
+		$(LIBTOOL) --mode=install cp $< $@; \
+	fi;
 	rm -f libtoolconfig.tmp
 
 CLEANFILES = \

--- a/xapian-bindings/tcl8/run-tcl-test
+++ b/xapian-bindings/tcl8/run-tcl-test
@@ -1,14 +1,20 @@
 #!/bin/sh
-${LIBTOOL-../libtool} --config > libtoolconfig.$$
-. ./libtoolconfig.$$
-rm -f libtoolconfig.$$
-module=yes
-eval shlibext=$shrext_cmds
-
 tclshlibext=`echo 'puts [info sharedlibextension]'|${TCLSH-tclsh}`
-
 rm -f xapian$tclshlibext
-ln -s $objdir/xapian$shlibext xapian$tclshlibext
+
+LIBTOOL="${LIBTOOL-../libtool}"
+module=yes
+
+# GNU libtool and slibtool have different and incompatible usage for --config.
+if ${LIBTOOL} --config > libtoolconfig.$$ 2>/dev/null; then
+	. ./libtoolconfig.$$
+	eval shlibext=$shrext_cmds
+	ln -s $objdir/xapian$shlibext xapian$tclshlibext
+else
+	${LIBTOOL} --mode=install cp xapian.la ./xapian$tclshlibext
+fi
+rm -f libtoolconfig.$$
+
 $OSX_SIP_HACK_ENV ${TCLSH-tclsh} ${srcdir-.}/runtest.tcl ${srcdir-.}/smoketest.tcl
 rc=$?
 rm -f xapian$tclshlibext


### PR DESCRIPTION
gentoo issue: https://bugs.gentoo.org/793428

Note: Tested against `xapian-bindings-1.4.19`.

When building `xapian-bindings` with slibtool instead of GNU libtool it will fail when trying to save the output of `$(LIBTOOL) --config` to `libtoolconfig.tmp` where slibtool does not have `--config`.

This all seems to not accomplish anything other than breaking slibtool so I suggest removing it so it works with both libtool implementations. The files installed with `make install` do not change.

The issue still exists in the `python` and `python3` directories and I can fix it there too, but I want to start here to see if the solution is acceptable.