### PR TITLE
Update andnotpostlist.cc

### DIFF
--- a/xapian-core/matcher/andnotpostlist.cc
+++ b/xapian-core/matcher/andnotpostlist.cc
@@ -120,7 +120,7 @@ AndNotPostList::get_termfreq_est() const
 {
     LOGCALL(MATCH, Xapian::doccount, "AndNotPostList::get_termfreq_est", NO_ARGS);
     // We shortcut an empty shard and avoid creating a postlist tree for it.
-    Assert(db_size);
+    Assert(dbsize);
     // Estimate assuming independence:
     // P(l and r) = P(l) . P(r)
     // P(l not r) = P(l) - P(l and r) = P(l) . ( 1 - P(r))


### PR DESCRIPTION
I have got error at 1.4.22 compilation
matcher/andnotpostlist.cc:123:12: error: ‘db_size’ was not declared in this scope; did you mean ‘dbsize’?
  123 |     Assert(db_size);
      |            ^~~~~~~
./config.h:573:41: note: in definition of macro ‘rare’

Linux Mint 20.3, Linux Aspire 5.15.0-56-generic #62~20.04.1-Ubuntu SMP Tue Nov 22 21:24:20 UTC 2022 x86_64 GNU/Linux