### PR TITLE
bootstrap: use HOMEBREW_PREFIX if set

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -660,8 +660,8 @@ if [ ! -r "$aclocal_ac_dir/pkg.m4" ] ; then
     aclocal_system_needed=/usr/local/share/aclocal
   elif [ -r /opt/local/share/aclocal/pkg.m4 ] ; then
     aclocal_system_needed=/opt/local/share/aclocal
-  elif [ -r /opt/homebrew/share/aclocal/pkg.m4 ] ; then
-    aclocal_system_needed=/opt/homebrew/share/aclocal
+  elif [ -n "$HOMEBREW_PREFIX" ] && [ -r "${HOMEBREW_PREFIX}/share/aclocal/pkg.m4" ] ; then
+    aclocal_system_needed="${HOMEBREW_PREFIX}/share/aclocal"
   fi
 fi
 

--- a/bootstrap
+++ b/bootstrap
@@ -660,6 +660,8 @@ if [ ! -r "$aclocal_ac_dir/pkg.m4" ] ; then
     aclocal_system_needed=/usr/local/share/aclocal
   elif [ -r /opt/local/share/aclocal/pkg.m4 ] ; then
     aclocal_system_needed=/opt/local/share/aclocal
+  elif [ -r /opt/homebrew/share/aclocal/pkg.m4 ] ; then
+    aclocal_system_needed=/opt/homebrew/share/aclocal
   fi
 fi
 


### PR DESCRIPTION
Had problems bootstrapping the project, it turned out that pkg.m4 was missing, but the error message was a cryptic
`configure.ac:128: error: possibly undefined macro: AC_MSG_ERROR` which took some time to figure out.