### PR TITLE
Windows: use explicit A-suffixed Win32 APIs (CreateProcessA(), CreateFileA()...)

### DIFF
--- a/xapian-core/api/error.cc
+++ b/xapian-core/api/error.cc
@@ -56,7 +56,7 @@ Xapian::Error::get_error_string() const
             int e = abs(my_errno);
             DWORD len;
             char * error;
-            len = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM|
+            len = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM|
                                 FORMAT_MESSAGE_ALLOCATE_BUFFER,
                                 0, e, 0, (CHAR*)&error, 0, 0);
             if (error) {

--- a/xapian-core/common/socket_utils.cc
+++ b/xapian-core/common/socket_utils.cc
@@ -148,8 +148,8 @@ pretty_ip6(const void* p, char* buf)
                      sizeof(struct sockaddr_in6) :
                      sizeof(struct sockaddr_in));
     DWORD size = PRETTY_IP6_LEN;
-    if (WSAAddressToString(const_cast<struct sockaddr*>(sa),
-                           in_size, NULL, buf, &size) != 0) {
+    if (WSAAddressToStringA(const_cast<struct sockaddr*>(sa),
+                            in_size, NULL, buf, &size) != 0) {
         return -1;
     }
     const char* r = buf;

--- a/xapian-core/net/progclient.cc
+++ b/xapian-core/net/progclient.cc
@@ -173,7 +173,7 @@ ProgClient::run_program(string_view progname, string_view args,
              static_cast<unsigned long long>(counter.QuadPart));
     pipename[sizeof(pipename) - 1] = '\0';
     // Create a pipe so we can read stdout from the child process.
-    HANDLE hPipe = CreateNamedPipe(pipename,
+    HANDLE hPipe = CreateNamedPipeA(pipename,
                                    PIPE_ACCESS_DUPLEX|FILE_FLAG_OVERLAPPED,
                                    0,
                                    1, 4096, 4096, NMPWAIT_USE_DEFAULT_WAIT,
@@ -185,10 +185,10 @@ ProgClient::run_program(string_view progname, string_view args,
                                    -int(GetLastError()));
     }
 
-    HANDLE hClient = CreateFile(pipename,
-                                GENERIC_READ|GENERIC_WRITE, 0, NULL,
-                                OPEN_EXISTING,
-                                FILE_FLAG_OVERLAPPED, NULL);
+    HANDLE hClient = CreateFileA(pipename,
+                                 GENERIC_READ|GENERIC_WRITE, 0, NULL,
+                                 OPEN_EXISTING,
+                                 FILE_FLAG_OVERLAPPED, NULL);
 
     if (hClient == INVALID_HANDLE_VALUE) {
         throw Xapian::NetworkError("CreateFile failed",
@@ -210,9 +210,9 @@ ProgClient::run_program(string_view progname, string_view args,
     PROCESS_INFORMATION procinfo;
     memset(&procinfo, 0, sizeof(PROCESS_INFORMATION));
 
-    STARTUPINFO startupinfo;
-    memset(&startupinfo, 0, sizeof(STARTUPINFO));
-    startupinfo.cb = sizeof(STARTUPINFO);
+    STARTUPINFOA startupinfo;
+    memset(&startupinfo, 0, sizeof(STARTUPINFOA));
+    startupinfo.cb = sizeof(STARTUPINFOA);
     startupinfo.hStdError = hClient;
     startupinfo.hStdOutput = hClient;
     startupinfo.hStdInput = hClient;
@@ -226,9 +226,9 @@ ProgClient::run_program(string_view progname, string_view args,
     cmdline += args;
     // For some reason Windows wants a modifiable command line so we
     // pass `&cmdline[0]` rather than `cmdline.c_str()`.
-    BOOL ok = CreateProcess(progname_string.c_str(), &cmdline[0],
-                            0, 0, TRUE, 0, 0, 0,
-                            &startupinfo, &procinfo);
+    BOOL ok = CreateProcessA(progname_string.c_str(), &cmdline[0],
+                             0, 0, TRUE, 0, 0, 0,
+                             &startupinfo, &procinfo);
     if (!ok) {
         throw Xapian::NetworkError("CreateProcess failed",
                                    context,


### PR DESCRIPTION


Rationale: this is mostly a cosmetic change. Using the explicit name makes the code a bit clearer, and prevents a compilation error if UNICODE is defined in the context.