### PR TITLE
QueryParser: do not try to parse unbroken words as group terms

### DIFF
--- a/xapian-core/queryparser/queryparser.lemony
+++ b/xapian-core/queryparser/queryparser.lemony
@@ -1506,6 +1506,9 @@ phrased_term:
 
 	    if (needs_word_break) {
 		Parse(&parser, UNBROKEN_WORDS, term_obj, &state);
+		// Drop out of IN_GROUP mode.
+		if (mode == IN_GROUP || mode == IN_GROUP2)
+		    mode = DEFAULT;
 		if (it == end) break;
 		continue;
 	    }

--- a/xapian-core/tests/api_queryparser.cc
+++ b/xapian-core/tests/api_queryparser.cc
@@ -741,6 +741,8 @@ static const test test_or_queries[] = {
     { "title:久有 归 天愿", "((XT久@1 AND XT有@1) OR 归@2 OR (天@3 AND 愿@3))" },
 
     { "h众ello万众", "(Zh@1 OR 众@2 OR Zello@3 OR (万@4 AND 众@4))" },
+    { "x 我y",  "(Zx@1 OR 我@2 OR Zy@3)" }, // WORD_BREAK ends group term
+    { "x 我 y", "(Zx@1 OR 我@2 OR Zy@3)" }, // WORD_BREAK ends group term
 
     // Korean splits some words by whitespace, and there is no available tool
     // to crosscheck Korean word splits for these tests. So the expected values


### PR DESCRIPTION
Fixes a bug where QueryParser fails with an error when parsing the sequence of: term, whitespace, unbroken words, term. The underlying issue is that unbroken words can not be part of a group according to the lemon grammar.

As the combination of unbroken words and terms is highly unlikely to ever form a multi-term synonym, this patch changes the query parser to leave group term mode after having parsed unbroken words.