### PR TITLE
add fallback UUID generation on Android

### DIFF
--- a/xapian-core/backends/uuids.cc
+++ b/xapian-core/backends/uuids.cc
@@ -35,6 +35,9 @@
 
 #ifdef USE_PROC_FOR_UUID
 # include "safesysstat.h"
+#ifdef __ANDROID__
+#  include <stdlib.h> // for arc4random_buf()
+#endif // __ANDROID__
 #elif defined HAVE_UUID_UUID_H
 # include <exception>
 # include <uuid/uuid.h>
@@ -68,25 +71,18 @@ Uuid::generate()
     if (rare(fd == -1)) {
 #ifdef __ANDROID__
         /*
-         * AOSP SELinux policy allows /proc/sys/kernel/random/uuid
-         * starting only with Android 9
+         * AOSP SELinux policyallows /proc/sys/kernel/random/uuid
+         *     starting only with Android 9
+         *
+         * but arc4random_buf() is avaliable on all API levels:
+         * https://android.googlesource.com/platform/
+         *     bionic/%2B/master/libc/include/stdlib.h
          */
-        fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
-        if (rare(fd == -1)) {
-            throw Xapian::DatabaseCreateError("Opening UUID generator failed",
-                                                errno);
-        }
-        bool failed = (read(fd, uuid_data, BINARY_SIZE)
-                        != ssize_t{BINARY_SIZE});
-        close(fd);
-        if (failed) {
-            throw Xapian::DatabaseCreateError("Generating UUID failed");
-        }
+        arc4random_buf(uuid_data, BINARY_SIZE);
         uuid_data[6] = (uuid_data[6] & 0x0f) | 0x40; // version 4
         uuid_data[8] = (uuid_data[8] & 0x3f) | 0x80; // RFC 4122
 #else
-        throw Xapian::DatabaseCreateError("Opening UUID generator failed",
-                                            errno);
+        throw Xapian::DatabaseCreateError("Opening UUID generator failed", errno);
 #endif
     } else {
         bool failed = (read(fd, buf, STRING_SIZE) != STRING_SIZE);

--- a/xapian-core/backends/uuids.cc
+++ b/xapian-core/backends/uuids.cc
@@ -70,7 +70,7 @@ Uuid::generate()
         /*
          * AOSP SELinux policyallows /proc/sys/kernel/random/uuid starting only with Android 9
          */
-        int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+        fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
         if (rare(fd == -1)) {
             throw Xapian::DatabaseCreateError("Opening UUID generator failed", errno);
         }

--- a/xapian-core/backends/uuids.cc
+++ b/xapian-core/backends/uuids.cc
@@ -74,7 +74,7 @@ Uuid::generate()
          * AOSP SELinux policyallows /proc/sys/kernel/random/uuid
          *     starting only with Android 9
          *
-         * but arc4random_buf() is avaliable on all API levels:
+         * but arc4random_buf() is available on all API levels:
          * https://android.googlesource.com/platform/
          *     bionic/%2B/master/libc/include/stdlib.h
          */

--- a/xapian-core/backends/uuids.cc
+++ b/xapian-core/backends/uuids.cc
@@ -66,14 +66,32 @@ Uuid::generate()
     char buf[STRING_SIZE];
     int fd = open("/proc/sys/kernel/random/uuid", O_RDONLY);
     if (rare(fd == -1)) {
+#ifdef __ANDROID__
+        /*
+         * AOSP SELinux policyallows /proc/sys/kernel/random/uuid starting only with Android 9
+         */
+        int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+        if (rare(fd == -1)) {
+            throw Xapian::DatabaseCreateError("Opening UUID generator failed", errno);
+        }
+        bool failed = (read(fd, uuid_data, BINARY_SIZE) != ssize_t{BINARY_SIZE});
+        close(fd);
+        if (failed) {
+            throw Xapian::DatabaseCreateError("Generating UUID failed");
+        }
+        uuid_data[6] = (uuid_data[6] & 0x0f) | 0x40; // version 4
+        uuid_data[8] = (uuid_data[8] & 0x3f) | 0x80; // RFC 4122
+#else
         throw Xapian::DatabaseCreateError("Opening UUID generator failed", errno);
+#endif
+    } else {
+        bool failed = (read(fd, buf, STRING_SIZE) != STRING_SIZE);
+        close(fd);
+        if (failed) {
+            throw Xapian::DatabaseCreateError("Generating UUID failed");
+        }
+        parse(buf);
     }
-    bool failed = (read(fd, buf, STRING_SIZE) != STRING_SIZE);
-    close(fd);
-    if (failed) {
-        throw Xapian::DatabaseCreateError("Generating UUID failed");
-    }
-    parse(buf);
 #elif defined HAVE_UUID_UUID_H
     uuid_t uu;
     uuid_generate(uu);

--- a/xapian-core/backends/uuids.cc
+++ b/xapian-core/backends/uuids.cc
@@ -68,13 +68,16 @@ Uuid::generate()
     if (rare(fd == -1)) {
 #ifdef __ANDROID__
         /*
-         * AOSP SELinux policyallows /proc/sys/kernel/random/uuid starting only with Android 9
+         * AOSP SELinux policy allows /proc/sys/kernel/random/uuid
+         * starting only with Android 9
          */
         fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
         if (rare(fd == -1)) {
-            throw Xapian::DatabaseCreateError("Opening UUID generator failed", errno);
+            throw Xapian::DatabaseCreateError("Opening UUID generator failed",
+                                                errno);
         }
-        bool failed = (read(fd, uuid_data, BINARY_SIZE) != ssize_t{BINARY_SIZE});
+        bool failed = (read(fd, uuid_data, BINARY_SIZE)
+                        != ssize_t{BINARY_SIZE});
         close(fd);
         if (failed) {
             throw Xapian::DatabaseCreateError("Generating UUID failed");
@@ -82,7 +85,8 @@ Uuid::generate()
         uuid_data[6] = (uuid_data[6] & 0x0f) | 0x40; // version 4
         uuid_data[8] = (uuid_data[8] & 0x3f) | 0x80; // RFC 4122
 #else
-        throw Xapian::DatabaseCreateError("Opening UUID generator failed", errno);
+        throw Xapian::DatabaseCreateError("Opening UUID generator failed",
+                                            errno);
 #endif
     } else {
         bool failed = (read(fd, buf, STRING_SIZE) != STRING_SIZE);


### PR DESCRIPTION
Currently I build Xapian for Linux/Web and Android. One of my Android devices has Android 8.1, on which SELinux policy bans the access to /proc/uuid and I get:
```
7505:05-09 22:53:41.631 13614 13614 W SDLThread: type=1400 audit(0.0:24): avc: denied { read } for name="uuid" dev="proc" ino=110567 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:proc:s0 tclass=file permissive=0
```

Yes, it is an **old** Android version, but supporting a fallback is not so heavy, I suppose.