### PR TITLE
fix compile error when with `--enable-64bit-termcount`

### DIFF
--- a/xapian-core/api/document.cc
+++ b/xapian-core/api/document.cc
@@ -198,7 +198,7 @@ Document::clear_values()
     internal->clear_values();
 }
 
-Xapian::termcount
+Xapian::valueno
 Document::values_count() const {
     return internal->values_count();
 }


### PR DESCRIPTION

```
api/document.cc:202:1: error: no declaration matches 'Xapian::termcount Xapian::Document::values_count() const'
  202 | Document::values_count() const {
      | ^~~~~~~~
In file included from api/document.cc:23:
./include/xapian/document.h:244:21: note: candidate is: 'Xapian::valueno Xapian::Document::values_count() const'
  244 |     Xapian::valueno values_count() const;
      |                     ^~~~~~~~~~~~
./include/xapian/document.h:64:33: note: 'class Xapian::Document' defined here
   64 | class XAPIAN_VISIBILITY_DEFAULT Document {
      |                                 ^~~~~~~~

```

