### PR TITLE
resolver.h: use AI_NUMERICSERV only when defined

### DIFF
--- a/xapian-core/net/resolver.h
+++ b/xapian-core/net/resolver.h
@@ -143,7 +143,9 @@ class Resolver {
 	if (host != "::1" && host != "127.0.0.1" && host != "localhost") {
 	    flags |= AI_ADDRCONFIG;
 	}
+#ifdef AI_NUMERICSERV
 	flags |= AI_NUMERICSERV;
+#endif
 
 	struct addrinfo hints;
 	std::memset(&hints, 0, sizeof(struct addrinfo));


### PR DESCRIPTION
Older macOS does not have `AI_NUMERICSERV`, so use it as long as it is defined.

Otherwise the build is broken:
```
libtool: compile:  /opt/local/bin/g++-mp-13 -DHAVE_CONFIG_H -I. -I./common -I./include -I/opt/local/include -Wall -W -Wredundant-decls -Wpointer-arith -Wcast-qual -Wcast-align -Wformat-security -fno-gnu-keywords -Wundef -Woverloaded-virtual -Wstrict-null-sentinel -Wshadow -Wstrict-overflow=1 -Wlogical-op -Wmissing-declarations -Wdouble-promotion -Winit-self -Wduplicated-cond -Wduplicated-branches -fvisibility=hidden -fvisibility-inlines-hidden -pipe -Os -D_GLIBCXX_USE_CXX11_ABI=0 -arch ppc -fno-math-errno -MT net/tcpclient.lo -MD -MP -MF net/.deps/tcpclient.Tpo -c net/tcpclient.cc  -fno-common -DPIC -o net/.libs/tcpclient.o
In file included from net/tcpclient.cc:29:
net/resolver.h: In constructor 'Resolver::Resolver(const std::string&, int, int)':
net/resolver.h:99:18: error: 'AI_NUMERICSERV' was not declared in this scope; did you mean 'NI_NUMERICSERV'?
   99 |         flags |= AI_NUMERICSERV;
      |                  ^~~~~~~~~~~~~~
      |                  NI_NUMERICSERV
make[2]: *** [net/tcpclient.lo] Error 1
```